### PR TITLE
[7.0] Add account journal period close

### DIFF
--- a/account_journal_period_close/__init__.py
+++ b/account_journal_period_close/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Adrien Peiffer
+#    Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)
+#    All Rights Reserved
+#
+#    WARNING: This program as such is intended to be used by professional
+#    programmers who take the whole responsibility of assessing all potential
+#    consequences resulting from its eventual inadequacies and bugs.
+#    End users who are looking for a ready-to-use solution with commercial
+#    guarantees and support are strongly advised to contact a Free Software
+#    Service Company.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from . import model
+from . import tests

--- a/account_journal_period_close/__openerp__.py
+++ b/account_journal_period_close/__openerp__.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Adrien Peiffer
+#    Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)
+#    All Rights Reserved
+#
+#    WARNING: This program as such is intended to be used by professional
+#    programmers who take the whole responsibility of assessing all potential
+#    consequences resulting from its eventual inadequacies and bugs.
+#    End users who are looking for a ready-to-use solution with commercial
+#    guarantees and support are strongly advised to contact a Free Software
+#    Service Company.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+{
+    "name": "Account Journal Period Close",
+    "version": "1.0",
+    "author": "ACSONE SA/NV",
+    "maintainer": "ACSONE SA/NV",
+    "website": "http://www.acsone.eu",
+    "images": [],
+    "category": "Accounting",
+    "depends": [
+                "account"],
+    "description": """
+Account Journal Period Close
+==============================
+this module allows to add some account move in a close period.
+To do this, you have to specify account journals on which will allow writing of account move on the period form view
+""",
+    "data": ['view/account_view.xml'],
+    "demo": [],
+    "test": [],
+    "licence": "AGPL-3",
+    "installable": True,
+    "auto_install": False,
+    "application": True,
+}

--- a/account_journal_period_close/__openerp__.py
+++ b/account_journal_period_close/__openerp__.py
@@ -38,10 +38,19 @@
     "depends": [
                 "account"],
     "description": """
-Account Journal Period Close
-==============================
-this module allows to add some account move in a close period.
-To do this, you have to specify account journals on which will allow writing of account move on the period form view
+Close period per journal
+========================
+
+This module allows fine grained control of period closing.
+Each journal can be closed independently for any period
+(using buttons on the fiscal period view).
+
+A common use case is letting accountants close the sale
+and purchase journals when the VAT declaration is done for
+a given period, while leaving the miscellaneous journal open.
+
+From a technical standpoint, the module leverages the
+account.journal.period model that is present in Odoo core.
 """,
     "data": ['view/account_view.xml'],
     "demo": [],

--- a/account_journal_period_close/model/__init__.py
+++ b/account_journal_period_close/model/__init__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Adrien Peiffer
+#    Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)
+#    All Rights Reserved
+#
+#    WARNING: This program as such is intended to be used by professional
+#    programmers who take the whole responsibility of assessing all potential
+#    consequences resulting from its eventual inadequacies and bugs.
+#    End users who are looking for a ready-to-use solution with commercial
+#    guarantees and support are strongly advised to contact a Free Software
+#    Service Company.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+from . import account

--- a/account_journal_period_close/model/account.py
+++ b/account_journal_period_close/model/account.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Adrien Peiffer
+#    Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)
+#    All Rights Reserved
+#
+#    WARNING: This program as such is intended to be used by professional
+#    programmers who take the whole responsibility of assessing all potential
+#    consequences resulting from its eventual inadequacies and bugs.
+#    End users who are looking for a ready-to-use solution with commercial
+#    guarantees and support are strongly advised to contact a Free Software
+#    Service Company.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from openerp.osv import orm, fields
+from openerp.tools.translate import _
+
+
+class account_period(orm.Model):
+    _inherit = 'account.period'
+    _columns = {
+        'journal_period_ids': fields.one2many('account.journal.period',
+                                              'period_id', 'Journal states'),
+    }
+
+
+class account_journal_period(orm.Model):
+    _inherit = 'account.journal.period'
+    _order = "type,name"
+    _columns = {
+        'type': fields.related('journal_id', 'type', type='char',
+                               relation='account.journal',
+                               string='Journal Type',
+                               store=True, readonly=True)
+    }
+
+    def _check(self, cr, uid, ids, context=None):
+        return True
+
+    def action_draft(self, cr, uid, ids, context=None):
+        return self.write(cr, uid, ids, {'state': 'draft'})
+
+    def action_done(self, cr, uid, ids, context=None):
+        for journal_period in self.browse(cr, uid, ids, context=context):
+            draft_move_ids = self.pool.get('account.move')\
+                .search(cr, uid, [('period_id', '=',
+                                   journal_period.period_id.id),
+                                  ('state', '=', "draft"),
+                                  ('journal_id', '=',
+                                   journal_period.journal_id.id)],
+                        context=context)
+            if draft_move_ids:
+                raise orm.except_orm(_('Invalid Action!'),
+                                     _('In order to close a journal,'
+                                       ' you must first post related'
+                                       ' journal entries.'))
+        return self.write(cr, uid, ids, {'state': 'done'})
+
+    def create(self, cr, uid, values, context=None):
+        if 'name' not in values:
+            if values.get('period_id') and values.get('journal_id'):
+                journal = self.pool.get('account.journal')\
+                    .browse(cr, uid, values['journal_id'], context=context)
+                period = self.pool.get('account.period')\
+                    .browse(cr, uid, values['period_id'], context=context)
+                values.update({'name': (journal.code or journal.name)+':' +
+                               (period.name or '')}),
+        return super(account_journal_period, self).create(cr,
+                                                          uid,
+                                                          values,
+                                                          context=context)

