### PR TITLE
[FIX] account_constraint: set default value for statement state on statement line

### DIFF
--- a/account_constraints/model/account_bank_statement.py
+++ b/account_constraints/model/account_bank_statement.py
@@ -46,7 +46,8 @@ class AccountBankStatementLine(models.Model):
     _inherit = "account.bank.statement.line"
 
     state = fields.Selection(string='Statement state',
-                             related='statement_id.state')
+                             related='statement_id.state',
+                             default='draft')
 
     @api.multi
     def cancel(self):


### PR DESCRIPTION
Without this, it is not possible to add bank statement lines manually (import invoice works, though).

It is probably a framework regression somewhere and this should not be necessary since this field is a related.
