### PR TITLE
currency_rate_update: fix wrong use of timetuple.

### DIFF
--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -119,13 +119,14 @@ class Currency_rate_update(osv.Model):
     _name = "currency.rate.update"
     _description = "Currency Rate Update"
     # Dict that represent a cron object
+    nextcall_time = (datetime.today() + timedelta(days=1)).timetuple()
+    nextcall = time.strftime("%Y-%m-%d %H:%M:%S", nextcall_time)
     cron = {
         'active': False,
         'priority': 1,
         'interval_number': 1,
         'interval_type': 'weeks',
-        'nextcall': time.strftime("%Y-%m-%d %H:%M:%S",
-                                  datetime.today() + timedelta(days=1)).timetuple(),
+        'nextcall': nextcall,
         'numbercall': -1,
         'doall': True,
         'model': 'currency.rate.update',

--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -36,7 +36,7 @@
 
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
 from openerp.osv import fields, osv, orm

--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -247,12 +247,12 @@ class Currency_rate_update(osv.Model):
                     # Show the most recent note at the top
                     msg = "%s \n%s currency updated. %s" % \
                           (log_info or '',
-                           datetime.strftime(datetime.today(), DEFAULT_SERVER_DATETIME_FORMAT),
+                           datetime.today().strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                            note)
                     service.write({'note': msg})
                 except Exception as exc:
                     error_msg = "\n%s ERROR : %s %s" %\
-                                (datetime.strftime(datetime.today(), DEFAULT_SERVER_DATETIME_FORMAT),
+                                (datetime.today().strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                                  repr(exc),
                                  note)
                     _logger.info(repr(exc))
@@ -401,7 +401,7 @@ class Curreny_getter_interface(object):
 
         # We always have a warning when rate_date != today
         rate_date_str = datetime.strftime(rate_date, DEFAULT_SERVER_DATE_FORMAT)
-        if rate_date_str != datetime.strftime(datetime.today(), DEFAULT_SERVER_DATE_FORMAT):
+        if rate_date.date() != datetime.today().date():
             msg = "The rate timestamp (%s) is not today's date"
             self.log_info = ("WARNING : %s %s") % (msg, rate_date_str)
             _logger.warning(msg, rate_date_str)


### PR DESCRIPTION
Remove error "TypeError: argument must be 9-item sequence, not datetime.datetime"
