### PR TITLE
Add update_posted in journal items to display or not the button cancel

### DIFF
--- a/account_default_draft_move/account_view.xml
+++ b/account_default_draft_move/account_view.xml
@@ -8,7 +8,12 @@
       <field name="arch" type="xml">
         <data>
           <button name="button_validate" position="replace"/>
-          <button name="button_cancel" position="replace"/>
+          <button name="button_cancel" position="after">
+            <field name="update_posted" invisible="1"/>
+          </button>
+          <button name="button_cancel" position="attributes">
+            <attribute name="attrs">{'invisible': ['|', ('update_posted', '=', False)]}</attribute>
+          </button>
         </data>
       </field>
     </record>


### PR DESCRIPTION
The goal is to use update_posted set on journal to display the cancel button on account_move.

As suggest by @sbidoul in #150, I "make the cancel button appear only if update_posted is true and account_cancel is installed".
