### PR TITLE
Fix bank of canada update

### DIFF
--- a/currency_rate_update/__openerp__.py
+++ b/currency_rate_update/__openerp__.py
@@ -24,7 +24,7 @@
 ##############################################################################
 {
     "name": "Currency Rate Update",
-    "version": "0.7",
+    "version": "0.8",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "http://camptocamp.com",
     "category": "Financial Management/Configuration",

--- a/currency_rate_update/company.py
+++ b/currency_rate_update/company.py
@@ -41,7 +41,7 @@ class res_company(orm.Model):
         return result
 
     def button_refresh_currency(self, cr, uid, ids, context=None):
-        """Refrech  the currency for all the company now"""
+        """Refresh  the currency for all the company now"""
         currency_updater_obj = self.pool.get('currency.rate.update')
         try:
             currency_updater_obj.run_currency_update(cr, uid)
@@ -50,11 +50,11 @@ class res_company(orm.Model):
         return True
 
     def on_change_auto_currency_up(self, cr, uid, id, value):
-        """handle the activation of the currecny update on compagnies.
+        """handle the activation of the currency update on companies.
         There are two ways of implementing multi_company currency,
         the currency is shared or not. The module take care of the two
         ways. If the currency are shared, you will only be able to set
-        auto update on one company, this will avoid to have unusefull cron
+        auto update on one company, this will avoid to have non-useful cron
         object running.
         If yours currency are not share you will be able to activate the
         auto update on each separated company
@@ -66,13 +66,13 @@ class res_company(orm.Model):
         else:
             return {}
         enable = self.browse(cr, uid, id).multi_company_currency_enable
-        compagnies = self.search(cr, uid, [])
+        companies = self.search(cr, uid, [])
         activate_cron = 'f'
         if not value:
-            # this statement is here beacaus we do no want to save #
+            # this statement is here because we do no want to save
             # in case of error
             self.write(cr, uid, id, {'auto_currency_up': value})
-            for comp in compagnies:
+            for comp in companies:
                 if self.browse(cr, uid, comp).auto_currency_up:
                     activate_cron = 't'
                     break
@@ -83,11 +83,11 @@ class res_company(orm.Model):
             )
             return {}
         else:
-            for comp in compagnies:
+            for comp in companies:
                 if comp != id and not enable:
                     current = self.browse(cr, uid, comp)
                     if current.multi_company_currency_enable:
-                        # We ensure taht we did not have write a true value
+                        # We ensure that we did not have write a true value
                         self.write(cr, uid, id, {'auto_currency_up': False})
                         msg = ('You can not activate auto currency'
                                'update on more thant one company with this '
@@ -101,7 +101,7 @@ class res_company(orm.Model):
                             }
                         }
             self.write(cr, uid, id, {'auto_currency_up': value})
