### PR TITLE
currency_rate_update v7 : Issue in 7.0.0.8 post_migrate script

### DIFF
--- a/currency_rate_update/migrations/7.0.0.8/post-migrate.py
+++ b/currency_rate_update/migrations/7.0.0.8/post-migrate.py
@@ -24,7 +24,7 @@ def rename_states(cr, pool, state_renames):
         for field_name, old_new_values in field_renames.iteritems():
             for old_new_value in old_new_values:
                 src, dest = old_new_value
-                ids = model_pool.search(cr, SUPERUSER_ID, 
+                ids = model_pool.search(cr, SUPERUSER_ID,
                                         [(field_name, '=', src)])
                 model_pool.write(cr, SUPERUSER_ID, ids, {field_name: dest})
 

--- a/currency_rate_update/migrations/7.0.0.8/post-migrate.py
+++ b/currency_rate_update/migrations/7.0.0.8/post-migrate.py
@@ -24,7 +24,8 @@ def rename_states(cr, pool, state_renames):
         for field_name, old_new_values in field_renames.iteritems():
             for old_new_value in old_new_values:
                 src, dest = old_new_value
-                ids = model_pool.search(cr, SUPERUSER_ID, [(field_name, '=', src)])
+                ids = model_pool.search(cr, SUPERUSER_ID,
+                                        [(field_name, '=', src)])
                 model_pool.write(cr, SUPERUSER_ID, ids, {field_name: dest})
 
 

--- a/currency_rate_update/migrations/7.0.0.8/post-migrate.py
+++ b/currency_rate_update/migrations/7.0.0.8/post-migrate.py
@@ -21,10 +21,11 @@ def rename_states(cr, pool, state_renames):
     """
     for model_name, field_renames in state_renames.iteritems():
         model_pool = pool[model_name]
-        for field_name, state_rename_spec in field_renames.iteritems():
-            src, dest = state_rename_spec
-            ids = model_pool.search(cr, SUPERUSER_ID, [(field_name, '=', src)])
-            model_pool.write(cr, SUPERUSER_ID, ids, {field_name: dest})
+        for field_name, old_new_values in field_renames.iteritems():
+            for old_new_value in old_new_values:
+                src, dest = old_new_value
+                ids = model_pool.search(cr, SUPERUSER_ID, [(field_name, '=', src)])
+                model_pool.write(cr, SUPERUSER_ID, ids, {field_name: dest})
 
 
 def migrate(cr, version):

--- a/currency_rate_update/migrations/7.0.0.8/post-migrate.py
+++ b/currency_rate_update/migrations/7.0.0.8/post-migrate.py
@@ -24,7 +24,8 @@ def rename_states(cr, pool, state_renames):
         for field_name, old_new_values in field_renames.iteritems():
             for old_new_value in old_new_values:
                 src, dest = old_new_value
-                ids = model_pool.search(cr, SUPERUSER_ID, [(field_name, '=', src)])
+                ids = model_pool.search(cr, SUPERUSER_ID, 
+                                        [(field_name, '=', src)])
                 model_pool.write(cr, SUPERUSER_ID, ids, {field_name: dest})
 
 


### PR DESCRIPTION
Hello,

When trying to update my Odoo, I get an error because of the post_migrate script of the v7 branch: 
File "currency_rate_update/migrations/7.0.0.8/post-migrate.py", line 39, in migrate
File "currency_rate_update/migrations/7.0.0.8/post-migrate.py", line 25, in rename_states
ValueError: need more than 1 value to unpack

Check issue https://github.com/OCA/account-financial-tools/issues/208
