### PR TITLE
Minor fix on Banxico Updates

### DIFF
--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -728,6 +728,7 @@ class Banxico_getter(Curreny_getter_interface):
             self.updated_currency[curr] = rate
             logger.debug("Rate retrieved : %s = %s %s" %
                          (main_currency, rate, curr))
+        return self.updated_currency, self.log_info
 
 
 # CA BOC #####   Bank of Canada   #############################################


### PR DESCRIPTION
There were a missing return line on banxico updater that prevents
module updates rates for mexican currency updater