-            for comp in compagnies:
+            for comp in companies:
                 if self.browse(cr, uid, comp).auto_currency_up:
                     activate_cron = 't'
                 self.pool.get('currency.rate.update').save_cron(
@@ -112,7 +112,7 @@ class res_company(orm.Model):
                 break
             return {}
 
-    def on_change_intervall(self, cr, uid, id, interval):
+    def on_change_interval(self, cr, uid, id, interval):
         # Function that will update the cron freqeuence
         self.pool.get('currency.rate.update').save_cron(
             cr,
@@ -128,26 +128,26 @@ class res_company(orm.Model):
     _columns = {
         # Activate the currency update
         'auto_currency_up': fields.boolean(
-            'Automatical update of the currency this company'
+            'Automatic update of the currency this company'
         ),
         'services_to_use': fields.one2many(
             'currency.rate.update.service',
             'company_id',
             'Currency update services'
         ),
-        # Predifine cron frequence
+        # Predefine cron frequency
         'interval_type': fields.selection(
             [
                 ('days', 'Day(s)'),
                 ('weeks', 'Week(s)'),
                 ('months', 'Month(s)')
             ],
-            'Currency update frequence',
+            'Currency update frequency',
             help="Changing this value will "
-                 "also affect other compagnies"
+                 "also affect other companies"
         ),
         # Function field that allows to know the
-        # mutli company currency implementation
+        # multi company currency implementation
         'multi_company_currency_enable': fields.function(
             _multi_curr_enable,
             method=True,

--- a/currency_rate_update/company.py
+++ b/currency_rate_update/company.py
@@ -19,6 +19,7 @@
 #
 ##############################################################################
 from openerp.osv import fields, orm
+from openerp.tools.translate import _
 
 
 class res_company(orm.Model):
@@ -43,7 +44,14 @@ class res_company(orm.Model):
     def button_refresh_currency(self, cr, uid, ids, context=None):
         """Refresh  the currency for all the company now"""
         currency_updater_obj = self.pool.get('currency.rate.update')
-        currency_updater_obj.run_currency_update(cr, uid, context=context)
+        errors = currency_updater_obj.run_currency_update(
+            cr, uid, context=context
+        )
+        if errors:
+            raise orm.except_orm(
+                _("Error"),
+                _("Errors occurred during update:\n") + "\n".join(errors),
+            )
         return True
 
     def on_change_auto_currency_up(self, cr, uid, id, value):

--- a/currency_rate_update/company.py
+++ b/currency_rate_update/company.py
@@ -43,10 +43,7 @@ class res_company(orm.Model):
     def button_refresh_currency(self, cr, uid, ids, context=None):
         """Refresh  the currency for all the company now"""
         currency_updater_obj = self.pool.get('currency.rate.update')
-        try:
-            currency_updater_obj.run_currency_update(cr, uid, context=context)
-        except Exception:
-            return False
+        currency_updater_obj.run_currency_update(cr, uid, context=context)
         return True
 
     def on_change_auto_currency_up(self, cr, uid, id, value):

--- a/currency_rate_update/company.py
+++ b/currency_rate_update/company.py
@@ -44,7 +44,7 @@ class res_company(orm.Model):
         """Refresh  the currency for all the company now"""
         currency_updater_obj = self.pool.get('currency.rate.update')
         try:
-            currency_updater_obj.run_currency_update(cr, uid)
+            currency_updater_obj.run_currency_update(cr, uid, context=context)
         except Exception:
             return False
         return True

--- a/currency_rate_update/company_view.xml
+++ b/currency_rate_update/company_view.xml
@@ -6,15 +6,15 @@
             <field name="inherit_id" ref="base.view_company_form"/>
             <field name="arch" type="xml">
                 <notebook position="inside">
-                    <page string="Currency auto update configuration">
+                    <page string="Currency Auto Update Configuration">
                         <group>
-                           <field name="auto_currency_up" on_change="on_change_auto_currency_up(auto_currency_up)"/> 
-                            <field name="interval_type" on_change="on_change_intervall(interval_type)"/>
+                            <field name="auto_currency_up" on_change="on_change_auto_currency_up(auto_currency_up)"/>
+                            <field name="interval_type" on_change="on_change_interval(interval_type)"/>
                             <field name="multi_company_currency_enable"/>
                         </group>
                         <separator string="Currency updates services" colspan="4"/>
                         <field name="services_to_use" colspan="4" nolabel="1"/>
-                        <button name="button_refresh_currency"  string="Refresh currencies" type='object' />
+                        <button name="button_refresh_currency"  string="Refresh Currencies" type='object' />
                     </page>
                 </notebook>
             </field>

--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -285,41 +285,6 @@ class CurrencyRateUpdate(orm.Model):
                     raise
 
 
-class AbstractClassError(Exception):
-    def __str__(self):
-        return 'Abstract Class'
-
-    def __repr__(self):
-        return 'Abstract Class'
-
-
-class AbstractMethodError(Exception):
-    def __str__(self):
-        return 'Abstract Method'
-
-    def __repr__(self):
-        return 'Abstract Method'
-
-
-class UnknownClassError(Exception):
-    def __str__(self):
-        return 'Unknown Class'
-
-    def __repr__(self):
-        return 'Unknown Class'
-
-
-class UnsupportedCurrencyError(Exception):
-    def __init__(self, value):
-        self.curr = value
-
-    def __str__(self):
-        return 'Unsupported currency %s' % self.curr
-
-    def __repr__(self):
-        return 'Unsupported currency %s' % self.curr
-
-
 def register(class_name):
     allowed = [
         'Admin_ch_getter',
@@ -335,7 +300,7 @@ def register(class_name):
         class_def = eval(class_name)
         return class_def()
     else:
-        raise UnknownClassError
+        raise AttributeError("Class %s not defined in module." % class_name)
 
 
 class CurrencyGetterInterface(object):
@@ -372,12 +337,17 @@ class CurrencyGetterInterface(object):
         """Interface method that will retrieve the currency
            This function has to be reimplemented in child
         """
-        raise AbstractMethodError
+        raise NotImplementedError(
+            "Function get_updated_currency not implemented in class %s"
+            % self.__class__
+        )
 
     def validate_currency(self, currency):
         """Validate if the currency to update is supported"""
         if currency not in self.supported_currency_array:
-            raise UnsupportedCurrencyError(currency)
+            raise AttributeError(
+                'Unsupported currency %s' % currency
+            )
 
     def get_url(self, url):
         """Return a string of a get url query"""

--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -797,7 +797,7 @@ class BankOfCanadaGetter(CurrencyGetterInterface):
 
                 # check for valid exchange data
                 if (boc_conn.base_currency == main_currency and
-                        boc_conn.target_currency == currency):
+                        boc_conn.target_currency.startswith(currency)):
                     self.check_rate_date(boc_conn.date_time, max_delta_days)
                     self.updated_currency[currency] = boc_conn.exchange_rate
                     _logger.debug(

--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -187,7 +187,6 @@ class CurrencyRateUpdate(orm.Model):
         return self.pool.get('ir.cron').write(cr, uid, [cron_id], datas)
 
     def run_currency_update(self, cr, uid, context=None):
-        factory = Currency_getter_factory()
         """Update currency at the given frequency"""
         curr_obj = self.pool.get('res.currency')
         rate_obj = self.pool.get('res.currency.rate')
@@ -233,7 +232,7 @@ class CurrencyRateUpdate(orm.Model):
                 try:
                     # We initialize the class that will handle the request
                     # and return a dict of rate
-                    getter = factory.register(service.service)
+                    getter = register(service.service)
                     curr_to_fetch = map(lambda x: x.name,
                                         service.currency_to_update)
                     res, log_info = getter.get_updated_currency(
@@ -321,28 +320,22 @@ class UnsupportedCurrencyError(Exception):
         return 'Unsupported currency %s' % self.curr
 
 
-class Currency_getter_factory():
-    """Factory pattern class that will return
-    a currency getter class base on the name passed
-    to the register method
-
-    """
-    def register(self, class_name):
-        allowed = [
-            'Admin_ch_getter',
-            'PL_NBP_getter',
-            'ECB_getter',
-            'NYFB_getter',
-            'Google_getter',
-            'Yahoo_getter',
-            'Banxico_getter',
-            'BankOfCanadaGetter',
-        ]
-        if class_name in allowed:
-            class_def = eval(class_name)
-            return class_def()
-        else:
-            raise UnknownClassError
+def register(class_name):
+    allowed = [
+        'Admin_ch_getter',
+        'PL_NBP_getter',
+        'ECB_getter',
+        'NYFB_getter',
+        'Google_getter',
+        'Yahoo_getter',
+        'Banxico_getter',
+        'BankOfCanadaGetter',
+    ]
+    if class_name in allowed:
+        class_def = eval(class_name)
+        return class_def()
+    else:
+        raise UnknownClassError
 
 
 class CurrencyGetterInterface(object):

--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -728,13 +728,13 @@ class BankOfCanadaConnection(object):
 
         # check if BOC service is running
         if self.dom.bozo and self.dom.status != 404:
-            _logger.error(
+            _logger.warn(
                 "Bank of Canada - service is down - try again later..."
             )
 
         # check if BOC sent a valid response for this currency
         if self.dom.status != 200:
-            _logger.error(
+            _logger.warn(
                 "Exchange data for %s is not reported by Bank of Canada."
                 % self.currency
             )
@@ -813,7 +813,7 @@ class BankOfCanadaGetter(CurrencyGetterInterface):
                             (main_currency, conn.exchange_rate, currency)
                         )
                     else:
-                        _logger.error(
+                        _logger.warn(
                             "Exchange data format error for Bank of Canada -"
                             "%s. Please check provider data format "
                             "and/or source code." % currency)

--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -370,7 +370,7 @@ class Curreny_getter_interface(object):
         """
         raise AbstractMethodError
 
-    def validate_cur(self, currency):
+    def validate_currency(self, currency):
         """Validate if the currency to update is supported"""
         if currency not in self.supported_currency_array:
             raise UnsupportedCurrencyError(currency)
@@ -424,13 +424,13 @@ class Yahoo_getter(Curreny_getter_interface):
     def get_updated_currency(self, currency_array, main_currency,
                              max_delta_days):
         """implementation of abstract method of curreny_getter_interface"""
-        self.validate_cur(main_currency)
+        self.validate_currency(main_currency)
         url = ('http://download.finance.yahoo.com/d/'
                'quotes.txt?s="%s"=X&f=sl1c1abg')
         if main_currency in currency_array:
             currency_array.remove(main_currency)
         for curr in currency_array:
-            self.validate_cur(curr)
+            self.validate_currency(curr)
             res = self.get_url(url % (main_currency + curr))
             val = res.split(',')[1]
             if val:
@@ -500,7 +500,7 @@ class Admin_ch_getter(Curreny_getter_interface):
         _logger.debug(
             "Supported currencies = " + str(self.supported_currency_array)
         )
-        self.validate_cur(main_currency)
+        self.validate_currency(main_currency)
         if main_currency != 'CHF':
             main_curr_data = self.rate_retrieve(dom, adminch_ns, main_currency)
             # 1 MAIN_CURRENCY = main_rate CHF
@@ -508,7 +508,7 @@ class Admin_ch_getter(Curreny_getter_interface):
             rate_ref = main_curr_data['rate_ref']
             main_rate = rate_curr / rate_ref
         for curr in currency_array:
-            self.validate_cur(curr)
+            self.validate_currency(curr)
             if curr == 'CHF':
                 rate = main_rate
             else:
@@ -580,11 +580,11 @@ class ECB_getter(Curreny_getter_interface):
         self.supported_currency_array.append('EUR')
         _logger.debug("Supported currencies = %s " %
                       self.supported_currency_array)
-        self.validate_cur(main_currency)
+        self.validate_currency(main_currency)
         if main_currency != 'EUR':
             main_curr_data = self.rate_retrieve(dom, ecb_ns, main_currency)
         for curr in currency_array:
-            self.validate_cur(curr)
+            self.validate_currency(curr)
             if curr == 'EUR':
                 rate = 1 / main_curr_data['rate_currency']
             else:
@@ -650,14 +650,14 @@ class PL_NBP_getter(Curreny_getter_interface):
         self.supported_currency_array.append('PLN')
         _logger.debug("Supported currencies = %s" %
                       self.supported_currency_array)
-        self.validate_cur(main_currency)
+        self.validate_currency(main_currency)
         if main_currency != 'PLN':
             main_curr_data = self.rate_retrieve(dom, ns, main_currency)
             # 1 MAIN_CURRENCY = main_rate PLN
             main_rate = (main_curr_data['rate_currency'] /
                          main_curr_data['rate_ref'])
         for curr in currency_array:
-            self.validate_cur(curr)
+            self.validate_currency(curr)
             if curr == 'PLN':
                 rate = main_rate
             else:

--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -12,7 +12,7 @@
 #     - if company_currency <> CHF, you can now update CHF via Admin.ch
 #       (same for EUR with ECB webservice and PLN with NBP webservice)
 #     For more details, see Launchpad bug #645263
-#     - mecanism to check if rates given by the webservice are "fresh"
+#     - mechanism to check if rates given by the webservice are "fresh"
 #       enough to be written in OpenERP
 #       ('max_delta_days' parameter for each currency update service)
 #    Ported to OpenERP 7.0 by Lorenzo Battistini
@@ -49,7 +49,7 @@ _logger = logging.getLogger(__name__)
 
 
 class Currency_rate_update_service(osv.Model):
-    """Class that tells for wich services wich currencies have to be updated
+    """Class that tells for which services which currencies have to be updated
 
     """
     _name = "currency.rate.update.service"
@@ -87,14 +87,14 @@ class Currency_rate_update_service(osv.Model):
             'res.company',
             'linked company',
         ),
-        # Note fileds that will be used as a logger
+        # Note fields that will be used as a logger
         'note': fields.text('update notice'),
         'max_delta_days': fields.integer(
             'Max delta days',
             required=True,
             help="If the time delta between the "
             "rate date given by the webservice and "
-            "the current date exeeds this value, "
+            "the current date exceeds this value, "
             "then the currency rate is not updated in OpenERP."
         ),
     }
@@ -183,8 +183,8 @@ class Currency_rate_update(osv.Model):
         return self.pool.get('ir.cron').write(cr, uid, [cron_id], datas)
 
     def run_currency_update(self, cr, uid):
-        "update currency at the given frequence"
         factory = Currency_getter_factory()
+        """Update currency at the given frequency"""
         curr_obj = self.pool.get('res.currency')
         rate_obj = self.pool.get('res.currency.rate')
         companies = self.pool.get('res.company').search(cr, uid, [])
@@ -222,7 +222,7 @@ class Currency_rate_update(osv.Model):
             for service in comp.services_to_use:
                 note = service.note or ''
                 try:
-                    # We initalize the class that will handle the request
+                    # We initialize the class that will handle the request
                     # and return a dict of rate
                     getter = factory.register(service.service)
                     curr_to_fetch = map(lambda x: x.name,
@@ -291,7 +291,7 @@ class AbstractMethodError(Exception):
         return 'Abstract Method'
 
 
-class UnknowClassError(Exception):
+class UnknownClassError(Exception):
     def __str__(self):
         return 'Unknown Class'
 
@@ -299,7 +299,7 @@ class UnknowClassError(Exception):
         return 'Unknown Class'
 
 
-class UnsuportedCurrencyError(Exception):
+class UnsupportedCurrencyError(Exception):
     def __init__(self, value):
         self.curr = value
 
@@ -331,11 +331,11 @@ class Currency_getter_factory():
             class_def = eval(class_name)
             return class_def()
         else:
-            raise UnknowClassError
+            raise UnknownClassError
 
 
 class Curreny_getter_interface(object):
-    "Abstract class of currency getter"
+    """Abstract class of currency getter"""
 
     log_info = " "
 
@@ -360,20 +360,20 @@ class Curreny_getter_interface(object):
         'ZWD'
     ]
 
-    # Updated currency this arry will contain the final result
+    # Updated currency this array will contain the final result
     updated_currency = {}
 
     def get_updated_currency(self, currency_array, main_currency,
                              max_delta_days):
         """Interface method that will retrieve the currency
-           This function has to be reinplemented in child
+           This function has to be reimplemented in child
         """
         raise AbstractMethodError
 
     def validate_cur(self, currency):
         """Validate if the currency to update is supported"""
         if currency not in self.supported_currency_array:
-            raise UnsuportedCurrencyError(currency)
+            raise UnsupportedCurrencyError(currency)
 
     def get_url(self, url):
         """Return a string of a get url query"""

--- a/currency_rate_update/currency_rate_update.xml
+++ b/currency_rate_update/currency_rate_update.xml
@@ -2,7 +2,7 @@
 <openerp>
     <data>
         <record model="ir.ui.view" id="currency_rate_update_tree">
-            <field name="name">Update Rates service</field>
+            <field name="name">Update Rates Service</field>
             <field name="model">currency.rate.update.service</field>
             <field name="arch" type="xml">
                 <tree string="Rates">
@@ -20,7 +20,7 @@
                 <form string="Rate">
                     <field name="service"/>
                     <field name="max_delta_days"/>
-                    <separator string="Currencies to update with this service" colspan="4"/>
+                    <separator string="Currencies to Update with this Service" colspan="4"/>
                     <field name="currency_to_update" colspan="4" nolabel="1"/>
                     <separator string="Logs" colspan="4"/>
                     <field name="note" colspan="4" nolabel="1"/>

--- a/currency_rate_update/i18n/currency_rate_update.pot
+++ b/currency_rate_update/i18n/currency_rate_update.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-10-18 17:52+0000\n"
-"PO-Revision-Date: 2013-10-18 17:52+0000\n"
+"POT-Creation-Date: 2015-04-15 20:27+0000\n"
+"PO-Revision-Date: 2015-04-15 20:27+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,13 +16,24 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: currency_rate_update
-#: view:res.company:0
-msgid "Currency auto update configuration"
+#: code:addons/currency_rate_update/currency_rate_update.py:225
+#, python-format
+msgid "There is no base currency set!"
+msgstr ""
+
+#. module: currency_rate_update
+#: field:res.company,interval_type:0
+msgid "Currency update frequency"
 msgstr ""
 
 #. module: currency_rate_update
 #: view:res.company:0
 msgid "Currency updates services"
+msgstr ""
+
+#. module: currency_rate_update
+#: selection:currency.rate.update.service,service:0
+msgid "Bank of Canada - noon rates"
 msgstr ""
 
 #. module: currency_rate_update
@@ -32,12 +43,18 @@ msgstr ""
 
 #. module: currency_rate_update
 #: view:currency.rate.update.service:0
-msgid "Rate"
+msgid "Rates"
 msgstr ""
 
 #. module: currency_rate_update
-#: view:currency.rate.update.service:0
-msgid "Rates"
+#: code:addons/currency_rate_update/currency_rate_update.py:832
+#, python-format
+msgid "Errors occurred during update"
+msgstr ""
+
+#. module: currency_rate_update
+#: view:res.company:0
+msgid "Refresh Currencies"
 msgstr ""
 
 #. module: currency_rate_update
@@ -46,13 +63,15 @@ msgid "Multi company currency"
 msgstr ""
 
 #. module: currency_rate_update
-#: field:res.company,interval_type:0
-msgid "Currency update frequence"
+#: selection:res.company,interval_type:0
+msgid "Day(s)"
 msgstr ""
 
 #. module: currency_rate_update
-#: selection:res.company,interval_type:0
-msgid "Day(s)"
+#: code:addons/currency_rate_update/company.py:53
+#, python-format
+msgid "Errors occurred during update:\n"
+""
 msgstr ""
 
 #. module: currency_rate_update
@@ -76,25 +95,40 @@ msgid "Webservice to use"
 msgstr ""
 
 #. module: currency_rate_update
-#: help:currency.rate.update.service,max_delta_days:0
-msgid "If the time delta between the rate date given by the webservice and the current date exeeds this value, then the currency rate is not updated in OpenERP."
+#: view:currency.rate.update.service:0
+msgid "Rate"
 msgstr ""
 
 #. module: currency_rate_update
-#: field:res.company,services_to_use:0
-msgid "Currency update services"
+#: field:res.company,auto_currency_up:0
+msgid "Automatic update of the currency this company"
 msgstr ""
 
 #. module: currency_rate_update
-#: constraint:currency.rate.update.service:0
-msgid "'Max delta days' must be >= 0"
+#: selection:currency.rate.update.service,service:0
+msgid "European Central Bank"
 msgstr ""
 
 #. module: currency_rate_update
-#: code:addons/currency_rate_update/currency_rate_update.py:89
+#: help:res.company,multi_company_currency_enable:0
+msgid "If this case is not check you can not set currency is active on two company"
+msgstr ""
+
+#. module: currency_rate_update
+#: help:res.company,interval_type:0
+msgid "Changing this value will also affect other companies"
+msgstr ""
+
+#. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:114
 #: sql_constraint:currency.rate.update.service:0
 #, python-format
 msgid "You can use a service one time per company !"
+msgstr ""
+
+#. module: currency_rate_update
+#: help:currency.rate.update.service,max_delta_days:0
+msgid "If the time delta between the rate date given by the webservice and the current date exceeds this value, then the currency rate is not updated in OpenERP."
 msgstr ""
 
 #. module: currency_rate_update
@@ -113,13 +147,25 @@ msgid "Admin.ch"
 msgstr ""
 
 #. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:822
+#, python-format
+msgid "Exchange data format error for Bank of Canada - %s"
+msgstr ""
+
+#. module: currency_rate_update
 #: model:ir.model,name:currency_rate_update.model_res_company
 msgid "Companies"
 msgstr ""
 
 #. module: currency_rate_update
 #: view:currency.rate.update.service:0
-msgid "Currencies to update with this service"
+msgid "Currencies to Update with this Service"
+msgstr ""
+
+#. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:224
+#, python-format
+msgid "Error!"
 msgstr ""
 
 #. module: currency_rate_update
@@ -128,12 +174,27 @@ msgid "Week(s)"
 msgstr ""
 
 #. module: currency_rate_update
-#: help:res.company,multi_company_currency_enable:0
-msgid "if this case is not check you can not set currency is active on two company"
+#: code:addons/currency_rate_update/company.py:52
+#: code:addons/currency_rate_update/currency_rate_update.py:229
+#: code:addons/currency_rate_update/currency_rate_update.py:742
+#: code:addons/currency_rate_update/currency_rate_update.py:821
+#, python-format
+msgid "Error"
 msgstr ""
 
 #. module: currency_rate_update
-#: code:addons/currency_rate_update/currency_rate_update.py:153
+#: field:res.company,services_to_use:0
+msgid "Currency update services"
+msgstr ""
+
+#. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:743
+#, python-format
+msgid "Exchange data for %s is not reported by Bank of Canada."
+msgstr ""
+
+#. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:184
 #: model:ir.model,name:currency_rate_update.model_currency_rate_update
 #: model:ir.model,name:currency_rate_update.model_currency_rate_update_service
 #, python-format
@@ -146,8 +207,20 @@ msgid "Logs"
 msgstr ""
 
 #. module: currency_rate_update
-#: field:res.company,auto_currency_up:0
-msgid "Automatical update of the currency this company"
+#: selection:currency.rate.update.service,service:0
+msgid "Banco de México"
+msgstr ""
+
+#. module: currency_rate_update
+#: view:res.company:0
+msgid "Currency Auto Update Configuration"
+msgstr ""
+
+#. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:230
+#, python-format
+msgid "Base currency rate should be 1.00.\n"
+"Currency %s has rate of %f"
 msgstr ""
 
 #. module: currency_rate_update
@@ -156,18 +229,6 @@ msgid "Month(s)"
 msgstr ""
 
 #. module: currency_rate_update
-#: selection:currency.rate.update.service,service:0
-msgid "European Central Bank"
+#: constraint:currency.rate.update.service:0
+msgid "'Max delta days' must be >= 0"
 msgstr ""
-
-#. module: currency_rate_update
-#: help:res.company,interval_type:0
-msgid "changing this value will\n"
-"                                                 also affect other compagnies"
-msgstr ""
-
-#. module: currency_rate_update
-#: view:res.company:0
-msgid "Refresh currencies"
-msgstr ""
-

--- a/currency_rate_update/i18n/fr_FR.po
+++ b/currency_rate_update/i18n/fr_FR.po
@@ -1,31 +1,42 @@
 # Translation of OpenERP Server.
 # This file contains the translation of the following modules:
-#	* c2c_currency_rate_update
+# 	* c2c_currency_rate_update
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.0\n"
-"Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2013-10-18 17:52+0000\n"
-"PO-Revision-Date: 2013-11-11 16:24+0000\n"
-"Last-Translator: Alexandre Fayolle - camptocamp "
-"<alexandre.fayolle@camptocamp.com>\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-04-15 20:27+0000\n"
+"PO-Revision-Date: 2015-04-15 16:34-0500\n"
+"Last-Translator: Sandy Carter <sandy.carter@savoirfairelinux.com>\n"
 "Language-Team: \n"
+"Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2014-06-12 06:31+0000\n"
-"X-Generator: Launchpad (build 17041)\n"
+"X-Generator: Poedit 1.7.5\n"
 
 #. module: currency_rate_update
-#: view:res.company:0
-msgid "Currency auto update configuration"
-msgstr "Configuration de la mise à jour automatique des taux de change"
+#: code:addons/currency_rate_update/currency_rate_update.py:225
+#, python-format
+msgid "There is no base currency set!"
+msgstr "Il n'y a pas de taux de change de base définie !"
+
+#. module: currency_rate_update
+#: field:res.company,interval_type:0
+msgid "Currency update frequency"
+msgstr "Fréquence de mise à jour"
 
 #. module: currency_rate_update
 #: view:res.company:0
 msgid "Currency updates services"
 msgstr "Services de mise à jour des taux de change"
+
+#. module: currency_rate_update
+#: selection:currency.rate.update.service,service:0
+msgid "Bank of Canada - noon rates"
+msgstr "Banque du Canada - taux du midi"
 
 #. module: currency_rate_update
 #: field:currency.rate.update.service,company_id:0
@@ -34,13 +45,19 @@ msgstr "Société liée"
 
 #. module: currency_rate_update
 #: view:currency.rate.update.service:0
-msgid "Rate"
+msgid "Rates"
 msgstr "Taux de change"
 
 #. module: currency_rate_update
-#: view:currency.rate.update.service:0
-msgid "Rates"
-msgstr "Taux de change"
+#: code:addons/currency_rate_update/currency_rate_update.py:832
+#, python-format
+msgid "Errors occurred during update"
+msgstr "Des erreur on eu lieu lors de la mise à jour"
+
+#. module: currency_rate_update
+#: view:res.company:0
+msgid "Refresh Currencies"
+msgstr "Mettre à jour les taux de change"
 
 #. module: currency_rate_update
 #: field:res.company,multi_company_currency_enable:0
@@ -48,14 +65,15 @@ msgid "Multi company currency"
 msgstr "Devies mutli société"
 
 #. module: currency_rate_update
-#: field:res.company,interval_type:0
-msgid "Currency update frequence"
-msgstr "Fréquence de mise à jour"
-
-#. module: currency_rate_update
 #: selection:res.company,interval_type:0
 msgid "Day(s)"
 msgstr "Quotidien"
+
+#. module: currency_rate_update
+#: code:addons/currency_rate_update/company.py:53
+#, python-format
+msgid "Errors occurred during update:\n"
+msgstr "Des erreur on eu lieu lors de la mise à jour :\n"
 
 #. module: currency_rate_update
 #: field:currency.rate.update.service,currency_to_update:0
@@ -78,39 +96,60 @@ msgid "Webservice to use"
 msgstr "Service web à utliser"
 
 #. module: currency_rate_update
-#: help:currency.rate.update.service,max_delta_days:0
+#: view:currency.rate.update.service:0
+msgid "Rate"
+msgstr "Taux de change"
+
+#. module: currency_rate_update
+#: field:res.company,auto_currency_up:0
+msgid "Automatic update of the currency this company"
+msgstr "Mise à jour automatique des taux de change"
+
+#. module: currency_rate_update
+#: selection:currency.rate.update.service,service:0
+msgid "European Central Bank"
+msgstr "Banque centrale européenne"
+
+#. module: currency_rate_update
+#: help:res.company,multi_company_currency_enable:0
 msgid ""
-"If the time delta between the rate date given by the webservice and the "
-"current date exeeds this value, then the currency rate is not updated in "
-"OpenERP."
+"If this case is not check you can not set currency is active on two company"
 msgstr ""
+"Si cette case n'est pas cochée vous ne pouvez pas utiliser la mise à jour "
+"sur plusieurs sociétés"
 
 #. module: currency_rate_update
-#: field:res.company,services_to_use:0
-msgid "Currency update services"
-msgstr "Service de mise à jour des taux de change"
+#: help:res.company,interval_type:0
+msgid "Changing this value will also affect other companies"
+msgstr "Modifier cette devise va aussi affecter les autre sociétés"
 
 #. module: currency_rate_update
-#: constraint:currency.rate.update.service:0
-msgid "'Max delta days' must be >= 0"
-msgstr ""
-
-#. module: currency_rate_update
-#: code:addons/currency_rate_update/currency_rate_update.py:89
+#: code:addons/currency_rate_update/currency_rate_update.py:114
 #: sql_constraint:currency.rate.update.service:0
 #, python-format
 msgid "You can use a service one time per company !"
 msgstr "Vous ne pouvez utiliser un service qu'une fois par société"
 
 #. module: currency_rate_update
+#: help:currency.rate.update.service,max_delta_days:0
+msgid ""
+"If the time delta between the rate date given by the webservice and the "
+"current date exceeds this value, then the currency rate is not updated in "
+"OpenERP."
+msgstr ""
+"Si le delta de temps entre le taux donné par le service et la date "
+"courante excèdent cette valeur, ce taux de change ne sera pas mis à jour "
+"dans OpenERP."
+
+#. module: currency_rate_update
 #: selection:currency.rate.update.service,service:0
 msgid "Yahoo Finance "
-msgstr ""
+msgstr "Yahoo Finance "
 
 #. module: currency_rate_update
 #: field:currency.rate.update.service,max_delta_days:0
 msgid "Max delta days"
-msgstr ""
+msgstr "Delta de jours maximum"
 
 #. module: currency_rate_update
 #: selection:currency.rate.update.service,service:0
@@ -118,14 +157,26 @@ msgid "Admin.ch"
 msgstr ""
 
 #. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:822
+#, python-format
+msgid "Exchange data format error for Bank of Canada - %s"
+msgstr "Erreur de format de donnés pour Banque du Canada - %s"
+
+#. module: currency_rate_update
 #: model:ir.model,name:currency_rate_update.model_res_company
 msgid "Companies"
-msgstr ""
+msgstr "Sociétés"
 
 #. module: currency_rate_update
 #: view:currency.rate.update.service:0
-msgid "Currencies to update with this service"
-msgstr ""
+msgid "Currencies to Update with this Service"
+msgstr "Taux de change à mettre à jour avec ce service"
+
+#. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:224
+#, python-format
+msgid "Error!"
+msgstr "Erreur !"
 
 #. module: currency_rate_update
 #: selection:res.company,interval_type:0
@@ -133,15 +184,29 @@ msgid "Week(s)"
 msgstr "Hebdomadaire"
 
 #. module: currency_rate_update
-#: help:res.company,multi_company_currency_enable:0
-msgid ""
-"if this case is not check you can not set currency is active on two company"
-msgstr ""
-"Si cette case n'est pas cochée vous ne pouvez pas utiliser la mise à jour "
-"sur plusieurs sociétés"
+#: code:addons/currency_rate_update/company.py:52
+#: code:addons/currency_rate_update/currency_rate_update.py:229
+#: code:addons/currency_rate_update/currency_rate_update.py:742
+#: code:addons/currency_rate_update/currency_rate_update.py:821
+#, python-format
+msgid "Error"
+msgstr "Erreur"
 
 #. module: currency_rate_update
-#: code:addons/currency_rate_update/currency_rate_update.py:153
+#: field:res.company,services_to_use:0
+msgid "Currency update services"
+msgstr "Service de mise à jour des taux de change"
+
+#. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:743
+#, python-format
+msgid "Exchange data for %s is not reported by Bank of Canada."
+msgstr ""
+"Les donnés de taux de change %s ne sont pas reportés par la Banque du "
+"Canada."
+
+#. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:184
 #: model:ir.model,name:currency_rate_update.model_currency_rate_update
 #: model:ir.model,name:currency_rate_update.model_currency_rate_update_service
 #, python-format
@@ -151,12 +216,27 @@ msgstr "Mise à jour des taux de change"
 #. module: currency_rate_update
 #: view:currency.rate.update.service:0
 msgid "Logs"
+msgstr "Logs"
+
+#. module: currency_rate_update
+#: selection:currency.rate.update.service,service:0
+msgid "Banco de México"
 msgstr ""
 
 #. module: currency_rate_update
-#: field:res.company,auto_currency_up:0
-msgid "Automatical update of the currency this company"
-msgstr "Mise à jour automatique des taux de change"
+#: view:res.company:0
+msgid "Currency Auto Update Configuration"
+msgstr "Configuration de la mise à jour automatique des taux de change"
+
+#. module: currency_rate_update
+#: code:addons/currency_rate_update/currency_rate_update.py:230
+#, python-format
+msgid ""
+"Base currency rate should be 1.00.\n"
+"Currency %s has rate of %f"
+msgstr ""
+"La devise de base devrait être 1.00.\n"
+"Cette devise %s a un taux de %f"
 
 #. module: currency_rate_update
 #: selection:res.company,interval_type:0
@@ -164,18 +244,6 @@ msgid "Month(s)"
 msgstr "Mensuelle"
 
 #. module: currency_rate_update
-#: selection:currency.rate.update.service,service:0
-msgid "European Central Bank"
-msgstr ""
-
-#. module: currency_rate_update
-#: help:res.company,interval_type:0
-msgid ""
-"changing this value will\n"
-"                                                 also affect other compagnies"
-msgstr "Modifier cette devise va aussi affecter les autre sociétés"
-
-#. module: currency_rate_update
-#: view:res.company:0
-msgid "Refresh currencies"
-msgstr "Mettre à jour les taux de change"
+#: constraint:currency.rate.update.service:0
+msgid "'Max delta days' must be >= 0"
+msgstr "'Le maximum du delta des jours doit être >= 0"

--- a/currency_rate_update/migrations/7.0.0.8/post-migrate.py
+++ b/currency_rate_update/migrations/7.0.0.8/post-migrate.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from openerp import pooler, SUPERUSER_ID
+
+
+state_renames = {
+    'currency.rate.update.service': {
+        'service': [
+            ('CA_BOC_getter', 'BankOfCanadaGetter'),
+        ],
+    },
+}
+
+
+def rename_states(cr, pool, state_renames):
+    """Rename states from an old name to new name
+
+    :param cr: Database Cursor
+    :param pool: ORM registry
+    :param state_renames: State Renames declaration
+    :type state_renames: dict of dict with list of tuple
+    """
+    for model_name, field_renames in state_renames.iteritems():
+        model_pool = pool[model_name]
+        for field_name, state_rename_spec in field_renames.iteritems():
+            src, dest = state_rename_spec
+            ids = model_pool.search(cr, SUPERUSER_ID, [(field_name, '=', src)])
+            model_pool.write(cr, SUPERUSER_ID, ids, {field_name: dest})
+
+
+def migrate(cr, version):
+    """Migration entry point
+
+    :param cr: Database Cursor
+    :param version: Odoo and module versions
+    """
+    if version is None:
+        return
+    pool = pooler.get_pool(cr.dbname)
+    rename_states(cr, pool, state_renames)

--- a/currency_rate_update/tests/__init__.py
+++ b/currency_rate_update/tests/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from . import test_bank_of_canada
+
+
+checks = [
+    test_bank_of_canada,
+]

--- a/currency_rate_update/tests/test_bank_of_canada.py
+++ b/currency_rate_update/tests/test_bank_of_canada.py
@@ -22,7 +22,8 @@ from unittest2 import TestCase
 from openerp.osv.orm import except_orm
 
 from openerp.tests.common import TransactionCase
-from ..currency_rate_update import BankOfCanadaGetter
+from openerp.addons.currency_rate_update import currency_rate_update
+BankOfCanadaGetter = currency_rate_update.BankOfCanadaGetter
 
 
 class TestBankOfCanada(TransactionCase):

--- a/currency_rate_update/tests/test_bank_of_canada.py
+++ b/currency_rate_update/tests/test_bank_of_canada.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from unittest2 import TestCase
+from openerp.osv.orm import except_orm
+
+from openerp.tests.common import TransactionCase
+from ..currency_rate_update import BankOfCanadaGetter
+
+
+class TestBankOfCanada(TransactionCase):
+
+    def setUp(self):
+        """Test the Bank of Canada Service on the main company"""
+        super(TestBankOfCanada, self).setUp()
+        # Get context
+        self.user_model = self.registry("res.users")
+        self.context = self.user_model.context_get(self.cr, self.uid)
+
+        currency_cad = self.browse_ref("base.CAD")
+        # Set to base currency, must be 1.0
+        currency_cad.write({"base": True, "rate_ids": [(0, 0, {"rate": 1.0})]})
+        self.company = self.browse_ref("base.main_company")
+        self.company.write({
+            "auto_currency_up": True,
+            "services_to_use": [(0, 0, {
+                "service": "BankOfCanadaGetter",
+                "currency_to_update": [(6, 0, [
+                    self.ref("base.CAD"),
+                    self.ref("base.USD"),
+                    self.ref("base.EUR"),
+                ])],
+            })],
+        })
+
+    def test_refresh_currency(self):
+        self.assertTrue(
+            self.registry("res.company").button_refresh_currency(
+                self.cr, self.uid, ids=None, context=self.context
+            )
+        )
+
+
+class TestBankOfCanadaGetter(TestCase):
+
+    def setUp(self):
+        """Test the Bank of Canada Service on the main company"""
+        self.getter = BankOfCanadaGetter()
+
+    def test_bad_currency(self):
+        """ALL should not be in Bank of Canada's currencies"""
+        with self.assertRaises(except_orm):
+            self.getter.get_updated_currency(
+                currencies=["ALL"],
+                main_currency="CAD",
+                max_delta_days=4,
+            )


### PR DESCRIPTION
The purpose of this PR was originally to fix the implementation with Bank of Canada
I found that it now appends _NOON to currencies on the way back, so post get verification failed.
It was fixed in 6e79bcf with just a `startswith`

I found a lot of Spelling mistakes, unclear function names, pointless java-like classes and exception declarations. These were fixed and the code was made more pythonic.

I allow exceptions to go further up the stack to reach the user when manually running the checks. Previously it would just fail silently.

Tests were added to test updates of Bank of Canada.
