### PR TITLE
Usability improvements on account_credit_control:

### DIFF
--- a/account_credit_control/account_view.xml
+++ b/account_credit_control/account_view.xml
@@ -15,14 +15,27 @@
       <field name="inherit_id" ref="account.invoice_form" />
       <field name="arch" type="xml">
         <notebook position="inside">
-        <page string="Credit Control"
-                 groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_user,account_credit_control.group_account_credit_control_info">
-           <label string="Force credit control policy:" />
-            <field name="credit_policy_id" widget="selection"
-                   groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_user,account_credit_control.group_account_credit_control_info"/>
-            <newline/>
+          <page string="Credit Control"
+            groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_user,account_credit_control.group_account_credit_control_info">
+            <group>
+              <field name="credit_policy_id" widget="selection"
+                string="Manual Credit Control Policy"
+                attrs="{'invisible': [('credit_policy_id', '=', False)]}"
+                groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_user,account_credit_control.group_account_credit_control_info"/>
+            </group>
+            <separator string="Issued Lines" colspan="4"/>
             <field name="credit_control_line_ids" colspan="4" nolabel="1"
-                   groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_user,account_credit_control.group_account_credit_control_info"/>
+              groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_user,account_credit_control.group_account_credit_control_info" >
+              <tree string="Credit Control Lines">
+                <field name="date"/>
+                <field name="level"/>
+                <field name="state"/>
+                <field name="channel"/>
+                <field name="balance_due"/>
+                <field name="policy_level_id"/>
+                <field name="policy_id"/>
+              </tree>
+            </field>
           </page>
         </notebook>
       </field>

--- a/account_credit_control/credit_control_demo.xml
+++ b/account_credit_control/credit_control_demo.xml
@@ -6,7 +6,6 @@
       <field ref="account.cas" name="parent_id"/>
       <field name="type">receivable</field>
       <field eval="True" name="reconcile"/>
-      <field name="credit_policy_id" ref="credit_control_no_follow"/>
       <field name="user_type" ref="account.data_account_type_receivable"/>
     </record>
 
@@ -16,7 +15,6 @@
       <field ref="account.cas" name="parent_id"/>
       <field name="type">receivable</field>
       <field eval="True" name="reconcile"/>
-      <field name="credit_policy_id" ref="credit_control_2_time"/>
       <field name="user_type" ref="account.data_account_type_receivable"/>
     </record>
 
@@ -26,7 +24,6 @@
       <field ref="account.cas" name="parent_id"/>
       <field name="type">receivable</field>
       <field eval="True" name="reconcile"/>
-      <field name="credit_policy_id" ref="credit_control_3_time"/>
       <field name="user_type" ref="account.data_account_type_receivable"/>
     </record>
   </data>

--- a/account_credit_control/i18n/account_credit_control.pot
+++ b/account_credit_control/i18n/account_credit_control.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-30 14:59+0000\n"
-"PO-Revision-Date: 2014-10-30 14:59+0000\n"
+"POT-Creation-Date: 2015-01-13 13:11+0000\n"
+"PO-Revision-Date: 2015-01-13 13:11+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -68,7 +68,7 @@ msgid "A credit control line"
 msgstr ""
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:87
+#: code:addons/account_credit_control/run.py:93
 #, python-format
 msgid "A credit control line more recent than %s exists at %s"
 msgstr ""
@@ -79,13 +79,13 @@ msgid "A credit control policy level"
 msgstr ""
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:154
+#: code:addons/account_credit_control/run.py:161
 #, python-format
 msgid "A credit control run is already running in background, please try later."
 msgstr ""
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:80
+#: code:addons/account_credit_control/run.py:86
 #, python-format
 msgid "A run has already been executed more recently than %s"
 msgstr ""
@@ -250,6 +250,7 @@ msgid "Credit Control Info"
 msgstr ""
 
 #. module: account_credit_control
+#: view:account.invoice:account_credit_control.invoice_followup_form_view
 #: field:credit.control.emailer,line_ids:0
 #: field:credit.control.marker,line_ids:0
 #: field:credit.control.printer,line_ids:0
@@ -350,6 +351,7 @@ msgid "Credit policy level"
 msgstr ""
 
 #. module: account_credit_control
+#: field:credit.control.communication,currency_id:0
 #: field:credit.control.line,currency_id:0
 msgid "Currency"
 msgstr ""
@@ -484,8 +486,8 @@ msgid "For policies which should not generate lines or are obsolete"
 msgstr ""
 
 #. module: account_credit_control
