### PR TITLE
Fix early removal when first depreciation line has not been processed

### DIFF
--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -182,7 +182,14 @@ class account_asset_remove(orm.TransientModel):
                 _("You can't make an early removal if all the depreciation "
                   "lines for previous periods are not posted."))
 
-        last_depr_date = first_to_depreciate_dl.previous_id.line_date
+        if first_to_depreciate_dl.previous_id:
+            last_depr_date = first_to_depreciate_dl.previous_id.line_date
+        else:
+            create_dl_id = asset_line_obj.search(
+                cr, uid,
+                [('asset_id', '=', asset.id), ('type', '=', 'create')])[0]
+            create_dl = asset_line_obj.browse(cr, uid, create_dl_id)
+            last_depr_date = create_dl.line_date
         period_number_days = (
             datetime.strptime(first_date, '%Y-%m-%d') -
             datetime.strptime(last_depr_date, '%Y-%m-%d')).days
@@ -302,7 +309,13 @@ class account_asset_remove(orm.TransientModel):
             cr, uid,
             [('asset_id', '=', asset.id), ('type', '=', 'depreciate')],
             order='line_date desc')
-        last_date = asset_line_obj.browse(cr, uid, dl_ids[0]).line_date
+        if dl_ids:
+            last_date = asset_line_obj.browse(cr, uid, dl_ids[0]).line_date
+        else:
+            create_dl_id = asset_line_obj.search(
+                cr, uid,
+                [('asset_id', '=', asset.id), ('type', '=', 'create')])[0]
+            last_date = asset_line_obj.browse(cr, uid, create_dl_id).line_date
         if wiz_data.date_remove < last_date:
             raise orm.except_orm(
                 _('Error!'),

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -187,8 +187,10 @@ class account_asset_remove(orm.TransientModel):
         else:
             create_dl_id = asset_line_obj.search(
                 cr, uid,
-                [('asset_id', '=', asset.id), ('type', '=', 'create')])[0]
-            create_dl = asset_line_obj.browse(cr, uid, create_dl_id)
+                [('asset_id', '=', asset.id), ('type', '=', 'create')],
+                context=context)[0]
+            create_dl = asset_line_obj.browse(
+                cr, uid, create_dl_id, context=context)
             last_depr_date = create_dl.line_date
         period_number_days = (
             datetime.strptime(first_date, '%Y-%m-%d') -
@@ -311,11 +313,13 @@ class account_asset_remove(orm.TransientModel):
             [('asset_id', '=', asset.id), ('type', '=', 'depreciate')],
             order='line_date desc')
         if dl_ids:
-            last_date = asset_line_obj.browse(cr, uid, dl_ids[0]).line_date
+            last_date = asset_line_obj.browse(
+                cr, uid, dl_ids[0], context=context).line_date
         else:
             create_dl_id = asset_line_obj.search(
                 cr, uid,
-                [('asset_id', '=', asset.id), ('type', '=', 'create')])[0]
+                [('asset_id', '=', asset.id), ('type', '=', 'create')],
+                context=context)[0]
             last_date = asset_line_obj.browse(cr, uid, create_dl_id).line_date
         if wiz_data.date_remove < last_date:
             raise orm.except_orm(

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -222,15 +222,16 @@ class account_asset_remove(orm.TransientModel):
 
         # asset and asset depreciation account reversal
         depr_amount = asset.asset_value - residual_value
-        move_line_vals = {
-            'name': asset.name,
-            'account_id': categ.account_depreciation_id.id,
-            'debit': depr_amount > 0 and depr_amount or 0.0,
-            'credit': depr_amount < 0 and -depr_amount or 0.0,
-            'partner_id': partner_id,
-            'asset_id': asset.id
-        }
-        move_lines.append((0, 0, move_line_vals))
+        if depr_amount:
+            move_line_vals = {
+                'name': asset.name,
+                'account_id': categ.account_depreciation_id.id,
+                'debit': depr_amount > 0 and depr_amount or 0.0,
+                'credit': depr_amount < 0 and -depr_amount or 0.0,
+                'partner_id': partner_id,
+                'asset_id': asset.id
+            }
+            move_lines.append((0, 0, move_line_vals))
         move_line_vals = {
             'name': asset.name,
             'account_id': categ.account_asset_id.id,


### PR DESCRIPTION
To reproduce the bug : create an asset with start date : 15/06/2014 for example.
compute depreciation line and then try to make an early removal at the date : 16/06/2014.

It will fail because the `first_to_depreciate_dl` (in the diff) have no previous_id since it is the very first depreciation line.

@luc-demeyer : What do you think?
