### PR TITLE
Add update_posted in journal items to display or not the button cancel

### DIFF
--- a/account_default_draft_move/account.py
+++ b/account_default_draft_move/account.py
@@ -62,7 +62,7 @@ class AccountMove(models.Model):
         can_cancel = ir_module.search([('name', '=', 'account_cancel'),
                                        ('state', '=', 'installed')])
         for move in self:
-            self.update_posted = can_cancel and move.journal_id.update_posted
+            move.update_posted = can_cancel and move.journal_id.update_posted
 
     update_posted = fields.Boolean(compute='_is_update_posted',
                                    string='Allow Cancelling Entries')

--- a/account_default_draft_move/account.py
+++ b/account_default_draft_move/account.py
@@ -17,7 +17,7 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ##############################################################################
 
-from openerp import models, api, exceptions, _
+from openerp import models, api, fields, exceptions, _
 
 
 class AccountInvoice(models.Model):
@@ -55,3 +55,14 @@ class AccountMove(models.Model):
                              'SET state=%s '
                              'WHERE id IN %s', ('draft', tuple(self.ids)))
         return True
+
+    @api.multi
+    def _is_update_posted(self):
+        ir_module = self.env['ir.module.module']
+        can_cancel = ir_module.search([('name', '=', 'account_cancel'),
+                                       ('state', '=', 'installed')])
+        for move in self:
+            self.update_posted = can_cancel and move.journal_id.update_posted
+
+    update_posted = fields.Boolean(compute='_is_update_posted',
+                                   string='Allow Cancelling Entries')

--- a/account_default_draft_move/account_view.xml
+++ b/account_default_draft_move/account_view.xml
@@ -8,7 +8,12 @@
       <field name="arch" type="xml">
         <data>
           <button name="button_validate" position="replace"/>
-          <button name="button_cancel" position="replace"/>
+          <button name="button_cancel" position="after">
+            <field name="update_posted" invisible="1"/>
+          </button>
+          <button name="button_cancel" position="attributes">
+            <attribute name="attrs">{'invisible': ['|', ('update_posted', '=', False)]}</attribute>
+          </button>
         </data>
       </field>
     </record>


### PR DESCRIPTION
The goal is to use update_posted set on journal to display the cancel button on account_move.

As suggest by @sbidoul in #150, I "make the cancel button appear only if update_posted is true and account_cancel is installed".

Forward port of #175 
