### PR TITLE
[ADD] 7.0 account_auto_fy_sequence

### DIFF
--- a/account_auto_fy_sequence/__init__.py
+++ b/account_auto_fy_sequence/__init__.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+##############################################################################
+#
+#    account_auto_fy_sequence module for Odoo
+#    Copyright (C) 2014 ACSONE SA/NV (<http://acsone.eu>)
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    account_auto_fy_sequence is free software:
+#    you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License v3 or later
+#    as published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    account_auto_fy_sequence is distributed
+#    in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License v3 or later for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    v3 or later along with this program.
+#    If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/account_auto_fy_sequence/__openerp__.py
+++ b/account_auto_fy_sequence/__openerp__.py
@@ -40,6 +40,8 @@
     already been used for the current fiscal year, make sure to manually
     create the fiscal year sequence for the current fiscal year and
     initialize it's next number to the correct value.
+    For this reason, the module will forbid the user to change
+    a sequence from %(year)s to %(fy)s if it's next number is > 1.
     """,
     'author': 'ACSONE SA/NV',
     'website': 'http://acsone.eu',

--- a/account_auto_fy_sequence/__openerp__.py
+++ b/account_auto_fy_sequence/__openerp__.py
@@ -44,7 +44,7 @@
     'author': 'ACSONE SA/NV',
     'website': 'http://acsone.eu',
     'depends': ['account'],
-    'data': [
+    'data': ['views/ir_sequence_view.xml',
     ],
     'installable': True,
     'application': False,

--- a/account_auto_fy_sequence/__openerp__.py
+++ b/account_auto_fy_sequence/__openerp__.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+##############################################################################
+#
+#    account_auto_fy_sequence module for Odoo
+#    Copyright (C) 2014 ACSONE SA/NV (<http://acsone.eu>)
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    account_auto_fy_sequence is free software:
+#    you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License v3 or later
+#    as published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    account_auto_fy_sequence is distributed
+#    in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License v3 or later for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    v3 or later along with this program.
+#    If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Automatic Fiscal Year Sequences',
+    'version': '0.1',
+    'category': 'Accounting',
+    'description': """
+    Automatic creation of fiscal year sequences.
+
+    This modules adds the possibility to use the %(fy)s placeholder
+    in sequences. %(fy)s is replaced by the fiscal year code when
+    using the sequence.
+
+    The first time the sequence is used for a given fiscal year,
+    a specific fiscal year sequence starting at 1 is created automatically.
+
+    /!\ If you change %(year)s to %(fy)s on a sequence that has
+    already been used for the current fiscal year, make sure to manually
+    create the fiscal year sequence for the current fiscal year and
+    initialize it's next number to the correct value.
+    """,
+    'author': 'ACSONE SA/NV',
+    'website': 'http://acsone.eu',
+    'depends': ['account'],
+    'data': [
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+    'license': 'AGPL-3',
+}

--- a/account_auto_fy_sequence/__openerp__.py
+++ b/account_auto_fy_sequence/__openerp__.py
@@ -44,7 +44,8 @@
     'author': 'ACSONE SA/NV',
     'website': 'http://acsone.eu',
     'depends': ['account'],
-    'data': ['views/ir_sequence_view.xml',
+    'data': [
+        'views/ir_sequence_view.xml',
     ],
     'installable': True,
     'application': False,

--- a/account_auto_fy_sequence/__openerp__.py
+++ b/account_auto_fy_sequence/__openerp__.py
@@ -29,7 +29,7 @@
     'description': """
     Automatic creation of fiscal year sequences.
 
-    This modules adds the possibility to use the %(fy)s placeholder
+    This module adds the possibility to use the %(fy)s placeholder
     in sequences. %(fy)s is replaced by the fiscal year code when
     using the sequence.
 

--- a/account_auto_fy_sequence/i18n/account_auto_fy_sequence.pot
+++ b/account_auto_fy_sequence/i18n/account_auto_fy_sequence.pot
@@ -19,13 +19,13 @@ msgstr ""
 #: code:addons/account_auto_fy_sequence/models/ir_sequence.py:44
 #, python-format
 msgid "Error!"