-#: view:account.invoice:account_credit_control.invoice_followup_form_view
-msgid "Force credit control policy:"
+#: field:credit.control.run,line_ids:0
+msgid "Generated lines"
 msgstr ""
 
 #. module: account_credit_control
@@ -538,6 +540,11 @@ msgstr ""
 #. module: account_credit_control
 #: view:website:account_credit_control.report_credit_control_summary_document
 msgid "Invoiced amount"
+msgstr ""
+
+#. module: account_credit_control
+#: view:account.invoice:account_credit_control.invoice_followup_form_view
+msgid "Issued Lines"
 msgstr ""
 
 #. module: account_credit_control
@@ -623,6 +630,16 @@ msgid "Mailer"
 msgstr ""
 
 #. module: account_credit_control
+#: view:account.invoice:account_credit_control.invoice_followup_form_view
+msgid "Manual Credit Control Policy"
+msgstr ""
+
+#. module: account_credit_control
+#: view:credit.control.run:account_credit_control.credit_control_run_form
+msgid "Manual Lines"
+msgstr ""
+
+#. module: account_credit_control
 #: view:credit.control.line:account_credit_control.credit_control_line_search
 msgid "Manual change"
 msgstr ""
@@ -679,11 +696,6 @@ msgid "Move line to change"
 msgstr ""
 
 #. module: account_credit_control
-#: view:credit.control.run:account_credit_control.credit_control_run_form
-msgid "Move lines To be treated manually"
-msgstr ""
-
-#. module: account_credit_control
 #: view:credit.control.policy.changer:account_credit_control.credit_control_policy_changer_form
 msgid "Move lines to affect"
 msgstr ""
@@ -731,6 +743,11 @@ msgstr ""
 #. module: account_credit_control
 #: help:credit.control.printer,mark_as_sent:0
 msgid "Only letter lines will be marked."
+msgstr ""
+
+#. module: account_credit_control
+#: view:credit.control.run:account_credit_control.credit_control_run_form
+msgid "Open Credit Control Lines"
 msgstr ""
 
 #. module: account_credit_control
@@ -873,7 +890,7 @@ msgid "Partner"
 msgstr ""
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:103
+#: code:addons/account_credit_control/run.py:109
 #, python-format
 msgid "Please select a policy"
 msgstr ""
@@ -891,17 +908,15 @@ msgid "Policies"
 msgstr ""
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:126
+#: code:addons/account_credit_control/run.py:132
 #, python-format
-msgid "Policy \"%s\" has generated %d Credit Control Lines.\n"
-""
+msgid "Policy \"<b>%s</b>\" has generated <b>%d Credit Control Lines.</b><br/>"
 msgstr ""
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:130
+#: code:addons/account_credit_control/run.py:136
 #, python-format
-msgid "Policy \"%s\" has not generated any Credit Control Lines.\n"
-""
+msgid "Policy \"<b>%s</b>\" has not generated any Credit Control Lines.<br/>"
 msgstr ""
 
 #. module: account_credit_control
@@ -965,13 +980,14 @@ msgid "Reminder"
 msgstr ""
 
 #. module: account_credit_control
+#: view:credit.control.run:account_credit_control.credit_control_run_form
 #: field:credit.control.run,report:0
 msgid "Report"
 msgstr ""
 
 #. module: account_credit_control
-#: view:credit.control.run:account_credit_control.credit_control_run_form
-msgid "Report and Errors"
+#: field:credit.control.communication,report_date:0
+msgid "Report Date"
 msgstr ""
 
 #. module: account_credit_control
@@ -1023,6 +1039,11 @@ msgstr ""
 #. module: account_credit_control
 #: view:credit.control.policy.changer:account_credit_control.credit_control_policy_changer_form
 msgid "Set new policy"
+msgstr ""
+
+#. module: account_credit_control
+#: field:credit.control.line,run_id:0
+msgid "Source"
 msgstr ""
 
 #. module: account_credit_control
@@ -1083,6 +1104,16 @@ msgid "This wizard will let you set the overdue policy and level for selected in
 msgstr ""
 
 #. module: account_credit_control
+#: view:website:account_credit_control.report_credit_control_summary_document
+msgid "Total Due"
+msgstr ""
+
+#. module: account_credit_control
+#: view:website:account_credit_control.report_credit_control_summary_document
+msgid "Total Invoiced"
+msgstr ""
+
+#. module: account_credit_control
 #: field:credit.control.communication,user_id:0
 msgid "User"
 msgstr ""
@@ -1093,7 +1124,7 @@ msgid "Warning: you will maybe not be able to revert this operation."
 msgstr ""
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/line.py:224
+#: code:addons/account_credit_control/line.py:226
 #, python-format
 msgid "You are not allowed to delete a credit control line that is not in draft state."
 msgstr ""
