### PR TITLE
8.0 account_credit_control: small enhancements

### DIFF
--- a/account_credit_control/credit_control_demo.xml
+++ b/account_credit_control/credit_control_demo.xml
@@ -26,5 +26,14 @@
       <field eval="True" name="reconcile"/>
       <field name="user_type" ref="account.data_account_type_receivable"/>
     </record>
+
+    <record id="base.user_root" model="res.users">
+      <field name="groups_id" eval="[(4, ref('group_account_credit_control_manager')), (4, ref('group_account_credit_control_user'))]"/>
+    </record>
+
+    <record id="base.user_demo" model="res.users">
+      <field name="groups_id" eval="[(4, ref('group_account_credit_control_user'))]"/>
+    </record>
+
   </data>
 </openerp>

--- a/account_credit_control/line.py
+++ b/account_credit_control/line.py
@@ -130,7 +130,7 @@ class CreditControlLine(models.Model):
                                 store=True,
                                 readonly=True)
 
-    level = fields.Integer('credit.control.policy.level',
+    level = fields.Integer(string='Policy Level',
                            related='policy_level_id.level',
                            store=True,
                            readonly=True)


### PR DESCRIPTION
Fix integer field definition
Automatically add admin and demo user to credit control groups, for easier testing
