### PR TITLE
Add a configuration parameter to use entry_posted journal setting

### DIFF
--- a/account_default_draft_move/__init__.py
+++ b/account_default_draft_move/__init__.py
@@ -19,3 +19,4 @@
 ##############################################################################
 from . import account
 from . import account_bank_statement
+from . import res_config

--- a/account_default_draft_move/__openerp__.py
+++ b/account_default_draft_move/__openerp__.py
@@ -50,7 +50,9 @@ need to make a refund).
     """,
     'website': 'http://www.camptocamp.com',
     'data': ['account_view.xml',
-              'invoice_view.xml'],
+             'invoice_view.xml',
+             'res_config_view.xml',
+             ],
     'installable': True,
     'active': False,
 }

--- a/account_default_draft_move/account.py
+++ b/account_default_draft_move/account.py
@@ -66,3 +66,17 @@ class AccountMove(orm.Model):
                        'SET state=%s '
                        'WHERE id IN %s', ('draft', tuple(ids),))
         return True
+
+
+class AccountJournal(orm.Model):
+    _inherit = 'account.journal'
+
+    def __init__(self, pool, cr):
+        super(AccountJournal, self).__init__(pool, cr)
+        # update help of entry_posted flag
+        self._columns['entry_posted'].string = 'Skip \'Draft\' State'
+        self._columns['entry_posted'].help = \
+            """Check this box if you don't want new journal entries
+to pass through the 'draft' state and instead goes directly
+to the 'posted state' without any manual validation."""
+        return

--- a/account_default_draft_move/account.py
+++ b/account_default_draft_move/account.py
@@ -30,8 +30,12 @@ class AccountInvoice(orm.Model):
         res = super(AccountInvoice, self).action_move_create(cr, uid, ids,
                                                              context=context)
         move_obj = self.pool.get('account.move')
+        use_journal_setting = bool(self.pool['ir.config_parameter'].get_param(
+            cr, uid, 'use_journal_setting', False))
         for inv in self.browse(cr, uid, ids, context=context):
             if inv.move_id:
+                if use_journal_setting and inv.move_id.journal_id.entry_posted:
+                    continue
                 move_obj.write(cr, uid, [inv.move_id.id], {'state': 'draft'},
                                context=context)
         return res

--- a/account_default_draft_move/account_bank_statement.py
+++ b/account_default_draft_move/account_bank_statement.py
@@ -44,9 +44,15 @@ class AccountBankStatement(orm.Model):
             move_ids = [move_ids]
         # We receive the move created for the bank statement, we set it
         # to draft
+        use_journal_setting = bool(self.pool['ir.config_parameter'].get_param(
+            cr, uid, 'use_journal_setting', False))
         if move_ids:
             move_obj = self.pool.get('account.move')
-            move_obj.write(cr, uid, move_ids,
-                           {'state': 'draft'}, context=context)
+            moves = move_obj.browse(cr, uid, move_ids, context=context)
+            for move in moves:
+                if use_journal_setting and move.journal_id.entry_posted:
+                    continue
+                move_obj.write(cr, uid, [move.id],
+                               {'state': 'draft'}, context=context)
         return move_ids
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_default_draft_move/i18n/account_default_draft_move.pot
+++ b/account_default_draft_move/i18n/account_default_draft_move.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-10-18 17:48+0000\n"
-"PO-Revision-Date: 2013-10-18 17:48+0000\n"
+"POT-Creation-Date: 2015-02-19 10:15+0000\n"
+"PO-Revision-Date: 2015-02-19 10:15+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -31,7 +31,7 @@ msgid "Bank Statement"
 msgstr ""
 
 #. module: account_default_draft_move
-#: code:addons/account_default_draft_move/account.py:47
+#: code:addons/account_default_draft_move/account.py:59
 #, python-format
 msgid "Error!"
 msgstr ""
@@ -42,9 +42,19 @@ msgid "Invoice"
 msgstr ""
 
 #. module: account_default_draft_move
-#: code:addons/account_default_draft_move/account.py:47
+#: code:addons/account_default_draft_move/account.py:60
 #, python-format
 msgid "You cannot modify a posted entry of this journal.\n"
 "First you should set the journal to allow cancelling entries."
 msgstr ""
 
+#. module: account_default_draft_move
+#: model:ir.model,name:account_default_draft_move.model_account_config_settings
+msgid "account.config.settings"
+msgstr ""
+
+#. module: account_default_draft_move
+#: field:account.config.settings,use_journal_setting:0
+#: model:ir.model.fields,field_description:account_default_draft_move.field_account_config_settings_use_journal_setting
+msgid "Use journal setting to post journal entries on invoice and bank statement validation"
+msgstr ""

--- a/account_default_draft_move/i18n/en.po
+++ b/account_default_draft_move/i18n/en.po
@@ -33,7 +33,7 @@ msgid "Bank Statement"
 msgstr "Bank Statement"
 
 #. module: account_default_draft_move
-#: code:addons/account_default_draft_move/account.py:47
+#: code:addons/account_default_draft_move/account.py:59
 #, python-format
 msgid "Error!"
 msgstr ""
@@ -44,9 +44,20 @@ msgid "Invoice"
 msgstr ""
 
 #. module: account_default_draft_move
-#: code:addons/account_default_draft_move/account.py:47
+#: code:addons/account_default_draft_move/account.py:60
 #, python-format
 msgid ""
 "You cannot modify a posted entry of this journal.\n"
 "First you should set the journal to allow cancelling entries."
+msgstr ""
+
+#. module: account_default_draft_move
+#: model:ir.model,name:account_default_draft_move.model_account_config_settings
+msgid "account.config.settings"
+msgstr ""
+
+#. module: account_default_draft_move
+#: field:account.config.settings,use_journal_setting:0
+#: model:ir.model.fields,field_description:account_default_draft_move.field_account_config_settings_use_journal_setting
+msgid "Use journal setting to post journal entries on invoice and bank statement validation"
 msgstr ""

--- a/account_default_draft_move/i18n/fr.po
+++ b/account_default_draft_move/i18n/fr.po
@@ -33,7 +33,7 @@ msgid "Bank Statement"
 msgstr "Relevé bancaire"
 
 #. module: account_default_draft_move
-#: code:addons/account_default_draft_move/account.py:47
+#: code:addons/account_default_draft_move/account.py:59
 #, python-format
 msgid "Error!"
 msgstr ""
@@ -44,9 +44,20 @@ msgid "Invoice"
 msgstr "Facture"
 
 #. module: account_default_draft_move
-#: code:addons/account_default_draft_move/account.py:47
+#: code:addons/account_default_draft_move/account.py:60
 #, python-format
 msgid ""
 "You cannot modify a posted entry of this journal.\n"
 "First you should set the journal to allow cancelling entries."
 msgstr ""
+
+#. module: account_default_draft_move
+#: model:ir.model,name:account_default_draft_move.model_account_config_settings
+msgid "account.config.settings"
+msgstr ""
+
+#. module: account_default_draft_move
+#: field:account.config.settings,use_journal_setting:0
+#: model:ir.model.fields,field_description:account_default_draft_move.field_account_config_settings_use_journal_setting
+msgid "Use journal setting to post journal entries on invoice and bank statement validation"
+msgstr "Utiliser les paramètres du journal pour comptabiliser les pièces comptables lièes aux factures et aux extraits bancaires"

--- a/account_default_draft_move/res_config.py
+++ b/account_default_draft_move/res_config.py
@@ -1,0 +1,55 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#
+#    Copyright (c) 2014 ACSONE SA/NV (http://acsone.eu).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class AccountConfigSettings(orm.TransientModel):
+    _inherit = 'account.config.settings'
+
+    _columns = {
+        'use_journal_setting': fields.boolean(
+            'Use journal setting to post journal entries '
+            'on invoice and bank statement validation',),
+    }
+
+    def set_parameters(self, cr, uid, ids, context=None):
+        config = self.browse(cr, uid, ids[0], context)
+        config_pool = self.pool['ir.config_parameter']
+        if config.use_journal_setting:
+            config_pool.set_param(cr, uid, 'use_journal_setting',
+                                  config.use_journal_setting)
+        else:
+            # remove the key from parameter
+            ids = config_pool.search(cr, uid,
+                                     [('key', '=', 'use_journal_setting')],
+                                     context=context)
+            if ids:
+                config_pool.unlink(cr, uid, ids)
+
+    def default_get(self, cr, uid, fields, context=None):
+        res = super(AccountConfigSettings, self).default_get(cr, uid, fields,
+                                                             context=context)
+        config_pool = self.pool['ir.config_parameter']
+        res['use_journal_setting'] = config_pool.get_param(
+            cr, uid, 'use_journal_setting', False)
+        return res

--- a/account_default_draft_move/res_config_view.xml
+++ b/account_default_draft_move/res_config_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_account_config_settings" model="ir.ui.view">
+            <field name="name">account.config.settings.inherit</field>
+            <field name="inherit_id" ref="account.view_account_config_settings"/>
+            <field name="model">account.config.settings</field>
+            <field name="arch" type="xml">
+                <div name="account_config" position="inside">
+                    <div>
+                        <field name="use_journal_setting" class="oe_inline"/>
+                        <label for="use_journal_setting"/>
+                    </div>
+                </div>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
In certain case (automatic invoice) we doesn't need to check generate entries and we want to post them.
So I introduce a new account config parameter : use_journal_setting to use the setting 'entry_posted' of the journal.
