### PR TITLE
Adding account move select reconciliation 7

### DIFF
--- a/account_move_select_reconciliation/__init__.py
+++ b/account_move_select_reconciliation/__init__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Copyright (C) 2014 Agile Business Group sagl
-#	 (<http://www.agilebg.com>)
+#    (<http://www.agilebg.com>)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published

--- a/account_move_select_reconciliation/__init__.py
+++ b/account_move_select_reconciliation/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Agile Business Group sagl
+#	 (<http://www.agilebg.com>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import account_move

--- a/account_move_select_reconciliation/__init__.py
+++ b/account_move_select_reconciliation/__init__.py
@@ -18,4 +18,4 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from . import account_move
+from . import account_move_line

--- a/account_move_select_reconciliation/__openerp__.py
+++ b/account_move_select_reconciliation/__openerp__.py
@@ -25,7 +25,15 @@
     'version': '0.1',
     'category': 'Finance',
     'description': """
+This module allows to manually select the journal item to be reconciled while
+registering a journal entry.
 
+**Example** (also see the included test case)
+
+You have an open credit and you need to close it by a manual journal entry.
+With this module you can manually create the payment journal entry, select the
+open credit and click 'Reconcile Line'. The system will close the credit
+generating the respective reconciliation.
     """,
     'author': 'Agile Business Group',
     'website': 'http://www.agilebg.com',

--- a/account_move_select_reconciliation/__openerp__.py
+++ b/account_move_select_reconciliation/__openerp__.py
@@ -29,6 +29,7 @@
     'website': 'http://www.agilebg.com',
     'license': 'AGPL-3',
     "depends": [
+        'account_accountant',
     ],
     "data": [
         'account_move_view.xml',

--- a/account_move_select_reconciliation/__openerp__.py
+++ b/account_move_select_reconciliation/__openerp__.py
@@ -3,7 +3,8 @@
 #
 #    Copyright (C) 2014 Agile Business Group sagl
 #    (<http://www.agilebg.com>)
-#    @author Alex Comba <alex.comba@agilebg.com>
+#    @authors Alex Comba <alex.comba@agilebg.com>
+#             Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published
@@ -24,6 +25,7 @@
     'version': '0.1',
     'category': 'Finance',
     'description': """
+
     """,
     'author': 'Agile Business Group',
     'website': 'http://www.agilebg.com',
@@ -34,6 +36,9 @@
     "data": [
         'account_move_view.xml',
     ],
+    "test": [
+        'test/account.yml',
+        ],
     "active": False,
     "installable": True
 }

--- a/account_move_select_reconciliation/__openerp__.py
+++ b/account_move_select_reconciliation/__openerp__.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Agile Business Group sagl
+#    (<http://www.agilebg.com>)
+#    @author Alex Comba <alex.comba@agilebg.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Account Move Select Reconciliation",
+    'version': '0.1',
+    'category': 'Finance',
+    'description': """
+    """,
+    'author': 'Agile Business Group',
+    'website': 'http://www.agilebg.com',
+    'license': 'AGPL-3',
+    "depends": [
+    ],
+    "data": [
+        'account_move_view.xml',
+    ],
+    "active": False,
+    "installable": True
+}

--- a/account_move_select_reconciliation/account_move.py
+++ b/account_move_select_reconciliation/account_move.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Agile Business Group sagl
+#    (<http://www.agilebg.com>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, orm
+
+
+class account_move(orm.Model):
+    _inherit = 'account.move'
+
+    def post(self, cr, uid, ids, context=None):
+        for move in self.browse(cr, uid, ids, context=context):
+            for line in move.line_id:
+                if line.move_line_to_reconcile_id:
+                    account_move_line_obj = self.pool.get('account.move.line')
+                    account_move_line_obj.reconcile_partial(
+                        cr, uid,
+                        [line.id, line.move_line_to_reconcile_id.id],
+                        context=context
+                    )
+        return super(account_move, self).post(cr, uid, ids, context=context)
+
+
+class account_move_line(orm.Model):
+    _inherit = 'account.move.line'
+
+    _columns = {
+        'move_line_to_reconcile_id': fields.many2one(
+            'account.move.line',
+            'Move Line To Reconcile',
+        ),
+    }

