### PR TITLE
account_auto_fy_sequence : When create journal, use fy instead of year in the sequence

### DIFF
--- a/account_auto_fy_sequence/__openerp__.py
+++ b/account_auto_fy_sequence/__openerp__.py
@@ -42,6 +42,9 @@
     initialize it's next number to the correct value.
     For this reason, the module will forbid the user to change
     a sequence from %(year)s to %(fy)s if it's next number is > 1.
+
+    The module also replaces %(year)s by %(fy)s in the default prefix
+    for new journals, assuming it is a safer default.
     """,
     'author': 'ACSONE SA/NV',
     'website': 'http://acsone.eu',

--- a/account_auto_fy_sequence/models/account_journal.py
+++ b/account_auto_fy_sequence/models/account_journal.py
@@ -3,7 +3,7 @@
 #
 #    account_auto_fy_sequence module for Odoo
 #    Copyright (C) 2014 ACSONE SA/NV (<http://acsone.eu>)
-#    @author Stéphane Bidoul <stephane.bidoul@acsone.eu>
+#    @author Laetitia Gangloff <laetitia.gangloff@acsone.eu>
 #
 #    account_auto_fy_sequence is free software:
 #    you can redistribute it and/or modify
@@ -23,5 +23,21 @@
 #
 ##############################################################################
 
-from . import ir_sequence
-from . import account_journal
+from openerp.osv import orm
+
+
+class account_journal(orm.Model):
+    _inherit = "account.journal"
+
+    def create_sequence(self, cr, uid, vals, context=None):
+        """ Create new no_gap entry sequence for every new Joural
+            with fiscal year prefix
+        """
+        seq_id = super(account_journal, self).create_sequence(cr, uid, vals,
+                                                              context=context)
+
+        seq_obj = self.pool['ir.sequence']
+        seq = seq_obj.browse(cr, uid, seq_id, context=context)
+        prefix = seq.prefix.replace('%(year)s', '%(fy)s')
+        seq_obj.write(cr, uid, seq_id, {'prefix': prefix}, context=context)
+        return seq_id

--- a/account_auto_fy_sequence/tests/test_auto_fy_sequence.py
+++ b/account_auto_fy_sequence/tests/test_auto_fy_sequence.py
@@ -67,3 +67,13 @@ class TestAutoFYSequence(common.TransactionCase):
         self.assertEqual(n, "SEQ/%s/1" % fiscalyear.code)
         n = self.seq_obj._next(self.cr, self.uid, [seq_id], context)
         self.assertEqual(n, "SEQ/%s/2" % fiscalyear.code)
+
+    def test_3(self):
+        """ Create journal and check the sequence attached to the journal """
+        aj_obj = self.registry('account.journal')
+        aj_id = aj_obj.create(self.cr, self.uid, {'name': 'sequence (test)',
+                                                  'code': 'SQT',
+                                                  'type': 'bank',
+                                                  })
+        aj = aj_obj.browse(self.cr, self.uid, aj_id)
+        self.assertEqual(aj.sequence_id.prefix, 'SQT/%(fy)s/')


### PR DESCRIPTION
Hello,

I rewrite the method 'create_sequence' from account.journal to be able to set an other prefix.
