### PR TITLE
[ADD][account_tax_analysis] Add group by journal filter on journal items view

### DIFF
--- a/account_tax_analysis/account_tax_analysis_view.xml
+++ b/account_tax_analysis/account_tax_analysis_view.xml
@@ -36,6 +36,9 @@
                     icon="terp-go-month"
                     domain="[]"
                     context="{'group_by': 'period_id'}"/>
+            <filter string="Journal"
+                    domain="[]"
+                    context="{'group_by': 'journal_id'}"/>
             <filter string="Tax account"
                     icon="terp-go-month"
                     domain="[]"


### PR DESCRIPTION
Currently, it's not possible to group by journal on view generated by taxes analysis.
This PR add this filter.