@@ -1122,5 +1153,13 @@ msgstr ""
 #. module: account_credit_control
 #: field:credit.control.line,level:0
 msgid "credit.control.policy.level"
+msgstr ""
+
+#. module: account_credit_control
+#: view:credit.control.emailer:account_credit_control.credit_line_emailer_form
+#: view:credit.control.marker:account_credit_control.credit_line_marker_form
+#: view:credit.control.policy.changer:account_credit_control.credit_control_policy_changer_form
+#: view:credit.control.printer:account_credit_control.credit_line_printer_form
+msgid "or"
 msgstr ""
 

--- a/account_credit_control/i18n/fr.po
+++ b/account_credit_control/i18n/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-30 14:59+0000\n"
+"POT-Creation-Date: 2015-01-13 13:11+0000\n"
 "PO-Revision-Date: 2014-10-30 14:59+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
@@ -38,8 +38,8 @@ msgid ""
 "      "
 msgstr ""
 "\n"
-"Notre comptabilité nous indique que vous avez encore des factures "
-"ouvertes malgré nos précédents rappels.\n"
+"Notre comptabilité nous indique que vous avez encore des factures ouvertes "
+"malgré nos précédents rappels.\n"
 "        Si ce courrier à croisé votre paiement veuillez le considérer comme "
 "nul et non avenu.\n"
 "        Si le paiement n'est pas effectué dans les 5 jours votre dossier "
@@ -54,7 +54,6 @@ msgstr ""
 
 #. module: account_credit_control
 #: model:email.template,body_html:account_credit_control.email_template_credit_control_base
-#, fuzzy
 msgid ""
 "\n"
 "      Dear ${object.contact_address.name or ''}\n"
@@ -97,7 +96,7 @@ msgid "A credit control line"
 msgstr "Ligne de relance"
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:87
+#: code:addons/account_credit_control/run.py:93
 #, python-format
 msgid "A credit control line more recent than %s exists at %s"
 msgstr "Une ligne plus récente que %s existe au %s"
@@ -108,14 +107,16 @@ msgid "A credit control policy level"
 msgstr "Une politique de relance"
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:154
+#: code:addons/account_credit_control/run.py:161
 #, python-format
 msgid ""
 "A credit control run is already running in background, please try later."
-msgstr "Un contrôle de relance est déjà en train de tourner en arrière-plan, merci d'essayer à nouveau plus tard."
+msgstr ""
+"Un contrôle de relance est déjà en train de tourner en arrière-plan, merci "
+"d'essayer à nouveau plus tard."
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:80
+#: code:addons/account_credit_control/run.py:86
 #, python-format
 msgid "A run has already been executed more recently than %s"
 msgstr "Un contrôle a déjà été exécuté plus récemment que le %s "
@@ -280,6 +281,7 @@ msgid "Credit Control Info"
 msgstr "Informations de rappel"
 
 #. module: account_credit_control
+#: view:account.invoice:account_credit_control.invoice_followup_form_view
 #: field:credit.control.emailer,line_ids:0
 #: field:credit.control.marker,line_ids:0
 #: field:credit.control.printer,line_ids:0
@@ -379,6 +381,7 @@ msgid "Credit policy level"
 msgstr "Niveau de relance"
 
 #. module: account_credit_control
+#: field:credit.control.communication,currency_id:0
 #: field:credit.control.line,currency_id:0
 msgid "Currency"
 msgstr "Devise"
@@ -513,12 +516,13 @@ msgstr "Filtres"
 #. module: account_credit_control
 #: help:credit.control.policy,do_nothing:0
 msgid "For policies which should not generate lines or are obsolete"
-msgstr "Pour les politiques qui ne doivent pas générer de lignes ou sont obsolètes"
+msgstr ""
+"Pour les politiques qui ne doivent pas générer de lignes ou sont obsolètes"
 
 #. module: account_credit_control
-#: view:account.invoice:account_credit_control.invoice_followup_form_view
-msgid "Force credit control policy:"
-msgstr "Forcer politique de relance:"
+#: field:credit.control.run,line_ids:0
+msgid "Generated lines"
+msgstr "Lignes générées"
 
 #. module: account_credit_control
 #: view:credit.control.line:account_credit_control.credit_control_line_search
@@ -571,6 +575,11 @@ msgstr "Numéro de facture"
 #: view:website:account_credit_control.report_credit_control_summary_document
 msgid "Invoiced amount"
 msgstr "Total de la facture"
+
+#. module: account_credit_control
+#: view:account.invoice:account_credit_control.invoice_followup_form_view
+msgid "Issued Lines"
+msgstr "Lignes de relance"
 
 #. module: account_credit_control
 #: field:credit.control.communication,write_uid:0
