### PR TITLE
Correct W0105(pointless-string-statement)

### DIFF
--- a/account_journal_period_close/tests/test_account_journal_period_close.py
+++ b/account_journal_period_close/tests/test_account_journal_period_close.py
@@ -164,10 +164,10 @@ class TestAccountJournalPeriodClose(common.TransactionCase):
         # issue on Odoo github : #1633
 
         # I check if the exception is correctly raised
-        """self.assertRaises(except_orm,
-                          self.registry('account.move').write,
-                          self.cr, self.uid, [move_id],
-                          {'journal_id': journal_id}, context=context)"""
+        # self.assertRaises(except_orm,
+        #                   self.registry('account.move').write,
+        #                   self.cr, self.uid, [move_id],
+        #                   {'journal_id': journal_id}, context=context)
 
     def test_draft_move_close_journal(self):
         context = {}


### PR DESCRIPTION
In order to turn the branch green.

Surrounding a string with """ is not a correct way to declare multiple
lines as comment, it behaves as a string with no effect (executed at runtime).

The reason for this code to be commented is
https://github.com/odoo/odoo/issues/1633
