### PR TITLE
[FIX] remove default value to avoid risk of setting done state on credit...

### DIFF
--- a/account_credit_control/wizard/credit_control_printer.py
+++ b/account_credit_control/wizard/credit_control_printer.py
@@ -54,7 +54,6 @@ class CreditControlPrinter(orm.TransientModel):
     }
 
     _defaults = {
-        'mark_as_sent': True,
         'line_ids': _get_line_ids,
     }
 


### PR DESCRIPTION
Remove default value on mark_as_sent to avoid risk of setting done state on credit control line , if you just to want to print the report for control.
