### PR TITLE
Module to include uninvoiced POs into budgets.

### DIFF
--- a/account_budget_purchase/__init__.py
+++ b/account_budget_purchase/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import account_budget

--- a/account_budget_purchase/__openerp__.py
+++ b/account_budget_purchase/__openerp__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': "Take uninvoiced Purchase Orders into account in Budget Lines",
+    'version': '1.0',
+    'author': u'Numérigraphe SARL',
+    'category': 'Generic Modules/Accounting',
+    'description': '''
+Take pending Purchase Orders into account in Budget Lines
+=========================================================
+Normally the Budgets are based on the Entries of General Accounting, and may be
+filtered by Analytic Account.
+The problem for purchase Budgets is that invoices may come in very late in the
+process. This often hides future problems from the budget managers.
+
+To help with this problem, this module lets Budget Lines include the amounts
+of Purchase Order Lines that have been confirmed but not yet invoiced.''',
+    'depends': ['account_budget', 'purchase'],
+    'data': [
+        'account_budget_view.xml',
+    ],
+    'test': [
+        # TODO add an automatic test:
+        # - create 3 identical budget lines:
+        #   - line A ignoring POs
+        #   - line B adding POs to amount
+        #   - line C subtracting POs from amount
+        # - record the initial "real" amount of line A
+        # - create a PO for 100 EUR and validate it
+        # - check that the amount of line A is unchanged
+        # - check that the amount of line B is A+100
+        # - check that the amount of line C is A-100
+    ]
+}

--- a/account_budget_purchase/account_budget.py
+++ b/account_budget_purchase/account_budget.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module is copyright (C) 2014 Numérigraphe SARL. All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class AccountBudgetPosition (orm.Model):
+    """Add purchase orders to budget positions"""
+    _inherit = 'account.budget.post'
+
+    _columns = {
+        'include_purchase': fields.boolean(
+            'Include Purchase Orders',
+            help="Check this box to take Purchase orders into account.\n"
+                 "If unchecked, only the Accounting Entries will be "
+                 "taken into account.\n"
+                 "This field lets managers make more realistic Budgets "
+                 "when dealing with suppliers who send their invoices late "
+                 "(i.e. monthly invoices after reception).\n"
+        ),
+        # The values are immutable on purpose: they trigger different code
+        'purchase_sign': fields.selection(
+            (('+', 'Positive'), ('-', 'Negative')), "Sign",
+            help="If you select 'Positive', the sum of all the "
+                 "lines of Purchase Orders already confirmed but not yet "
+                 "Invoiced will be added to the 'real amount' of all the "
+                 "Budget Lines that use this Budgetary position.\n"
+                 "If you select 'Negative', it will be subtracted "
+                 "instead.\n"
+        ),
+    }
+
+
+class BudgetLine(orm.Model):
+    """Adapt the computation of the Real amount"""
+
+    _inherit = "crossovered.budget.lines"
+
+    # Only count the PO with the following states
+    PO_STATES = [
+        'confirmed',
+        'approved',
+        'except_picking',
+        'except_invoice',
+        'done',
+    ]
+
+    # Doing this on _prac would need us to redefine the field too
+    def _prac_amt(self, cr, uid, ids, context=None):
+        """Optionally add/subtract the amount of the Purchase Order Lines"""
+        # Get the standard amounts
+        results = super(BudgetLine, self)._prac_amt(cr, uid, ids,
+                                                    context=context)
+        # Compute the total amount of current purchase order lines
+        po_obj = self.pool["purchase.order"]
+        po_ids = po_obj.search(
+            cr, uid, [('state', 'in', self.PO_STATES)], context=context)
+        # XXX does it need rounding?
+        po_amount = sum([po.amount_untaxed * (100.0 - po.invoiced_rate) / 100.0
+                         for po in po_obj.browse(cr, uid, po_ids,
+                                                 context=context)
+                         if not po.invoiced])
+        if not po_amount:
+            # Nothing to do if no POs are running
+            return results
+        # Add/subtract the total amount of POs to/from lines
+        for line in self.browse(cr, uid, ids, context=context):
+            if line.general_budget_id.include_purchase:
+                if line.general_budget_id.purchase_sign == '+':
+                    results[line.id] += po_amount
+                elif line.general_budget_id.purchase_sign == '-':
+                    results[line.id] -= po_amount
+        return results

--- a/account_budget_purchase/account_budget_view.xml
+++ b/account_budget_purchase/account_budget_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_budget_post_form_purchase">
+            <field name="name">account.budget.post.form.purchase</field>
+            <field name="inherit_id" ref="account_budget.view_budget_post_form" />
+            <field name="model">account.budget.post</field>
+            <field name="arch" type="xml">
+                <field name="company_id" position="before">
+                    <group colspan="2" col="4">
+                        <field name="include_purchase" />
+                        <field name="purchase_sign" attrs="{'invisible': [('include_purchase', '==', False)], 'required': [('include_purchase', '!=', False)]}"/>
+                    </group>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>
+

