### PR TITLE
New module: enforce_tax_account

### DIFF
--- a/enforce_tax_account/__init__.py
+++ b/enforce_tax_account/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) 2015 Bringsvor Consulting AS. All rights reserved.
+#    @author Torvald B. Bringsvor
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import account_move_line

--- a/enforce_tax_account/__openerp__.py
+++ b/enforce_tax_account/__openerp__.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) 2015 Bringsvor Consulting AS. All rights reserved.
+#    @author Torvald B. Bringsvor
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Enforce tax account',
+    'category': 'Accounting',
+    'summary': 'Enforce tax Account',
+    'version': '1.0',
+    'description': """Forces movelines for a given account to have a given tax code.
+    It is quite common in other systems to have the possibility to control VAT by
+    bookkeeping accounts.
+    """,
+    'author': 'Bringsvor Consulting AS',
+    'website': 'http://www.bringsvor.com',
+    'depends': ['base', 'account'],
+    'data': [
+        'views/account_move_view.xml',
+    ],
+    'test': [
+        ],
+    'installable': True,
+}

--- a/enforce_tax_account/account_move_line.py
+++ b/enforce_tax_account/account_move_line.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) 2015 Bringsvor Consulting AS. All rights reserved.
+#    @author Torvald B. Bringsvor
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import api, models, fields, _
+
+
+class account_move_line(models.Model):
+    _inherit = "account.move.line"
+
+    def check_foced_tax_code(self, account, values):
+        if values['tax_code_id'] != account.force_tax_id.id:
+            tax = self.env['account.tax.code'].search([('id', '=', values['tax_code_id'])])[0]
+            raise Warning(_('Wrong value'), _(
+                'Account %s is set to force tax code "%s" but got a moveline with "%s"' % (
+                account.code, account.force_tax_id.name, tax.name)))
+
+    @api.model
+    def create(self, values):
+        if not 'account_id' in values:
+            raise Warning(_('Missing value'), _('Account must be set on accounting move lines.'))
+        accounts = self.env['account.account'].search([('id','=',values['account_id'])])
+
+        if len(accounts)==0:
+            raise Warning(_('Missing value'), _('Account must be set on accounting move lines.'))
+        account = accounts[0]
+        if account.force_tax_id:
+            if not 'tax_code_id' in values:
+                raise Warning(_('Missing value'), _('Tax code must be set on accounting move lines on account %s' % account.code))
+            self.check_foced_tax_code(account, values)
+
+        return super(account_move_line, self).create(values)
+
+    def write(self, cr, uid, ids, values, context=None, check=True, update_check=True):
+        """
+        I intended to use the new api here too, but somehow I got an error saying
+        that there were multiple instances of the keyword argument check.
+        """
+        for moveline in self.browse(cr, uid, ids):
+            if 'account_id' in values:
+                accounts = moveline.env['account.account'].search([('id','=',values['account_id'])])
+                if len(accounts)==0:
+                    raise Warning(_('Missing value'), _('Account must be set on accounting move lines.'))
+                account = accounts[0]
+            else:
+                account = moveline.account_id
+
+            if account.force_tax_id:
+                if 'tax_code_id' in values:
+                    moveline.check_foced_tax_code(account, values)
+
+        return super(account_move_line, self).write(cr, uid, ids, values, context, check, update_check)
+
+class account_account(models.Model):
+    _inherit = 'account.account'
+
+    force_tax_id = fields.Many2one('account.tax.code', string='Forced tax')

--- a/enforce_tax_account/tests/__init__.py
+++ b/enforce_tax_account/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) 2015 Bringsvor Consulting AS. All rights reserved.
+#    @author Torvald B. Bringsvor
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_enforce_tax