--- a/account_move_select_reconciliation/account_move.py
+++ b/account_move_select_reconciliation/account_move.py
@@ -45,5 +45,26 @@ class account_move_line(orm.Model):
         'move_line_to_reconcile_id': fields.many2one(
             'account.move.line',
             'Move Line To Reconcile',
+            domain="[('reconcile_id', '=', False)]",
         ),
     }
+
+    def onchange_move_line_to_reconcile_id(
+        self, cr, uid, ids, move_line_to_reconcile_id, context=None
+    ):
+        res = {}
+        if move_line_to_reconcile_id:
+            account_move_line_obj = self.pool.get('account.move.line')
+            line = account_move_line_obj.browse(
+                cr, uid, move_line_to_reconcile_id, context=context)
+            res['value'] = {
+                'partner_id': line.partner_id.id,
+                'account_id': line.account_id.id,
+                'debit': line.credit,
+                'credit': line.debit,
+                'amount_currency': -line.amount_currency,
+                'currency_id': line.currency_id.id,
+                'tax_code_id':  line.tax_code_id.id,
+                'tax_amount': -line.tax_amount,
+            }
+        return res

--- a/account_move_select_reconciliation/account_move_line.py
+++ b/account_move_select_reconciliation/account_move_line.py
@@ -29,7 +29,8 @@ class account_move_line(orm.Model):
         'move_line_to_reconcile_id': fields.many2one(
             'account.move.line',
             'Move Line To Reconcile',
-            domain="[('reconcile_id', '=', False)]",
+            domain="[('reconcile_id', '=', False), \
+                ('account_id.reconcile', '=', True)]",
         ),
     }
 

--- a/account_move_select_reconciliation/account_move_view.xml
+++ b/account_move_select_reconciliation/account_move_view.xml
@@ -11,8 +11,12 @@
                     <field
                         name="move_line_to_reconcile_id"
                         on_change="onchange_move_line_to_reconcile_id(move_line_to_reconcile_id)"/>
-                    <button icon="gtk-yes" name="reconcile_move_line" string="Reconcile Line" type="object"/>
-                    <button icon="gtk-no" name="unreconcile_move_line" string="Unreconcile Line" type="object"/>
+                    <button 
+                        icon="gtk-yes" name="reconcile_move_line" string="Reconcile Line"
+                        type="object" attrs="{'invisible':[('move_line_to_reconcile_id','=',False)]}"/>
+                    <button
+                        icon="gtk-no" name="unreconcile_move_line" string="Unreconcile Line"
+                        type="object" attrs="{'invisible':[('move_line_to_reconcile_id','=',False)]}"/>
                 </xpath>
             </field>
         </record>

--- a/account_move_select_reconciliation/account_move_view.xml
+++ b/account_move_select_reconciliation/account_move_view.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="account.view_move_form"/>
             <field name="arch" type="xml">
                 <xpath expr="/form/sheet/notebook/page[@string='Journal Items']/field[@name='line_id']/tree/field[@name='name']" position="after">
-                    <field name="move_line_to_reconcile_id"/>
+                    <field name="move_line_to_reconcile_id" domain="[('reconcile_id', '=', False)]"/>
                 </xpath>
             </field>
         </record>

--- a/account_move_select_reconciliation/account_move_view.xml
+++ b/account_move_select_reconciliation/account_move_view.xml
@@ -7,7 +7,7 @@
             <field name="model">account.move</field>
             <field name="inherit_id" ref="account.view_move_form"/>
             <field name="arch" type="xml">
-                <xpath expr="/form/sheet/notebook/page[@string='Journal Items']/field[@name='line_id']/tree/field[@name='state']" position="after">
+                <xpath expr="/form/sheet/notebook/page[@string='Journal Items']/field[@name='line_id']/tree/field[@name='name']" position="after">
                     <field name="move_line_to_reconcile_id"/>
                 </xpath>
             </field>

