### PR TITLE
FIX currency_rate_update - Bank of Canada error

### DIFF
--- a/currency_rate_update/README.rst
+++ b/currency_rate_update/README.rst
@@ -30,7 +30,10 @@ The module is able to use the following sources:
 5. Banxico for USD & MXN (created by Agustín Cruz)
    Updated daily
 
-6. Bank of Canada
+6. Bank of Canada - noon rates (by Daniel Dico - OERP Canada)
+   Using RSS feeds from: http://www.bankofcanada.ca/rss-feeds/
+   Updated daily (except weekends and holidays).
+   Noon and Closing rates available - this module is using the noon rates.
 
 7. National Bank of Romania (Banca Nationala a Romaniei)
 
@@ -92,6 +95,7 @@ Contributors
 * Agustin Cruz <openpyme.mx> (BdM)
 * Dorin Hongu <dhongu@gmail.com> (BNR)
 * Fekete Mihai <feketemihai@gmail.com> (Port to V8)
+* Daniel Dico <dd@oerp.ca> (BoC)
 
 Maintainer
 ----------

--- a/currency_rate_update/services/update_service_CA_BOC.py
+++ b/currency_rate_update/services/update_service_CA_BOC.py
@@ -40,6 +40,8 @@ class CA_BOC_getter(Currency_getter_interface):
         """implementation of abstract method of Curreny_getter_interface"""
 
         # as of Jan 2014 BOC is publishing noon rates for about 60 currencies
+        # currency codes in the XML file have the suffix "_NOON" or "_CLOSE" as
+        # of April 2015
         url = ('http://www.bankofcanada.ca/stats/assets/'
                'rates_rss/noon/en_%s.xml')
         # closing rates are available as well (please note there are only 12
@@ -78,7 +80,7 @@ class CA_BOC_getter(Currency_getter_interface):
 
             # check for valid exchange data
             if (dom.entries[0].cb_basecurrency == main_currency) and \
-                    (dom.entries[0].cb_targetcurrency == curr):
+                    (dom.entries[0].cb_targetcurrency[:3] == curr):
                 rate = dom.entries[0].cb_exchangerate.split('\n', 1)[0]
                 rate_date_datetime = parser.parse(dom.entries[0].updated)\
                     .astimezone(pytz.utc).replace(tzinfo=None)


### PR DESCRIPTION
- Earlier this month Bank of Canada has added the suffix "_NOON" and "_CLOSE"
  to the currency code in the XML file triggering an error to the existing code.
- Assign credits as per f79cc06
