### PR TITLE
[FIX] prevent contraint trigger currency revaluation error on reconcile

### DIFF
--- a/account_constraints/account_constraints.py
+++ b/account_constraints/account_constraints.py
@@ -166,6 +166,9 @@ class AccountMoveLine(orm.Model):
 
     def _check_currency_amount(self, cr, uid, ids, context=None):
         for l in self.browse(cr, uid, ids, context=context):
+            # If account have a second currency, don't apply constraint
+            if l.account_id.currency_id:
+                continue
             if l.amount_currency:
                 if ((l.amount_currency > 0.0 and l.credit > 0.0) or
                         (l.amount_currency < 0.0 and l.debit > 0.0)):


### PR DESCRIPTION
Hello,

This PR, deactivate the contraint when account linked to the move line is configured with a secondary currency to solve the issue #135

Vincent
