### PR TITLE
Credit Control: compatibility with account_constraints

### DIFF
--- a/account_credit_control/line.py
+++ b/account_credit_control/line.py
@@ -153,7 +153,6 @@ class CreditControlLine(models.Model):
                               move_line.credit)
         data['balance_due'] = open_amount
         data['policy_level_id'] = level.id
-        data['company_id'] = move_line.company_id.id
         data['move_line_id'] = move_line.id
         return data
 


### PR DESCRIPTION
The field company_id is a related towards the move line.
If we write in credit_control_line.company_id, the ORM will
do a write on the company_id field of account_move_line.

It is useless anyway and if the module account_constraints is installed, it
will block the creation of credit_control_line records.
