### PR TITLE
Improve domain

### DIFF
--- a/account_check_deposit/account_deposit_view.xml
+++ b/account_check_deposit/account_deposit_view.xml
@@ -68,7 +68,7 @@
                                    widget="many2many"
                                    domain="[('reconcile_id', '=', False),
                                             ('debit', '>', 0),
-                                            ('journal_id', '=', journal_id),
+                                            ('check_deposit_id', '=', False),
                                             ('currency_id', '=', currency_none_same_company_id),
                                             ('account_id', '=', journal_default_account_id)]"
                                     context="{'currency': currency_id,


### PR DESCRIPTION
Filtering on the journal is useless and avoid having 2 journal for the check (one for receving the check and one for the deposit)

Add the filter on the deposit to avoid selecting a check that have been unreconciled but still linked to a deposit
