### PR TITLE
Credit Control Dunning Fees: improve handling of currencies

### DIFF
--- a/account_credit_control_dunning_fees/model/dunning.py
+++ b/account_credit_control_dunning_fees/model/dunning.py
@@ -108,12 +108,14 @@ class FeesComputer(models.BaseModel):
         :return: fees amount float (in credit line currency)
 
         """
-        credit_currency = credit_line.currency_id
+        credit_currency = (credit_line.currency_id or
+                           credit_line.company_id.currency_id)
         level = credit_line.policy_level_id
         fees_amount = level.dunning_fixed_amount
         if not fees_amount:
             return 0.0
-        fees_currency = level.dunning_currency_id
+        fees_currency = (level.dunning_currency_id or
+                         level.policy_id.company_id.currency_id)
         if fees_currency == credit_currency:
             return fees_amount
         else:

--- a/account_credit_control_dunning_fees/model/policy.py
+++ b/account_credit_control_dunning_fees/model/policy.py
@@ -31,8 +31,12 @@ class CreditControlPolicy(models.Model):
 
     dunning_fixed_amount = fields.Float(string='Fees Fixed Amount')
 
-    dunning_currency_id = fields.Many2one('res.currency',
-                                          string='Fees currency')
+    dunning_currency_id = fields.Many2one(
+        'res.currency',
+        string='Fees currency',
+        help="Currency of the dunning fees. If empty, it takes the "
+             "company's currency."
+    )
 
     # planned type are fixed, percent, compound
     dunning_fees_type = fields.Selection([('fixed', 'Fixed')],

--- a/account_credit_control_dunning_fees/tests/test_fees_generation.py
+++ b/account_credit_control_dunning_fees/tests/test_fees_generation.py
@@ -84,6 +84,38 @@ class FixedFeesTester(common.TransactionCase):
         fees = self.dunning_model.compute_fixed_fees(credit_line)
         self.assertNotEqual(fees, self.euro_level.dunning_fixed_amount)
 
+    def test_computation_credit_currency_empty(self):
+        """Test that fees are correctly computed with empty credit currency"""
+        credit_line = self.line_model.new({
+            'policy_level_id': self.euro_level,
+            'currency_id': False,
+            'company_id': self.company,
+        })
+        fees = self.dunning_model.compute_fixed_fees(credit_line)
+        self.assertEqual(fees, self.euro_level.dunning_fixed_amount)
+
+    def test_computation_level_currency_empty(self):
+        """Test that fees are correctly computed with empty level currency"""
+        credit_line = self.line_model.new({
+            'policy_level_id': self.euro_level,
+            'currency_id': self.euro,
+            'company_id': self.company,
+        })
+        self.euro_level.currency_id = False
+        fees = self.dunning_model.compute_fixed_fees(credit_line)
+        self.assertEqual(fees, self.euro_level.dunning_fixed_amount)
+
+    def test_computation_all_currency_empty(self):
+        """Test that fees are correctly computed with empty currencies"""
+        credit_line = self.line_model.new({
+            'policy_level_id': self.euro_level,
+            'currency_id': False,
+            'company_id': self.company,
+        })
+        self.euro_level.currency_id = False
+        fees = self.dunning_model.compute_fixed_fees(credit_line)
+        self.assertEqual(fees, self.euro_level.dunning_fixed_amount)
+
     def test_no_fees(self):
         """Test that fees are not generated if no amount defined on level"""
         credit_line = self.line_model.new({

--- a/account_credit_control_dunning_fees/tests/test_fees_generation.py
+++ b/account_credit_control_dunning_fees/tests/test_fees_generation.py
@@ -18,7 +18,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from mock import MagicMock
 from openerp.tests import common
 
 
@@ -35,16 +34,25 @@ class FixedFeesTester(common.TransactionCase):
         self.usd = self.currency_model.search([('name', '=', 'USD')])
         self.assertTrue(self.usd)
 
-        self.euro_level = MagicMock(name='Euro policy level')
-        self.euro_level.dunning_fixed_amount = 5.0
-        self.euro_level.dunning_currency_id = self.euro
-        self.euro_level.dunning_type = 'fixed'
+        self.company = self.browse_ref('base.main_company')
+        self.company.currency_id = self.euro
 
-        self.usd_level = MagicMock(name='USD policy level')
-        self.usd_level.dunning_fixed_amount = 5.0
-        self.usd_level.dunning_currency_id = self.usd
-        self.usd_level.dunning_type = 'fixed'
+        level_obj = self.env['credit.control.policy.level']
+        self.euro_level = level_obj.new({
+            'name': 'Euro Level',
+            'dunning_fixed_amount': 5.0,
+            'dunning_currency_id': self.euro,
+            'dunning_type': 'fixed',
+        })
+
+        self.usd_level = level_obj.new({
+            'name': 'USD Level',
+            'dunning_fixed_amount': 5.0,
+            'dunning_currency_id': self.usd,
+            'dunning_type': 'fixed',
+        })
         self.dunning_model = self.env['credit.control.dunning.fees.computer']
+        self.line_model = self.env['credit.control.line']
 
     def test_type_getter(self):
         """Test that correct compute function is returned for "fixed" type"""
@@ -58,25 +66,31 @@ class FixedFeesTester(common.TransactionCase):
 
     def test_computation_same_currency(self):
         """Test that fees are correctly computed with same currency"""
-        credit_line = MagicMock(name='Euro credit line')
-        credit_line.policy_level_id = self.euro_level
-        credit_line.currency_id = self.euro
+        credit_line = self.line_model.new({
+            'policy_level_id': self.euro_level,
+            'currency_id': self.euro,
+            'company_id': self.company,
+        })
         fees = self.dunning_model.compute_fixed_fees(credit_line)
         self.assertEqual(fees, self.euro_level.dunning_fixed_amount)
 
     def test_computation_different_currency(self):
         """Test that fees are correctly computed with different currency"""
-        credit_line = MagicMock(name='USD credit line')
-        credit_line.policy_level_id = self.euro_level
-        credit_line.currency_id = self.usd
+        credit_line = self.line_model.new({
+            'policy_level_id': self.euro_level,
+            'currency_id': self.usd.id,
+            'company_id': self.company,
+        })
         fees = self.dunning_model.compute_fixed_fees(credit_line)
         self.assertNotEqual(fees, self.euro_level.dunning_fixed_amount)
 
     def test_no_fees(self):
         """Test that fees are not generated if no amount defined on level"""
-        credit_line = MagicMock(name='USD credit line')
-        credit_line.policy_level_id = self.euro_level
+        credit_line = self.line_model.new({
+            'policy_level_id': self.euro_level,
+            'currency_id': self.usd,
+            'company_id': self.company,
+        })
         self.euro_level.dunning_fixed_amount = 0.0
-        credit_line.currency_id = self.usd
         fees = self.dunning_model.compute_fixed_fees(credit_line)
         self.assertEqual(fees, 0.0)

--- a/account_credit_control_dunning_fees/view/policy_view.xml
+++ b/account_credit_control_dunning_fees/view/policy_view.xml
@@ -11,10 +11,8 @@
             <group>
               <group>
                 <field name="dunning_fixed_amount"/>
-                <field name="dunning_product_id"
-                       attrs="{'required': [('dunning_fixed_amount', '!=', False)]}"/>
-                <field name="dunning_currency_id"
-                       attrs="{'required': [('dunning_fixed_amount', '!=', False)]}"/>
+                <field name="dunning_product_id"/>
+                <field name="dunning_currency_id"/>
               </group>
             </group>
           </page>


### PR DESCRIPTION
Remove required on the currency and fallback to company's currency on the
policy level if it is empty.

Also, it fixes a bug when a credit line had no currency and the level had
the company's currency. As False is different than any currency, it entered
in res_currency.compute() with a False currency. It must just fallback on
the company's currency if the credit line's currency is empty.
