### PR TITLE
[FIX] Bug #119 account_auto_fy_sequence now works well with the POS

### DIFF
--- a/account_auto_fy_sequence/models/ir_sequence.py
+++ b/account_auto_fy_sequence/models/ir_sequence.py
@@ -26,6 +26,8 @@
 from openerp.osv import orm
 from openerp import SUPERUSER_ID
 from openerp.tools.translate import _
+from openerp import api
+
 
 FY_SLOT = '%(fy)s'
 YEAR_SLOT = '%(year)s'
@@ -62,6 +64,12 @@ class Sequence(orm.Model):
             }, context=context)
         return fy_seq_id
 
+    # We NEED to have @api.cr_uid_ids_context even if this file still uses
+    # the old API, to avoid breaking the POS, see this bug:
+    # https://github.com/OCA/account-financial-tools/issues/119
+    # Don't ask me why it fixes the bug, I have no idea  -- Alexis de Lattre
+    # I "copied" this solution from odoo-80/addons/account/ir_sequence.py
+    @api.cr_uid_ids_context
     def _next(self, cr, uid, seq_ids, context=None):
         if context is None:
             context = {}


### PR DESCRIPTION
Please refer to the bug report #119 for a detailed scenario of the crash.

Don't ask me why this fix solves the bug, I have no idea ! But it fixes the bug, that's the most important ! :) I hit this bug this morning (1/1/2015) when rolling out my first OpenERP POS in production... ARG !!!
I "copied" this solution from odoo-80/addons/account/ir_sequence.py : this file also uses the old API like account_auto_fy_sequence, but uses the decorator "@api.cr_uid_ids_context" above the _next() method.

Another way to fix the bug is to modify the code of odoo-80/addons/point_of_sale/point_of_sale.py line 750 in the create() method:
replace:

```
values['name'] = session.config_id.sequence_id._next()
```

by 

```
values['name'] = self.pool['ir.sequence']._next(cr, uid, [session.config_id.sequence_id.id], context=context)
```
