### PR TITLE
Add update_posted in journal items to display or not the button cancel

### DIFF
--- a/account_default_draft_move/account.py
+++ b/account_default_draft_move/account.py
@@ -18,7 +18,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ##############################################################################
 
-from openerp.osv import orm, osv
+from openerp.osv import orm, osv, fields
 from tools.translate import _
 
 
@@ -43,6 +43,12 @@ class AccountInvoice(orm.Model):
 
 class AccountMove(orm.Model):
     _inherit = 'account.move'
+
+    _columns = {
+        'update_posted': fields.related(
+            'journal_id', 'update_posted', type='boolean',
+            string='Allow Cancelling Entries', readonly=True),
+    }
 
     def button_cancel(self, cr, uid, ids, context=None):
         """ We rewrite function button_cancel, to allow invoice or bank

--- a/account_default_draft_move/account_view.xml
+++ b/account_default_draft_move/account_view.xml
@@ -8,7 +8,12 @@
       <field name="arch" type="xml">
         <data>
           <button name="button_validate" position="replace"/>
-          <button name="button_cancel" position="replace"/>
+          <button name="button_cancel" position="after">
+            <field name="update_posted" invisible="1"/>
+          </button>
+          <button name="button_cancel" position="attributes">
+            <attribute name="attrs">{'invisible': ['|', ('update_posted', '=', False)]}</attribute>
+          </button>
         </data>
       </field>
     </record>


### PR DESCRIPTION
The goal is to use  update_posted set on journal to display the cancel button on account_move.