--- a/account_move_select_reconciliation/account_move_view.xml
+++ b/account_move_select_reconciliation/account_move_view.xml
@@ -8,7 +8,9 @@
             <field name="inherit_id" ref="account.view_move_form"/>
             <field name="arch" type="xml">
                 <xpath expr="/form/sheet/notebook/page[@string='Journal Items']/field[@name='line_id']/tree/field[@name='name']" position="after">
-                    <field name="move_line_to_reconcile_id" domain="[('reconcile_id', '=', False)]"/>
+                    <field
+                        name="move_line_to_reconcile_id"
+                        on_change="onchange_move_line_to_reconcile_id(move_line_to_reconcile_id)"/>
                 </xpath>
             </field>
         </record>

--- a/account_move_select_reconciliation/account_move_view.xml
+++ b/account_move_select_reconciliation/account_move_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_move_form" model="ir.ui.view">
+            <field name="name">account.move.form</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_move_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="/form/sheet/notebook/page[@string='Journal Items']/field[@name='line_id']/tree/field[@name='state']" position="after">
+                    <field name="move_line_to_reconcile_id"/>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/account_move_select_reconciliation/account_move_view.xml
+++ b/account_move_select_reconciliation/account_move_view.xml
@@ -11,6 +11,8 @@
                     <field
                         name="move_line_to_reconcile_id"
                         on_change="onchange_move_line_to_reconcile_id(move_line_to_reconcile_id)"/>
+                    <button icon="gtk-yes" name="reconcile_move_line" string="Reconcile Line" type="object"/>
+                    <button icon="gtk-no" name="unreconcile_move_line" string="Unreconcile Line" type="object"/>
                 </xpath>
             </field>
         </record>

--- a/account_move_select_reconciliation/i18n/account_move_select_reconciliation.pot
+++ b/account_move_select_reconciliation/i18n/account_move_select_reconciliation.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-02-24 15:13+0000\n"
-"PO-Revision-Date: 2014-02-24 15:13+0000\n"
+"POT-Creation-Date: 2014-02-26 16:06+0000\n"
+"PO-Revision-Date: 2014-02-26 16:06+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -26,7 +26,12 @@ msgid "Move Line To Reconcile"
 msgstr ""
 
 #. module: account_move_select_reconciliation
-#: model:ir.model,name:account_move_select_reconciliation.model_account_move
-msgid "Account Entry"
+#: view:account.move:0
+msgid "Reconcile Line"
+msgstr ""
+
+#. module: account_move_select_reconciliation
+#: view:account.move:0
+msgid "Unreconcile Line"
 msgstr ""
 

--- a/account_move_select_reconciliation/i18n/account_move_select_reconciliation.pot
+++ b/account_move_select_reconciliation/i18n/account_move_select_reconciliation.pot
@@ -1,0 +1,32 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_move_select_reconciliation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-02-24 15:13+0000\n"
+"PO-Revision-Date: 2014-02-24 15:13+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_move_select_reconciliation
+#: model:ir.model,name:account_move_select_reconciliation.model_account_move_line
+msgid "Journal Items"
+msgstr ""
+
+#. module: account_move_select_reconciliation
+#: field:account.move.line,move_line_to_reconcile_id:0
+msgid "Move Line To Reconcile"
+msgstr ""
+
+#. module: account_move_select_reconciliation
+#: model:ir.model,name:account_move_select_reconciliation.model_account_move
+msgid "Account Entry"
+msgstr ""
+

--- a/account_move_select_reconciliation/i18n/it.po
+++ b/account_move_select_reconciliation/i18n/it.po
@@ -1,0 +1,32 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* account_move_select_reconciliation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-02-24 15:13+0000\n"
+"PO-Revision-Date: 2014-02-24 16:55+0100\n"
+"Last-Translator: Alex Comba <alex.comba@agilebg.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: account_move_select_reconciliation
+#: model:ir.model,name:account_move_select_reconciliation.model_account_move_line
+msgid "Journal Items"
+msgstr "Voci Sezionale"
+
+#. module: account_move_select_reconciliation
+#: field:account.move.line,move_line_to_reconcile_id:0
+msgid "Move Line To Reconcile"
+msgstr "Voce Sezionale da Riconciliare"
+
+#. module: account_move_select_reconciliation
+#: model:ir.model,name:account_move_select_reconciliation.model_account_move
+msgid "Account Entry"
+msgstr "Registrazione Sezionale"

