### PR TITLE
7.0 refactor account_partner_required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,12 @@ python:
   - "2.7"
 
 env:
-  - VERSION="7.0" ODOO_REPO="odoo/odoo" EXCLUDE="account_constraints,account_partner_required,async_move_line_importer,account_move_validation_improvement,account_default_draft_move,account_move_batch_validate"
+  - VERSION="7.0" ODOO_REPO="odoo/odoo" EXCLUDE="account_constraints,async_move_line_importer,account_move_validation_improvement,account_default_draft_move,account_move_batch_validate"
   - VERSION="7.0" ODOO_REPO="odoo/odoo" INCLUDE="account_constraints,account_move_validation_improvement,account_default_draft_move,account_move_batch_validate"
-  - VERSION="7.0" ODOO_REPO="odoo/odoo" INCLUDE="account_partner_required"
   - VERSION="7.0" ODOO_REPO="odoo/odoo" INCLUDE="async_move_line_importer"
 
-  - VERSION="7.0" ODOO_REPO="OCA/OCB"   EXCLUDE="account_constraints, account_partner_required,async_move_line_importer,account_move_validation_improvement,account_default_draft_move,account_move_batch_validate"
+  - VERSION="7.0" ODOO_REPO="OCA/OCB"   EXCLUDE="account_constraints, async_move_line_importer,account_move_validation_improvement,account_default_draft_move,account_move_batch_validate"
   - VERSION="7.0" ODOO_REPO="OCA/OCB"   INCLUDE="account_constraints,account_move_validation_improvement,account_default_draft_move,account_move_batch_validate"
-  - VERSION="7.0" ODOO_REPO="OCA/OCB"   INCLUDE="account_partner_required"
   - VERSION="7.0" ODOO_REPO="OCA/OCB" INCLUDE="async_move_line_importer"
 
 virtualenv:

--- a/account_partner_required/account.py
+++ b/account_partner_required/account.py
@@ -95,5 +95,5 @@ class account_move_line(orm.Model):
     _constraints = [
         (_check_partner_required,
          _check_partner_required_msg,
-         ['partner_id', 'account_id']),
+         ['partner_id', 'account_id', 'debit', 'credit']),
     ]

--- a/account_partner_required/account.py
+++ b/account_partner_required/account.py
@@ -95,5 +95,5 @@ class account_move_line(orm.Model):
     _constraints = [
         (_check_partner_required,
          _check_partner_required_msg,
-         ['partner_id']),
+         ['partner_id', 'account_id']),
     ]

--- a/account_partner_required/account.py
+++ b/account_partner_required/account.py
@@ -29,17 +29,13 @@ class account_account_type(orm.Model):
 
     def _get_policies(self, cr, uid, context=None):
         """This is the method to be inherited for adding policies"""
-        return [('optional', 'Optional'),
-                ('always', 'Always'),
-                ('never', 'Never')]
-
-    def __get_policies(self, cr, uid, context=None):
-        """ Call method which can be inherited """
-        return self._get_policies(cr, uid, context=context)
+        return [('optional', _('Optional')),
+                ('always', _('Always')),
+                ('never', _('Never'))]
 
     _columns = {
         'partner_policy': fields.selection(
-            __get_policies,
+            lambda self, *args, **kwargs: self._get_policies(*args, **kwargs),
             'Policy for partner field',
             required=True,
             help="Set the policy for the partner field : if you select "

--- a/account_partner_required/account.py
+++ b/account_partner_required/account.py
@@ -75,18 +75,18 @@ class account_move_line(orm.Model):
                          "with account %s '%s' but the "
                          "partner is missing in the account "
                          "move line with label '%s'." %
-                    (move_line.account_id.code,
-                     move_line.account_id.name,
-                     move_line.name))
+                         (move_line.account_id.code,
+                          move_line.account_id.name,
+                          move_line.name))
             elif policy == 'never' and move_line.partner_id:
                 return _("Partner policy is set to 'Never' "
                          "with account %s '%s' but the "
                          "account move line with label '%s' "
                          "has a partner '%s'." %
-                    (move_line.account_id.code,
-                     move_line.account_id.name,
-                     move_line.name,
-                     move_line.partner_id.name))
+                         (move_line.account_id.code,
+                          move_line.account_id.name,
+                          move_line.name,
+                          move_line.partner_id.name))
 
     def _check_partner_required(self, cr, uid, ids, context=None):
         return not self._check_partner_required_msg(cr, uid, ids,

--- a/account_partner_required/tests/test_account_partner_required.py
+++ b/account_partner_required/tests/test_account_partner_required.py
@@ -109,7 +109,7 @@ class test_account_partner_required(common.TransactionCase):
         self._set_partner_policy('always')
         line_id = self._create_move(with_partner=True)
         with self.assertRaises(orm.except_orm):
-            self.move_line_obj.write(self.cr, self.uid, line_id,
+            self.move_line_obj.write(self.cr, self.uid, [line_id],
                                      {'partner_id': False})
 
     def test_change_account(self):
@@ -117,13 +117,13 @@ class test_account_partner_required(common.TransactionCase):
         line_id = self._create_move(with_partner=False)
         # change account to a_pay with policy always but missing partner
         with self.assertRaises(orm.except_orm):
-            self.move_line_obj.write(self.cr, self.uid, line_id,
+            self.move_line_obj.write(self.cr, self.uid, [line_id],
                                      {'account_id': self.ref('account.a_pay')})
         # change account to a_pay with policy always with partner -> ok
         self.move_line_obj.write(
             self.cr,
             self.uid,
-            line_id,
+            [line_id],
             {
                 'account_id': self.ref('account.a_pay'),
                 'partner_id': self.ref('base.res_partner_1')


### PR DESCRIPTION
refactor account_partner_required:
- add extension points for policies
- use constraints for readbility and robustness
- slightly adapt the test to work around an issue in account_constraints (which allows the simplification of the travis configuration)
