### PR TITLE
Fix for previous commit: address correctly lined up, date displays correctly

### DIFF
--- a/account_credit_control/report/credit_control_summary.html.mako
+++ b/account_credit_control/report/credit_control_summary.html.mako
@@ -96,10 +96,9 @@ table {
 }
 
 .address .recipient {
-    font-size: 13px;
-    margin-right: 120px;
-    margin-left: 350px;
-    float: right;
+    font-size: 12px;
+    margin-top: 60px;
+    float: left;
 }
 
 
@@ -136,8 +135,9 @@ tr.line {
 
     %for comm in objects :
     <% setLang(comm.get_contact_address().lang) %>
+    <%from datetime import date %>
     <div class="address">
-        <table class="recipient">
+        <table class="recipient" width="100%">
           <%
              add = comm.get_contact_address()
           %>


### PR DESCRIPTION
This PR is to fix something missing from https://github.com/OCA/account-financial-tools/pull/133 :
- the address was pushed to the far right,
- date was not imported, leading to an issue.