-msgstr "Erreur!"
+msgstr ""
 
 #. module: account_auto_fy_sequence
 #: code:addons/account_auto_fy_sequence/models/ir_sequence.py:45
 #, python-format
 msgid "The system tried to access a fiscal year sequence without specifying the actual fiscal year."
-msgstr "Le système tente d'accéder à une séquence pour exercice fiscal sans préciser d'exercice."
+msgstr ""
 
 #. module: account_auto_fy_sequence
 #: model:ir.model,name:account_auto_fy_sequence.model_ir_sequence

--- a/account_auto_fy_sequence/i18n/fr.po
+++ b/account_auto_fy_sequence/i18n/fr.po
@@ -1,0 +1,3 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* account_auto_fy_sequence

--- a/account_auto_fy_sequence/models/__init__.py
+++ b/account_auto_fy_sequence/models/__init__.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+##############################################################################
+#
+#    account_auto_fy_sequence module for Odoo
+#    Copyright (C) 2014 ACSONE SA/NV (<http://acsone.eu>)
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    account_auto_fy_sequence is free software:
+#    you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License v3 or later
+#    as published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    account_auto_fy_sequence is distributed
+#    in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License v3 or later for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    v3 or later along with this program.
+#    If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import ir_sequence

--- a/account_auto_fy_sequence/models/ir_sequence.py
+++ b/account_auto_fy_sequence/models/ir_sequence.py
@@ -1,0 +1,77 @@
+# coding=utf-8
+##############################################################################
+#
+#    account_auto_fy_sequence module for Odoo
+#    Copyright (C) 2014 ACSONE SA/NV (<http://acsone.eu>)
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    account_auto_fy_sequence is free software:
+#    you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License v3 or later
+#    as published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    account_auto_fy_sequence is distributed
+#    in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License v3 or later for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    v3 or later along with this program.
+#    If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+from openerp.tools.translate import _
+
+FY_SLOT = '%(fy)s'
+
+
+class Sequence(orm.Model):
+    _inherit = 'ir.sequence'
+
+    def _next(self, cr, uid, seq_ids, context=None):
+        if context is None:
+            context = {}
+        assert len(seq_ids) == 1
+        seq = self.browse(cr, uid, seq_ids[0], context)
+        if (seq.prefix and FY_SLOT in seq.prefix) or \
+                (seq.suffix and FY_SLOT in seq.suffix):
+            fiscalyear_id = context.get('fiscalyear_id')
+            if not fiscalyear_id:
+                raise orm.except_orm(_('Error!'),
+                                     _('The system tried to access '
+                                       'a fiscal year sequence '
+                                       'without specifying the actual '
+                                       'fiscal year.'))
+            for line in seq.fiscal_ids:
+                if line.fiscalyear_id.id == fiscalyear_id:
+                    return super(Sequence, self)\
+                        ._next(cr, uid, [line.sequence_id.id], context)
+            # no fiscal year sequence found, auto create it
+            fiscalyear = self.pool['account.fiscalyear']\
+                .browse(cr, uid, fiscalyear_id, context=context)
+            fy_seq_id = self.create(cr, uid, {
+                'name': seq.name + ' - ' + fiscalyear.code,
+                'code': seq.code,
+                'implementation': seq.implementation,
+                'prefix': (seq.prefix and
+                           seq.prefix.replace(FY_SLOT, fiscalyear.code)),
+                'suffix': (seq.suffix and
+                           seq.suffix.replace(FY_SLOT, fiscalyear.code)),
+                'number_next': 1,
+                'number_increment': seq.number_increment,
+                'padding': seq.padding,
+                'company_id': seq.company_id.id,
+            }, context=context)
+            self.pool['account.sequence.fiscalyear']\
+                .create(cr, uid, {
+                    'sequence_id': fy_seq_id,
+                    'sequence_main_id': seq.id,
+                    'fiscalyear_id': fiscalyear_id,
+                }, context=context)
+            return super(Sequence, self)\
+                ._next(cr, uid, [fy_seq_id], context)
+        return super(Sequence, self)._next(cr, uid, seq_ids, context)