@@ -655,6 +664,16 @@ msgid "Mailer"
 msgstr "Mailer"
 
 #. module: account_credit_control
+#: view:account.invoice:account_credit_control.invoice_followup_form_view
+msgid "Manual Credit Control Policy"
+msgstr "Politique de relance manuelle"
+
+#. module: account_credit_control
+#: view:credit.control.run:account_credit_control.credit_control_run_form
+msgid "Manual Lines"
+msgstr "Lignes manuelles"
+
+#. module: account_credit_control
 #: view:credit.control.line:account_credit_control.credit_control_line_search
 msgid "Manual change"
 msgstr "Changement manuel"
@@ -711,11 +730,6 @@ msgid "Move line to change"
 msgstr "Écriture comptable à changer"
 
 #. module: account_credit_control
-#: view:credit.control.run:account_credit_control.credit_control_run_form
-msgid "Move lines To be treated manually"
-msgstr "A traiter manuellement"
-
-#. module: account_credit_control
 #: view:credit.control.policy.changer:account_credit_control.credit_control_policy_changer_form
 msgid "Move lines to affect"
 msgstr "Écriture comptable à traiter"
@@ -739,6 +753,7 @@ msgstr "Nouveau niveau de relance"
 #: code:addons/account_credit_control/wizard/credit_control_emailer.py:62
 #: code:addons/account_credit_control/wizard/credit_control_marker.py:74
 #: code:addons/account_credit_control/wizard/credit_control_printer.py:60
+#, python-format
 msgid "No credit control lines selected."
 msgstr "Pas de ligne de relance sélectionnée"
 
@@ -756,12 +771,19 @@ msgstr "Politique sans suivi"
 #: code:addons/account_credit_control/wizard/credit_control_marker.py:78
 #, python-format
 msgid "No lines will be changed. All the selected lines are already done."
-msgstr "Aucune ligne ne sera modifiée. Toutes les lignes sélectionnées sont déjà terminées."
+msgstr ""
+"Aucune ligne ne sera modifiée. Toutes les lignes sélectionnées sont déjà "
+"terminées."
 
 #. module: account_credit_control
 #: help:credit.control.printer,mark_as_sent:0
 msgid "Only letter lines will be marked."
 msgstr "Seules les relances par courrier seront traitées."
+
+#. module: account_credit_control
+#: view:credit.control.run:account_credit_control.credit_control_run_form
+msgid "Open Credit Control Lines"
+msgstr "Ouvrir les lignes de relance"
 
 #. module: account_credit_control
 #: view:website:account_credit_control.report_credit_control_summary_document
@@ -829,8 +851,8 @@ msgid ""
 "Best regards\n"
 "      "
 msgstr ""
-"Notre comptabilité nous informe que les factures mentionnées dans le document ci-joint n'ont pas été "
-"payées malgré un précédent rappel.\n"
+"Notre comptabilité nous informe que les factures mentionnées dans le "
+"document ci-joint n'ont pas été payées malgré un précédent rappel.\n"
 "       Si ce courrier a croisé votre paiement veuillez le considérer comme "
 "nul et non avenu. Sinon, Merci de procéder au paiement dans les 10 jours.\n"
 "\n"
@@ -852,8 +874,8 @@ msgid ""
 "Best regards\n"
 "      "
 msgstr ""
-"Notre comptabilité nous informe que les factures mentionnées dans le document ci-joint n'ont pas été "
-"payées malgré un précédent rappel.\n"
+"Notre comptabilité nous informe que les factures mentionnées dans le "
+"document ci-joint n'ont pas été payées malgré un précédent rappel.\n"
 "       Si ce courrier a croisé votre paiement veuillez le considérer comme "
 "nul et non avenu. Sinon, Merci de procéder au paiement dans les 10 jours.\n"
 "\n"
@@ -898,8 +920,8 @@ msgid ""
 "Best regards\n"
 "      "
 msgstr ""
-"Notre comptabilité nous informe que les factures mentionnées dans le document ci-joint n'ont pas été "
-"payées malgré un précédent rappel.\n"
+"Notre comptabilité nous informe que les factures mentionnées dans le "
+"document ci-joint n'ont pas été payées malgré un précédent rappel.\n"
 "       Si ce courrier à croisé votre paiement veuillez le considérer comme "
 "nul et non avenu. Sinon, Merci de procéder au paiement dans les 5 jours.\n"
 "\n"
@@ -930,15 +952,15 @@ msgid ""
 "        Best regards\n"
 "      "
 msgstr ""
