### PR TITLE
Remove post_install and at_install instructions on tests

### DIFF
--- a/account_credit_control_dunning_fees/tests/test_fees_generation.py
+++ b/account_credit_control_dunning_fees/tests/test_fees_generation.py
@@ -22,8 +22,6 @@ from mock import MagicMock
 from openerp.tests import common
 
 
-@common.at_install(True)
-@common.post_install(True)
 class FixedFeesTester(common.TransactionCase):
 
     def setUp(self):


### PR DESCRIPTION
With that, the suite is run even when we update another module and that not
what we expect.

I misunderstood the meaning of these decorators when I added them.
