### PR TITLE
[8.0] account_default_draft_move uses tuples instead of lists in sql operations

### DIFF
--- a/account_default_draft_move/account.py
+++ b/account_default_draft_move/account.py
@@ -55,5 +55,3 @@ class AccountMove(models.Model):
                              'SET state=%s '
                              'WHERE id IN %s', ('draft', tuple(self.ids)))
         return True
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_default_draft_move/account.py
+++ b/account_default_draft_move/account.py
@@ -53,7 +53,7 @@ class AccountMove(models.Model):
         if self:
             self._cr.execute('UPDATE account_move '
                              'SET state=%s '
-                             'WHERE id IN %s', ('draft', self.ids,))
+                             'WHERE id IN %s', ('draft', tuple(self.ids)))
         return True
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
lists are converted into ARRAY which is invalid for a sql IN.

I'm 99.9% certain this was working before. Perhaps a change in the ORM.