--- a/account_budget_purchase/i18n/account_budget_purchase.pot
+++ b/account_budget_purchase/i18n/account_budget_purchase.pot
@@ -1,0 +1,66 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_budget_purchase
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-07-01 16:01+0000\n"
+"PO-Revision-Date: 2014-07-01 16:01+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_budget_purchase
+#: code:_description:0
+#: model:ir.model,name:account_budget_purchase.model_crossovered_budget_lines
+#, python-format
+msgid "Budget Line"
+msgstr ""
+
+#. module: account_budget_purchase
+#: code:_description:0
+#: model:ir.model,name:account_budget_purchase.model_account_budget_post
+#, python-format
+msgid "Budgetary Position"
+msgstr ""
+
+#. module: account_budget_purchase
+#: help:account.budget.post,include_purchase:0
+msgid "Check this box to take Purchase orders into account.\n"
+"If unchecked, only the Accounting Entries will be taken into account.\n"
+"This field lets managers make more realistic Budgets when dealing with suppliers who send their invoices late (i.e. monthly invoices after reception).\n"
+""
+msgstr ""
+
+#. module: account_budget_purchase
+#: help:account.budget.post,purchase_sign:0
+msgid "If you select 'Positive', the sum of all the lines of Purchase Orders already confirmed but not yet Invoiced will be added to the 'real amount' of all the Budget Lines that use this Budgetary position.\n"
+"If you select 'Negative', it will be subtracted instead.\n"
+""
+msgstr ""
+
+#. module: account_budget_purchase
+#: field:account.budget.post,include_purchase:0
+msgid "Include Purchase Orders"
+msgstr ""
+
+#. module: account_budget_purchase
+#: selection:account.budget.post,purchase_sign:0
+msgid "Negative"
+msgstr ""
+
+#. module: account_budget_purchase
+#: selection:account.budget.post,purchase_sign:0
+msgid "Positive"
+msgstr ""
+
+#. module: account_budget_purchase
+#: field:account.budget.post,purchase_sign:0
+msgid "Sign"
+msgstr ""
+

--- a/account_budget_purchase/i18n/fr.po
+++ b/account_budget_purchase/i18n/fr.po
@@ -1,0 +1,71 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_budget_purchase
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-07-01 15:55+0000\n"
+"PO-Revision-Date: 2014-07-01 15:55+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_budget_purchase
+#: code:_description:0
+#: model:ir.model,name:account_budget_purchase.model_crossovered_budget_lines
+#, python-format
+msgid "Budget Line"
+msgstr "Ligne de budget"
+
+#. module: account_budget_purchase
+#: code:_description:0
+#: model:ir.model,name:account_budget_purchase.model_account_budget_post
+#, python-format
+msgid "Budgetary Position"
+msgstr "Poste budgétaire"
+
+#. module: account_budget_purchase
+#: help:account.budget.post,include_purchase:0
+msgid "Check this box to take Purchase orders into account.\n"
+"If unchecked, only the Accounting Entries will be taken into account.\n"
+"This field lets managers make more realistic Budgets when dealing with suppliers who send their invoices late (i.e. monthly invoices after reception).\n"
+""
+msgstr "Cochez cette case pour prendre en compre les commandes d'achat.\n"
+"Si elle n'est pas cochée, seules les écritures comptables sont prises en compte.\n"
+"Ce champ permet aux responsables de faire des budgets plus réalistes lorsqu'ils traitent avec des fournisseurs qui envoient leurs factures tard (ex. : factures mensuelles après livraisons).\n"
+""
+
+#. module: account_budget_purchase
+#: help:account.budget.post,purchase_sign:0
+msgid "If you select 'Positive', the sum of all the lines of Purchase Orders already confirmed but not yet Invoiced will be added to the 'real amount' of all the Budget Lines that use this Budgetary position.\n"
+"If you select 'Negative', it will be subtracted instead.\n"
+""
+msgstr "Si vous choisissez \"Positif\", la somme des lignes de commande d'achat déjà confirmées mais pas encore facturées sera ajoutée au \"montant réel\" de toutes les lignes de budget qui utilisent ce poste budgétaire.\n"
+"Si vous choisissez \"Négatif\", elle sera déduite.\n"
+""
+
+#. module: account_budget_purchase
+#: field:account.budget.post,include_purchase:0
+msgid "Include Purchase Orders"
+msgstr "Inclure les commandes d'achat"
+
+#. module: account_budget_purchase
+#: selection:account.budget.post,purchase_sign:0
+msgid "Negative"
+msgstr "Négatif"
+
+#. module: account_budget_purchase
+#: selection:account.budget.post,purchase_sign:0
+msgid "Positive"
+msgstr "Positif"
+
+#. module: account_budget_purchase
+#: field:account.budget.post,purchase_sign:0
+msgid "Sign"
+msgstr "Signe"
+


### PR DESCRIPTION
Add account_budget_purchase: new module to let budget managers optionally count purchase orders not yet invoiced in their budgets.
This come is handy when suppliers send the invoices very late (like every several months) and you want to watch the purchases before spending more cash.

This module should work fine and be useful all by itself.
Used along with purchase_budget_limit (module which blocks purchase orders when budgets are exhausted - https://code.launchpad.net/~numerigraphe-team/purchase-wkfl/7.0-add-purchase_budget_limit/+merge/219829), it lets us watch the real/anticipated vs expected cash flow for purchases.