--- a/account_move_select_reconciliation/i18n/it.po
+++ b/account_move_select_reconciliation/i18n/it.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-02-24 15:13+0000\n"
-"PO-Revision-Date: 2014-02-24 16:55+0100\n"
+"POT-Creation-Date: 2014-02-26 16:10+0000\n"
+"PO-Revision-Date: 2014-02-26 17:13+0100\n"
 "Last-Translator: Alex Comba <alex.comba@agilebg.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,7 +19,7 @@ msgstr ""
 #. module: account_move_select_reconciliation
 #: model:ir.model,name:account_move_select_reconciliation.model_account_move_line
 msgid "Journal Items"
-msgstr "Voci Sezionale"
+msgstr "Voci sezionale"
 
 #. module: account_move_select_reconciliation
 #: field:account.move.line,move_line_to_reconcile_id:0
@@ -27,6 +27,11 @@ msgid "Move Line To Reconcile"
 msgstr "Voce Sezionale da Riconciliare"
 
 #. module: account_move_select_reconciliation
-#: model:ir.model,name:account_move_select_reconciliation.model_account_move
-msgid "Account Entry"
-msgstr "Registrazione Sezionale"
+#: view:account.move:0
+msgid "Reconcile Line"
+msgstr "Riconcilia Voce Sezionale"
+
+#. module: account_move_select_reconciliation
+#: view:account.move:0
+msgid "Unreconcile Line"
+msgstr "Annulla Riconciliazione su Voce Sezionale"

--- a/account_move_select_reconciliation/test/account.yml
+++ b/account_move_select_reconciliation/test/account.yml
@@ -1,0 +1,51 @@
+-
+  I create a customer invoice
+-
+  !record {model: account.invoice, id: account_invoice_customer_1, view: account.invoice_form}:
+    partner_id: base.res_partner_3
+    account_id: account.a_recv
+    invoice_line:
+      - name: 'service'
+        quantity: 1
+        price_unit: 100
+-
+  I confirm the invoice
+-
+  !workflow {model: account.invoice, action: invoice_open, ref: account_invoice_customer_1}
+-
+  I create the payment move
+-
+  !record {model: account.move, id: move_1, view: view_move_form}:
+    journal_id: account.bank_journal
+    line_id:
+      - name: 'bank'
+        account_id: account.bnk
+        debit: 100
+        credit: 0
+      - name: 'customer'
+        account_id: account.a_recv
+        debit: 0
+        credit: 100
+-
+  I set the journal item to be reconciled and perform reconciliation
+-
+  !python {model: account.move}: |
+    move = self.browse(cr, uid, ref("move_1"))
+    inv = self.pool.get('account.invoice').browse(cr, uid, ref("account_invoice_customer_1"))
+    for move_line in move.line_id:
+      for line in inv.move_id.line_id:
+        if line.account_id.id == move_line.account_id.id:
+          res = move_line.onchange_move_line_to_reconcile_id(line.id)
+          res['value']['move_line_to_reconcile_id'] = line.id
+          move_line.write(res['value'])
+          move_line.reconcile_move_line()
+          move_line.refresh()
+          inv.refresh()
+          assert move_line.reconcile_id, "move_line %s is not reconciled" % move_line.name
+          assert inv.state == 'paid', "Invoice is not paid but %s" % inv.state
+          move_line.unreconcile_move_line()
+          move_line.refresh()
+          inv.refresh()
+          assert not move_line.reconcile_id, "move_line %s is reconciled" % move_line.name
+          assert inv.state == 'open', "Invoice is not open but %s" % inv.state
+    


### PR DESCRIPTION
This module allows to manually select the journal item to be reconciled while
registering a journal entry.

**Example** (also see the included test case)

You have an open credit and you need to close it by a manual journal entry.
With this module you can manually create the payment journal entry, select the
open credit and click 'Reconcile Line'. The system will close the credit
generating the respective reconciliation.