--- a/account_auto_fy_sequence/tests/__init__.py
+++ b/account_auto_fy_sequence/tests/__init__.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+##############################################################################
+#
+#    account_auto_fy_sequence module for Odoo
+#    Copyright (C) 2014 ACSONE SA/NV (<http://acsone.eu>)
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    account_auto_fy_sequence is free software:
+#    you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License v3 or later
+#    as published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    account_auto_fy_sequence is distributed
+#    in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License v3 or later for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    v3 or later along with this program.
+#    If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_auto_fy_sequence
+
+checks = [
+    test_auto_fy_sequence,
+]

--- a/account_auto_fy_sequence/tests/test_auto_fy_sequence.py
+++ b/account_auto_fy_sequence/tests/test_auto_fy_sequence.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+##############################################################################
+#
+#    account_auto_fy_sequence module for Odoo
+#    Copyright (C) 2014 ACSONE SA/NV (<http://acsone.eu>)
+#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#
+#    account_auto_fy_sequence is free software:
+#    you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License v3 or later
+#    as published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    account_auto_fy_sequence is distributed
+#    in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License v3 or later for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    v3 or later along with this program.
+#    If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import time
+
+import openerp.tests.common as common
+from openerp.osv import orm
+
+
+class TestAutoFYSequence(common.TransactionCase):
+
+    def setUp(self):
+        super(TestAutoFYSequence, self).setUp()
+        self.seq_obj = self.registry('ir.sequence')
+
+    def _create_seq(self, prefix):
+        seq_id = self.seq_obj.create(self.cr, self.uid, {
+            'name': 'test sequence',
+            'implementation': 'no_gap',
+            'prefix': prefix,
+        })
+        return seq_id
+
+    def test_0(self):
+        """ normal sequence """
+        seq_id = self._create_seq('SEQ/%(year)s/')
+        n = self.seq_obj._next(self.cr, self.uid, [seq_id])
+        self.assertEqual(n, "SEQ/%s/1" % time.strftime("%Y"))
+
+    def test_1(self):
+        """ invoke fiscal year sequence
+        without specifying the fiscal year """
+        seq_id = self._create_seq('SEQ/%(fy)s/')
+        with self.assertRaises(orm.except_orm):
+            self.seq_obj._next(self.cr, self.uid, [seq_id])
+
+    def test_2(self):
+        """ invoke fiscal year sequence """
+        fiscalyear_id = self.ref('account.data_fiscalyear')
+        context = {'fiscalyear_id': fiscalyear_id}
+        fiscalyear = self.registry('account.fiscalyear')\
+            .browse(self.cr, self.uid, fiscalyear_id)
+        seq_id = self._create_seq('SEQ/%(fy)s/')
+        n = self.seq_obj._next(self.cr, self.uid, [seq_id], context)
+        self.assertEqual(n, "SEQ/%s/1" % fiscalyear.code)
+        n = self.seq_obj._next(self.cr, self.uid, [seq_id], context)
+        self.assertEqual(n, "SEQ/%s/2" % fiscalyear.code)

--- a/account_auto_fy_sequence/views/ir_sequence_view.xml
+++ b/account_auto_fy_sequence/views/ir_sequence_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="sequence_inherit_form" model="ir.ui.view">
+            <field name="name">ir.sequence.form</field>
+            <field name="model">ir.sequence</field>
+            <field name="inherit_id" ref="base.sequence_view"/>
+            <field name="arch" type="xml">
+                <label string="Day: %%(day)s" position="after">
+                    <label colspan="2" string="Fiscal Year: %%(fy)s"/>
+                </label>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
```
Automatic creation of fiscal year sequences.

This modules adds the possibility to use the %(fy)s placeholder
in sequences. %(fy)s is replaced by the fiscal year code when
using the sequence.

The first time the sequence is used for a given fiscal year,
a specific fiscal year sequence starting at 1 is created automatically.

/!\ If you change %(year)s to %(fy)s on a sequence that has
already been used for the current fiscal year, make sure to manually
create the fiscal year sequence for the current fiscal year and
initialize it's next number to the correct value.
```