--- a/account_journal_period_close/tests/__init__.py
+++ b/account_journal_period_close/tests/__init__.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Adrien Peiffer
+#    Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)
+#    All Rights Reserved
+#
+#    WARNING: This program as such is intended to be used by professional
+#    programmers who take the whole responsibility of assessing all potential
+#    consequences resulting from its eventual inadequacies and bugs.
+#    End users who are looking for a ready-to-use solution with commercial
+#    guarantees and support are strongly advised to contact a Free Software
+#    Service Company.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from . import test_account_journal_period_close

--- a/account_journal_period_close/tests/test_account_journal_period_close.py
+++ b/account_journal_period_close/tests/test_account_journal_period_close.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Adrien Peiffer
+#    Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)
+#    All Rights Reserved
+#
+#    WARNING: This program as such is intended to be used by professional
+#    programmers who take the whole responsibility of assessing all potential
+#    consequences resulting from its eventual inadequacies and bugs.
+#    End users who are looking for a ready-to-use solution with commercial
+#    guarantees and support are strongly advised to contact a Free Software
+#    Service Company.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+import openerp.tests.common as common
+from openerp.osv import orm
+from datetime import datetime
+
+DB = common.DB
+ADMIN_USER_ID = common.ADMIN_USER_ID
+
+
+def get_simple_account_move_values(self, period_id, journal_id):
+    sale_product_account_id = self.ref('account.a_sale')
+    cash_account_id = self.ref('account.cash')
+    partner_id = self.ref('base.res_partner_2')
+    year = datetime.now().strftime('%Y')
+    return {'partner_id': partner_id,
+            'period_id': period_id,
+            'date': year + '-01-01',
+            'journal_id': journal_id,
+            'line_id': [(0, 0, {'name': 'test',
+                                'account_id': cash_account_id,
+                                'debit': 50.0,
+                                }),
+                        (0, 0, {'name': 'test_conterpart',
+                                'account_id': sale_product_account_id,
+                                'credit': 50.0,
+                                })
+                        ]
+            }
+
+
+def close_period(self, period_id, context=None):
+    close_period_wizard_id =\
+        self.registry('account.period.close').create(self.cr,
+                                                     self.uid,
+                                                     {'sure': True
+                                                      },
+                                                     context=context)
+    context.update({'active_ids': [period_id]})
+    self.registry('account.period.close')\
+        .data_save(self.cr,
+                   self.uid,
+                   [close_period_wizard_id],
+                   context=context)
+
+
+def create_journal_period(self, period_id, journal_id, context):
+    jour_per_obj = self.registry('account.journal.period')
+    journal_period_id = jour_per_obj.create(self.cr,
+                                            self.uid,
+                                            {'period_id': period_id,
+                                             'journal_id': journal_id,
+                                             },
+                                            context=context)
+    return journal_period_id
+
+
+def journal_period_done(self, journal_period_id, context):
+    jour_per_obj = self.registry('account.journal.period')
+    jour_per_obj.action_done(self.cr,
+                             self.uid,
+                             [journal_period_id],
+                             context=context)
+
+
+def journal_period_draft(self, journal_period_id, context):
+    jour_per_obj = self.registry('account.journal.period')
+    jour_per_obj.action_draft(self.cr,
+                              self.uid,
+                              [journal_period_id],
+                              context=context)
+
+
+class TestAccountConstraintChronology(common.TransactionCase):
+
+    def setUp(self):
+        super(TestAccountConstraintChronology, self).setUp()
+
+    def test_close_period_open_journal(self):
+        context = {}
+        journal_id = self.ref('account.sales_journal')
+        period_id = self.ref('account.period_1')
+        close_period(self, period_id, context)
+        journal_period_id = create_journal_period(self,
+                                                  period_id,
+                                                  journal_id,
+                                                  context)
+        journal_period_draft(self, journal_period_id, context)
+        self.registry('account.move')\
+            .create(self.cr,
+                    self.uid,
+                    get_simple_account_move_values(self,
+                                                   period_id,
+                                                   journal_id),
+                    context=context)
+        # Here, no exception should be raised because the journal's state is
+        # draft although the period is closed
+
+    def test_open_period_close_journal(self):
+        context = {}
+        journal_id = self.ref('account.sales_journal')
+        period_id = self.ref('account.period_1')
+        journal_period_id = create_journal_period(self,
+                                                  period_id,
+                                                  journal_id,
+                                                  context)
+        journal_period_done(self, journal_period_id, context)
+        move_values = get_simple_account_move_values(self,
+                                                     period_id,
+                                                     journal_id)
+        # I check if the exception is correctly raised at create of an account
+        # move which is linked with a closed journal
+        self.assertRaises(orm.except_orm,
+                          self.registry('account.move').create,
+                          self.cr, self.uid, move_values, context=context)
+
+    def test_change_journal_on_move(self):
+        context = {}
+        journal_id = self.ref('account.sales_journal')
+        journal_cash_id = self.ref('account.cash_journal')
+        period_id = self.ref('account.period_1')
+        journal_period_id = create_journal_period(self,
+                                                  period_id,
+                                                  journal_id,
+                                                  context)
+        journal_period_done(self, journal_period_id, context)
+        move_values = get_simple_account_move_values(self,
+                                                     period_id,
+                                                     journal_cash_id)
+        self.registry('account.move').create(self.cr,
+                                             self.uid,
+                                             move_values,
+                                             context=context)
+        # Standard of Odoo doesn't check account_journal_period at write on
+        # account_move
+        # issue on Odoo github : #1633
+
+        # I check if the exception is correctly raised
+        """self.assertRaises(orm.except_orm,
+                          self.registry('account.move').write,
+                          self.cr, self.uid, [move_id],
+                          {'journal_id': journal_id}, context=context)"""
+
+    def test_draft_move_close_journal(self):
+        context = {}
+
+        jour_per_obj = self.registry('account.journal.period')
+        journal_id = self.ref('account.sales_journal')
+        period_id = self.ref('account.period_1')
+        move_values = get_simple_account_move_values(self,
+                                                     period_id,
+                                                     journal_id)
+        self.registry('account.move').create(self.cr,
+                                             self.uid,
+                                             move_values,
+                                             context=context)
+        journal_period_ids =\
+            jour_per_obj.search(self.cr,
+                                self.uid,
+                                [('period_id', '=', period_id),
+                                 ('journal_id', '=', journal_id),
+                                 ],
+                                context=context)
+        # I check if the exception is correctly raised at closing journal that
+        # contains some draft account move
+        self.assertRaises(orm.except_orm,
+                          jour_per_obj.action_done,
+                          self.cr, self.uid, journal_period_ids,
+                          context=context)