-"Notre comptabilité nous indique que vous avez encore des factures "
-"ouvertes malgré nos précédents rappels.\n"
+"Notre comptabilité nous indique que vous avez encore des factures ouvertes "
+"malgré nos précédents rappels.\n"
 "        Si ce courrier a croisé votre paiement veuillez le considérer comme "
 "nul et non avenu.\n"
-"        Si le paiement n'est pas effectué dans les 5 jours votre dossier sera "
-"transféré à une société de recouvrement.\n"
+"        Si le paiement n'est pas effectué dans les 5 jours votre dossier "
+"sera transféré à une société de recouvrement.\n"
 "\n"
-"        Si vous désirez un accord de paiement n'hésitez pas à nous contacter. "
-"\n"
+"        Si vous désirez un accord de paiement n'hésitez pas à nous "
+"contacter. \n"
 "        Un décompte est disponible ci-joint.\n"
 "\n"
 "        En vous remerciant de votre coopération\n"
@@ -966,15 +988,15 @@ msgid ""
 "        Best regards\n"
 "      "
 msgstr ""
-"Notre comptabilité nous indique que vous avez encore des factures "
-"ouvertes malgré nos précédents rappels.\n"
+"Notre comptabilité nous indique que vous avez encore des factures ouvertes "
+"malgré nos précédents rappels.\n"
 "        Si ce courrier a croisé votre paiement veuillez le considérer comme "
 "nul et non avenu.\n"
 "        Si le paiement n'est pas effectué dans les 5 jours votre dossier "
 "sera transféré à une société de recouvrement.\n"
 "\n"
-"        Si vous désirez un accord de paiement n'hésitez pas à nous contacter. "
-"\n"
+"        Si vous désirez un accord de paiement n'hésitez pas à nous "
+"contacter. \n"
 "        Un décompte est disponible ci-joint.\n"
 "\n"
 "        En vous remerciant de votre coopération       "
@@ -999,15 +1021,15 @@ msgid ""
 "        Best regards\n"
 "      "
 msgstr ""
-"Notre comptabilité nous indique que vous avez encore des factures "
-"ouvertes malgré nos précédents rappels.\n"
+"Notre comptabilité nous indique que vous avez encore des factures ouvertes "
+"malgré nos précédents rappels.\n"
 "        Si ce courrier a croisé votre paiement veuillez le considérer comme "
 "nul et non avenu.\n"
-"        Si le paiement n'est pas effectué dans les 5 jours votre dossier sera "
-"transféré à une société de recouvrement.\n"
+"        Si le paiement n'est pas effectué dans les 5 jours votre dossier "
+"sera transféré à une société de recouvrement.\n"
 "\n"
-"        Si vous désirez un accord de paiement n'hésitez pas à nous contacter. "
-"\n"
+"        Si vous désirez un accord de paiement n'hésitez pas à nous "
+"contacter. \n"
 "        Un décompte est disponible ci-joint.\n"
 "\n"
 "        En vous remerciant de votre coopération \n"
@@ -1032,7 +1054,7 @@ msgid "Partner"
 msgstr "Client"
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:103
+#: code:addons/account_credit_control/run.py:109
 #, python-format
 msgid "Please select a policy"
 msgstr "Choisissez une politique"
@@ -1050,15 +1072,20 @@ msgid "Policies"
 msgstr "Politiques"
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:126
-msgid "Policy \"%s\" has generated %d Credit Control Lines.\n"
-msgstr "La politique de relance \"%s\" a généré %d lignes de relance.\n"
+#: code:addons/account_credit_control/run.py:132
+#, python-format
+msgid "Policy \"<b>%s</b>\" has generated <b>%d Credit Control Lines.</b><br/>"
+msgstr ""
+"La politique de relance \"<b>%s</b>\" a généré <b>%d lignes de relance</b>."
+"<br/>"
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/run.py:130
+#: code:addons/account_credit_control/run.py:136
 #, python-format
-msgid "Policy \"%s\" has not generated any Credit Control Lines.\n"
-msgstr "La politique de relance \"%s\" n'a pas généré de lignes de relance.\n"
+msgid "Policy \"<b>%s</b>\" has not generated any Credit Control Lines.<br/>"
+msgstr ""
+"La politique de relance \"<b>%s</b>\" n'a pas généré de lignes de relance."
+"<br/>"
 
 #. module: account_credit_control
 #: field:credit.control.policy,level_ids:0
@@ -1121,14 +1148,15 @@ msgid "Reminder"
 msgstr "Rappel"
 
 #. module: account_credit_control
