### PR TITLE
[7.0][account_journal_period_close] Display close button on printed state

### DIFF
--- a/account_journal_period_close/view/account_period_view.xml
+++ b/account_journal_period_close/view/account_period_view.xml
@@ -19,7 +19,7 @@
                                         invisible="1" />
                                     <button name="action_done"
                                         type="object" icon="gtk-cancel"
-                                        states="draft" help="Close journal for this period"/>
+                                        states="draft,printed" help="Close journal for this period"/>
                                     <button name="action_draft"
                                         type="object" icon="gtk-redo"
                                         states="done" help="Reopen journal for this period"/>


### PR DESCRIPTION
Currently, the button that allows to close the journal does not appear if the state of the line is "printed".
This fix display close button also in printed state