--- a/enforce_tax_account/tests/test_enforce_tax.py
+++ b/enforce_tax_account/tests/test_enforce_tax.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) 2015 Bringsvor Consulting AS. All rights reserved.
+#    @author Torvald B. Bringsvor
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+from openerp.tests import common
+from openerp import fields, _
+from datetime import datetime
+
+class test_enforce_tax_account(common.TransactionCase):
+
+    def setUp(self):
+        super(test_enforce_tax_account, self).setUp()
+        self.moveline = self.env['account.move.line']
+        self.journal = self.env['account.journal'].search([])[0]
+        self.period = self.env['account.period'].search([('company_id','=',self.journal.company_id.id)])[0]
+        self.account = self.env['account.account'].search([('code','!=',''), ('type','=','other'),('company_id','=',self.journal.company_id.id)])[0]
+        self.tax_code = self.env['account.tax.code'].search([('company_id','=',self.journal.company_id.id)])[0]
+        self.other_tax_code = self.env['account.tax.code'].search([('id','!=',self.tax_code.id), ('company_id','=',self.journal.company_id.id)])[0]
+
+    def test_create_fail_no_account(self):
+        with self.assertRaises(Warning) as cm:
+            self.moveline.create({})
+
+    def test_create_fail_when_no_tax(self):
+        #self.account.write({'force_tax_id': self.tax_code.id})
+        self.account.force_tax_id = self.tax_code
+        val = {'debit': 100.0,
+               'date': fields.Date.today(),
+               'name': 'Test Entry - should fail',
+               'company_id': self.period.company_id.id,
+               'account_id' : self.account.id,
+            'credit': 0.0,
+            'journal_id': self.journal.id,
+            'period_id': self.period.id,
+            }
+        with self.assertRaises(Warning) as cm:
+            self.moveline.create(val)
+
+        the_exception = cm.exception
+        expected_args = _('Missing value'), _('Tax code must be set on accounting move lines on account %s' % self.account.code)
+        self.assertEqual(the_exception.args, expected_args)
+
+    def test_create_fail_when_wrong_tax(self):
+        #self.account.write({'force_tax_id': self.tax_code.id})
+        self.account.force_tax_id = self.tax_code
+        val = {'debit': 100.0,
+               'date': fields.Date.today(),
+               'name': 'Test Entry - should fail',
+               'company_id': self.period.company_id.id,
+               'account_id' : self.account.id,
+               'tax_code_id': self.other_tax_code.id,
+            'credit': 0.0,
+            'journal_id': self.journal.id,
+            'period_id': self.period.id,
+            }
+        with self.assertRaises(Warning) as cm:
+            self.moveline.create(val)
+
+        the_exception = cm.exception
+
+        expected_args = _('Wrong value'), _('Account %s is set to force tax code "%s" but got a moveline with "%s"' % (self.account.code, self.tax_code.name, self.other_tax_code.name))
+        self.assertEqual(the_exception.args, expected_args)
+
+
+    def test_write_fail_when_wrong_vat(self):
+        self.account.force_tax_id = self.tax_code
+        val = {'debit': 100.0,
+               'date': fields.Date.today(),
+               'name': 'Test Entry - should fail',
+               'company_id': self.period.company_id.id,
+               'account_id' : self.account.id,
+               'tax_code_id': self.tax_code.id,
+            'credit': 0.0,
+            'journal_id': self.journal.id,
+            'period_id': self.period.id,
+            }
+        ml = self.moveline.create(val)
+
+        with self.assertRaises(Warning) as cm:
+            ml.write({'tax_code_id': self.other_tax_code.id})
+
+        the_exception = cm.exception
+        expected_args = _('Wrong value'), _('Account %s is set to force tax code "%s" but got a moveline with "%s"' % (self.account.code, self.tax_code.name, self.other_tax_code.name))
+        self.assertEqual(the_exception.args, expected_args)
+

--- a/enforce_tax_account/tests/test_enforce_tax.py
+++ b/enforce_tax_account/tests/test_enforce_tax.py
@@ -20,6 +20,7 @@
 ##############################################################################
 
 
+
 from openerp.tests import common
 from openerp import fields, _
 from datetime import datetime

--- a/enforce_tax_account/views/account_move_view.xml
+++ b/enforce_tax_account/views/account_move_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_account_forced_tax" model="ir.ui.view">
+            <field name="name">account.account.form.inerhit</field>
+            <field name="model">account.account</field>
+            <field name="inherit_id" ref="account.view_account_form" />
+            <field name="arch" type="xml">
+                <field name="tax_ids" position="after">
+                    <field name="force_tax_id"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Added a new module to force accounting moves on a given account to have a certain tax code.

At least here in Norway it is common practice to have one account per vat code, to simplify reconciliation.