+#: view:credit.control.run:account_credit_control.credit_control_run_form
 #: field:credit.control.run,report:0
 msgid "Report"
 msgstr "Lettre"
 
 #. module: account_credit_control
-#: view:credit.control.run:account_credit_control.credit_control_run_form
-msgid "Report and Errors"
-msgstr "Résumé des erreurs"
+#: field:credit.control.communication,report_date:0
+msgid "Report Date"
+msgstr "Date du rapport"
 
 #. module: account_credit_control
 #: view:credit.control.line:account_credit_control.credit_control_line_search
@@ -1182,6 +1210,11 @@ msgid "Set new policy"
 msgstr "Définir une nouvelle politique de relance"
 
 #. module: account_credit_control
+#: field:credit.control.line,run_id:0
+msgid "Source"
+msgstr "Source"
+
+#. module: account_credit_control
 #: field:credit.control.line,state:0 field:credit.control.run,state:0
 msgid "State"
 msgstr "État"
@@ -1222,7 +1255,9 @@ msgstr ""
 #. module: account_credit_control
 #: view:credit.control.line:account_credit_control.credit_control_line_search
 msgid "The line was deprecated by a manual change of policy on invoice."
-msgstr "La ligne a été remplacée par un changement manuel de politique sur la facture."
+msgstr ""
+"La ligne a été remplacée par un changement manuel de politique sur la "
+"facture."
 
 #. module: account_credit_control
 #: help:credit.control.line,currency_id:0
@@ -1252,7 +1287,19 @@ msgstr ""
 msgid ""
 "This wizard will let you set the overdue policy and level for selected "
 "invoices"
-msgstr "Cette action vous permet de définir une politique et un niveau de relance pour les factures sélectionnées"
+msgstr ""
+"Cette action vous permet de définir une politique et un niveau de relance "
+"pour les factures sélectionnées"
+
+#. module: account_credit_control
+#: view:website:account_credit_control.report_credit_control_summary_document
+msgid "Total Due"
+msgstr "Total dû"
+
+#. module: account_credit_control
+#: view:website:account_credit_control.report_credit_control_summary_document
+msgid "Total Invoiced"
+msgstr "Total facturé"
 
 #. module: account_credit_control
 #: field:credit.control.communication,user_id:0
@@ -1265,12 +1312,13 @@ msgid "Warning: you will maybe not be able to revert this operation."
 msgstr "Attention: Cette opération ne peut pas être annulée"
 
 #. module: account_credit_control
-#: code:addons/account_credit_control/line.py:224
+#: code:addons/account_credit_control/line.py:226
 #, python-format
 msgid ""
 "You are not allowed to delete a credit control line that is not in draft "
 "state."
-msgstr "Vous ne pouvez pas supprimer une ligne de relance qui n'est pas en brouillon"
+msgstr ""
+"Vous ne pouvez pas supprimer une ligne de relance qui n'est pas en brouillon"
 
 #. module: account_credit_control
 #: code:addons/account_credit_control/policy.py:203
@@ -1279,12 +1327,14 @@ msgid ""
 "You can only use a policy set on account %s.\n"
 "Please choose one of the following policies:\n"
 " %s"
-msgstr "Vous ne pouvez utiliser qu'une politique associée au compte %s."
-"Vous pouvez choisir une des politique suivantes:\n"
+msgstr ""
+"Vous ne pouvez utiliser qu'une politique associée au compte %s.Vous pouvez "
+"choisir une des politique suivantes:\n"
 " %s"
 
 #. module: account_credit_control
 #: code:addons/account_credit_control/invoice.py:57
+#, python-format
 msgid ""
 "You cannot cancel this invoice.\n"
 "A payment reminder has already been sent to the customer.\n"
@@ -1302,3 +1352,11 @@ msgstr "Lettre de relance"
 #: field:credit.control.line,level:0
 msgid "credit.control.policy.level"
 msgstr "Une politique de relance"
+
+#. module: account_credit_control
+#: view:credit.control.emailer:account_credit_control.credit_line_emailer_form
+#: view:credit.control.marker:account_credit_control.credit_line_marker_form
+#: view:credit.control.policy.changer:account_credit_control.credit_control_policy_changer_form
+#: view:credit.control.printer:account_credit_control.credit_line_printer_form
+msgid "or"
+msgstr "ou"

--- a/account_credit_control/line.py
+++ b/account_credit_control/line.py
@@ -137,6 +137,9 @@ class CreditControlLine(models.Model):
 
     manually_overridden = fields.Boolean(string='Manually overridden')
 
+    run_id = fields.Many2one(comodel_name='credit.control.run',
+                             string='Source')
+
     @api.model
     def _prepare_from_move_line(self, move_line, level, controlling_date,
                                 open_amount):