--- a/account_journal_period_close/view/account_view.xml
+++ b/account_journal_period_close/view/account_view.xml
@@ -31,4 +31,3 @@
         </record>
     </data>
 </openerp>
-        

--- a/account_journal_period_close/view/account_view.xml
+++ b/account_journal_period_close/view/account_view.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_account_period_form" model="ir.ui.view">
+            <field name="name">account.period.form
+                (account_journal_period_close)</field>
+            <field name="model">account.period</field>
+            <field name="inherit_id" ref="account.view_account_period_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//sheet/group" position="after">
+                    <notebook>
+                        <page string="Journals">
+                            <field name="journal_period_ids">
+                                <tree editable="bottom">
+                                    <field name="journal_id" attrs="{'readonly': [('type', '!=', False)]}"/>
+                                    <field name="type"/>
+                                    <field name="state" readonly="0"
+                                        invisible="1" />
+                                    <button name="action_done"
+                                        type="object" icon="gtk-cancel"
+                                        states="draft" help="Close journal for this period"/>
+                                    <button name="action_draft"
+                                        type="object" icon="gtk-redo"
+                                        states="done" help="Reopen journal for this period"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>
+        


### PR DESCRIPTION
Add account_journal_period_close module

This module allows fine grained control of period closing.
Each journal can be closed independently for any period
(using buttons on the fiscal period view).

A common use case is letting accountants close the sale
and purchase journals when the VAT declaration is done for
a given period, while leaving the miscellaneous journal open.

From a technical standpoint, the module leverages the
account.journal.period model that is present in Odoo core.
