### PR TITLE
[FIX][account_credit_control] Do not link e-mails to Transient records

### DIFF
--- a/account_credit_control/wizard/credit_control_communication.py
+++ b/account_credit_control/wizard/credit_control_communication.py
@@ -194,7 +194,10 @@ class CreditCommunication(models.TransientModel):
                                                              comm.id,
                                                              context=context)
             email_values['type'] = 'email'
-
+            # model is Transient record (self) removed periodically so no point
+            # of storing res_id
+            email_values.pop('model', None)
+            email_values.pop('res_id', None)
             email = email_message_obj.create(email_values)
 
             state = 'sent'


### PR DESCRIPTION
Transient records are deleted periodically so res_id will point to ID which
does not exists. And when reading email records system would also check if
res_id can be read by user which would cause an exception because res_id
might not exist at that point.