--- a/account_credit_control/line_view.xml
+++ b/account_credit_control/line_view.xml
@@ -163,6 +163,7 @@
         name="Credit Control Lines"
         parent="base_credit_control_menu"
         action="credit_control_line_action"
+        sequence="20"
         id="credit_control_line_action_menu"/>
 
 

--- a/account_credit_control/report/report_credit_control_summary.xml
+++ b/account_credit_control/report/report_credit_control_summary.xml
@@ -11,6 +11,9 @@
                 "fields": ["address", "name"],
                 "no_marker": true}' />
             </div>
+            <div class="col-xs-5 col-xs-offset-7">
+              <span t-field="o.report_date"/>
+            </div>
           </div>
 
           <h2 id="policy_level">

--- a/account_credit_control/report/report_credit_control_summary.xml
+++ b/account_credit_control/report/report_credit_control_summary.xml
@@ -66,6 +66,25 @@
             </tbody>
           </table>
 
+          <div class="row">
+            <div class="col-xs-4 pull-right">
+              <table class="table table-condensed">
+                <tr>
+                  <td><strong>Total Invoiced</strong></td>
+                  <td class="text-right">
+                    <span t-field="o.total_invoiced" t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                  </td>
+                </tr>
+                <tr>
+                  <td><strong>Total Due</strong></td>
+                  <td class="text-right">
+                    <span t-field="o.total_due" t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                  </td>
+                </tr>
+              </table>
+            </div>
+          </div>
+
         </div>
       </t>
     </template>

--- a/account_credit_control/run.py
+++ b/account_credit_control/run.py
@@ -49,7 +49,7 @@ class CreditControlRun(models.Model):
         states={'draft': [('readonly', False)]},
         default=_get_policies,
     )
-    report = fields.Text(string='Report', readonly=True, copy=False)
+    report = fields.Html(string='Report', readonly=True, copy=False)
     state = fields.Selection([('draft', 'Draft'),
                               ('done', 'Done')],
                              string='State',
@@ -123,13 +123,13 @@ class CreditControlRun(models.Model):
                                                      self.date)
             generated |= policy_lines_generated
             if policy_lines_generated:
-                report += (_("Policy \"%s\" has generated %d Credit "
-                             "Control Lines.\n") %
+                report += (_("Policy \"<b>%s</b>\" has generated <b>%d Credit "
+                             "Control Lines.</b><br/>") %
                             (policy.name, len(policy_lines_generated)))
             else:
                 report += _(
-                    "Policy \"%s\" has not generated any "
-                    "Credit Control Lines.\n" % policy.name
+                    "Policy \"<b>%s</b>\" has not generated any "
+                    "Credit Control Lines.<br/>" % policy.name
                 )
 
         vals = {'state': 'done',

--- a/account_credit_control/run_view.xml
+++ b/account_credit_control/run_view.xml
@@ -29,10 +29,12 @@
             <notebook>
               <page string="Policies">
                 <field name="policy_ids" colspan="4" nolabel="1"/>
+                <separator string="Report"
+                  attrs="{'invisible': [('report', '=', False)]}"/>
+                <field name="report" colspan="4" nolabel="1"
+                  attrs="{'invisible': [('report', '=', False)]}"/>
               </page>
-              <page string="Report and Errors">
-                <field name="report" colspan="4" nolabel="1"/>
-                <separator string="Move lines To be treated manually"/>
+              <page string="Manual Lines" groups="base.group_no_one">
                 <field name="manual_ids" colspan="4" nolabel="1"/>
               </page>
             </notebook>

--- a/account_credit_control/run_view.xml
+++ b/account_credit_control/run_view.xml
@@ -18,6 +18,11 @@
       <field name="arch" type="xml">
         <form string="Credit control run">
           <header>
+            <button name="generate_credit_lines"
+              string="Compute Credit Control Lines"
+              class="oe_highlight"
+              type="object" icon="gtk-execute"
+              attrs="{'invisible': [('state', '!=', 'draft')]}"/>
             <field name="state" widget="statusbar"
               statusbar_visible="draft,done"
               statusbar_colors='{}'/>
@@ -38,13 +43,6 @@
                 <field name="manual_ids" colspan="4" nolabel="1"/>
               </page>
             </notebook>
-            <group col="3" colspan="4">
-              <button name="generate_credit_lines"
-                string="Compute Credit Control Lines"
-                colspan="1"
-                type="object" icon="gtk-execute"
-                attrs="{'invisible': [('state', '!=', 'draft')]}"/>
-            </group>
           </sheet>
         </form>
       </field>

--- a/account_credit_control/run_view.xml
+++ b/account_credit_control/run_view.xml
@@ -68,6 +68,7 @@
         name="Credit Control Run"
         parent="base_credit_control_menu"
         action="credit_control_run"
+        sequence="10"
         id="credit_control_run_menu"/>
 
   </data>

--- a/account_credit_control/run_view.xml
+++ b/account_credit_control/run_view.xml
@@ -23,6 +23,10 @@
               class="oe_highlight"
               type="object" icon="gtk-execute"
               attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+            <button name="open_credit_lines"
+              string="Open Credit Control Lines"
+              type="object"
+              attrs="{'invisible': [('state', '=', 'draft')]}"/>
             <field name="state" widget="statusbar"
               statusbar_visible="draft,done"
               statusbar_colors='{}'/>

--- a/account_credit_control/wizard/credit_control_communication.py
+++ b/account_credit_control/wizard/credit_control_communication.py
@@ -47,6 +47,8 @@ class CreditCommunication(models.TransientModel):
     contact_address = fields.Many2one('res.partner',
                                       string='Contact Address',
                                       readonly=True)
+    report_date = fields.Date(string='Report Date',
+                              default=fields.Date.context_today)
 
     @api.model
     def _get_company(self):

--- a/account_credit_control/wizard/credit_control_communication.py
+++ b/account_credit_control/wizard/credit_control_communication.py
@@ -98,12 +98,13 @@ class CreditCommunication(models.TransientModel):
 
     @api.model
     @api.returns('credit.control.line')
-    def _get_credit_lines(self, line_ids, partner_id, level_id):
+    def _get_credit_lines(self, line_ids, partner_id, level_id, currency_id):
         """ Return credit lines related to a partner and a policy level """
         cr_line_obj = self.env['credit.control.line']
         cr_lines = cr_line_obj.search([('id', 'in', line_ids),
                                        ('partner_id', '=', partner_id),
-                                       ('policy_level_id', '=', level_id)])
+                                       ('policy_level_id', '=', level_id),
+                                       ('currency_id', '=', currency_id)])
         return cr_lines
 
     @api.model
