### PR TITLE
[IMP][account_asset_management] Define a list of move's fields that can't be modified if a move is linked with a depriciation line

### DIFF
--- a/account_asset_management/account_move.py
+++ b/account_asset_management/account_move.py
@@ -28,7 +28,7 @@ _logger = logging.getLogger(__name__)
 
 # List of move's fields that can't be modified if move is linked
 # with a depreciation line
-FIELDS_AFFETCS_ASSET_MOVE = ['period_id', 'journal_id', 'date']
+FIELDS_AFFETCS_ASSET_MOVE = set(['period_id', 'journal_id', 'date'])
 
 
 class account_move(orm.Model):
@@ -55,7 +55,7 @@ class account_move(orm.Model):
             cr, uid, ids, context=context, check=check)
 
     def write(self, cr, uid, ids, vals, context=None):
-        if set(vals).intersection(set(FIELDS_AFFETCS_ASSET_MOVE)):
+        if set(vals).intersection(FIELDS_AFFETCS_ASSET_MOVE):
             if isinstance(ids, (int, long)):
                 ids = [ids]
             depr_obj = self.pool.get('account.asset.depreciation.line')

--- a/account_asset_management/account_move.py
+++ b/account_asset_management/account_move.py
@@ -29,6 +29,10 @@ _logger = logging.getLogger(__name__)
 # List of move's fields that can't be modified if move is linked
 # with a depreciation line
 FIELDS_AFFECTS_ASSET_MOVE = set(['period_id', 'journal_id', 'date'])
+# List of move line's fields that can't be modified if move is linked
+# with a depreciation line
+FIELDS_AFFECTS_ASSET_MOVE_LINE = \
+    set(['credit', 'debit', 'account_id', 'journal_id', 'date'])
 
 
 class account_move(orm.Model):
@@ -128,6 +132,13 @@ class account_move_line(orm.Model):
 
     def write(self, cr, uid, ids, vals,
               context=None, check=True, update_check=True):
+        for move_line in self.browse(cr, uid, ids, context=context):
+            if move_line.asset_id.id:
+                if set(vals).intersection(FIELDS_AFFECTS_ASSET_MOVE_LINE):
+                    raise orm.except_orm(
+                        _('Error!'),
+                        _("You cannot change an accounting item "
+                          "linked to an asset depreciation line."))
         if vals.get('asset_id'):
             raise orm.except_orm(
                 _('Error!'),

--- a/account_asset_management/account_move.py
+++ b/account_asset_management/account_move.py
@@ -26,6 +26,10 @@ from openerp.tools.translate import _
 import logging
 _logger = logging.getLogger(__name__)
 
+# List of move's fields that can't be modified if move is linked
+# with a depreciation line
+FIELDS_AFFETCS_ASSET_MOVE = ['period_id', 'journal_id', 'date']
+
 
 class account_move(orm.Model):
     _inherit = 'account.move'
@@ -51,7 +55,7 @@ class account_move(orm.Model):
             cr, uid, ids, context=context, check=check)
 
     def write(self, cr, uid, ids, vals, context=None):
-        if vals:
+        if set(vals).intersection(set(FIELDS_AFFETCS_ASSET_MOVE)):
             if isinstance(ids, (int, long)):
                 ids = [ids]
             depr_obj = self.pool.get('account.asset.depreciation.line')

--- a/account_asset_management/account_move.py
+++ b/account_asset_management/account_move.py
@@ -28,7 +28,7 @@ _logger = logging.getLogger(__name__)
 
 # List of move's fields that can't be modified if move is linked
 # with a depreciation line
-FIELDS_AFFETCS_ASSET_MOVE = set(['period_id', 'journal_id', 'date'])
+FIELDS_AFFECTS_ASSET_MOVE = set(['period_id', 'journal_id', 'date'])
 
 
 class account_move(orm.Model):
@@ -55,7 +55,7 @@ class account_move(orm.Model):
             cr, uid, ids, context=context, check=check)
 
     def write(self, cr, uid, ids, vals, context=None):
-        if set(vals).intersection(FIELDS_AFFETCS_ASSET_MOVE):
+        if set(vals).intersection(FIELDS_AFFECTS_ASSET_MOVE):
             if isinstance(ids, (int, long)):
                 ids = [ids]
             depr_obj = self.pool.get('account.asset.depreciation.line')

--- a/account_asset_management/account_move.py
+++ b/account_asset_management/account_move.py
@@ -32,7 +32,8 @@ FIELDS_AFFECTS_ASSET_MOVE = set(['period_id', 'journal_id', 'date'])
 # List of move line's fields that can't be modified if move is linked
 # with a depreciation line
 FIELDS_AFFECTS_ASSET_MOVE_LINE = \
-    set(['credit', 'debit', 'account_id', 'journal_id', 'date'])
+    set(['credit', 'debit', 'account_id', 'journal_id', 'date',
+         'asset_category_id', 'asset_id', 'tax_code_id', 'tax_amount'])
 
 
 class account_move(orm.Model):


### PR DESCRIPTION
Currently, isn't possible to change some fields on a move if it's linked with a depriciation line.
This process can produce some problems if you want to change the value of a field that does not matter for depreciation.
Let me take an exemple. For this moment, isn't possible to validate moves with account_move_batch_validate (OCA/account-financial-tools) because this module attempts to write job_uuid on the move. 