@@ -128,16 +129,17 @@ class CreditCommunication(models.TransientModel):
         cr = self.env.cr
         cr.execute(sql, (tuple(lines.ids), ))
         res = cr.dictfetchall()
-        for level_assoc in res:
+        for group in res:
             data = {}
             level_lines = self._get_credit_lines(lines.ids,
-                                                 level_assoc['partner_id'],
-                                                 level_assoc['policy_level_id']
+                                                 group['partner_id'],
+                                                 group['policy_level_id'],
+                                                 group['currency_id']
                                                  )
 
             data['credit_control_line_ids'] = [(6, 0, level_lines.ids)]
-            data['partner_id'] = level_assoc['partner_id']
-            data['current_policy_level'] = level_assoc['policy_level_id']
+            data['partner_id'] = group['partner_id']
+            data['current_policy_level'] = group['policy_level_id']
             comm = self.create(data)
             comms += comm
         return comms

--- a/account_credit_control/wizard/credit_control_marker.py
+++ b/account_credit_control/wizard/credit_control_marker.py
@@ -34,7 +34,7 @@ class CreditControlMarker(models.TransientModel):
                 context.get('active_ids')):
             return False
         line_obj = self.env['credit.control.line']
-        lines = line_obj.browse(context['active_id'])
+        lines = line_obj.browse(context['active_ids'])
         return self._filter_lines(lines)
 
     name = fields.Selection([('ignored', 'Ignored'),

--- a/account_credit_control/wizard/credit_control_printer_view.xml
+++ b/account_credit_control/wizard/credit_control_printer_view.xml
@@ -20,7 +20,8 @@
           </notebook>
           <footer>
             <button class="oe_highlight" name="print_lines" string="Print" type="object"/>
-            <button special="cancel" string="Cancel" icon='gtk-cancel'/>
+            or
+            <button class="oe_link" special="cancel" string="Cancel"/>
           </footer>
         </form>
       </field>


### PR DESCRIPTION
- Generation of lines:
  - Display the report on the main page (prevents user to have to switch page to view the result)
  - Add a button that opens the generated lines
  - Move the button in the <header>
- On the invoice:
  - Put the policy field in a <group>
  - Hide the policy field when empty (irrelevant if empty)
  - Use a correct label for the policy field
  - Remove useless fields from the tree view for the lines: it was
    overflowing from the sheet view
- Add the date of the day on the report
- Move the 'run' menu before the 'lines' menu
- Add totals on the letter
- Correct the wizard to change state of lines
- Fix a warning
- Correct the letters when a customers has lines with different currencies
