### PR TITLE
[FIX] common.DB does not exist anymore in stable 8.0

### DIFF
--- a/account_constraints/tests/test_account_constraints.py
+++ b/account_constraints/tests/test_account_constraints.py
@@ -32,9 +32,6 @@ from datetime import datetime
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
 from openerp import workflow, exceptions
 
-DB = common.DB
-ADMIN_USER_ID = common.ADMIN_USER_ID
-
 
 def create_simple_invoice(self):
     partner_id = self.ref('base.res_partner_2')

--- a/account_default_draft_move/tests/test_account_default_draft_move.py
+++ b/account_default_draft_move/tests/test_account_default_draft_move.py
@@ -32,9 +32,6 @@ from datetime import datetime
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
 from openerp import workflow
 
-DB = common.DB
-ADMIN_USER_ID = common.ADMIN_USER_ID
-
 
 def create_simple_invoice(self):
     partner_id = self.ref('base.res_partner_2')

--- a/account_invoice_constraint_chronology/tests/test_account_constraint_chronology.py
+++ b/account_invoice_constraint_chronology/tests/test_account_constraint_chronology.py
@@ -33,9 +33,6 @@ from openerp import exceptions
 from datetime import datetime, timedelta
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
 
-DB = common.DB
-ADMIN_USER_ID = common.ADMIN_USER_ID
-
 
 def get_simple_product_id(self):
     return self.env['product.product'].create({'name': 'product_test_01',

--- a/account_journal_period_close/tests/test_account_journal_period_close.py
+++ b/account_journal_period_close/tests/test_account_journal_period_close.py
@@ -32,9 +32,6 @@ from openerp.exceptions import except_orm
 from datetime import datetime
 from psycopg2 import IntegrityError
 
-DB = common.DB
-ADMIN_USER_ID = common.ADMIN_USER_ID
-
 
 def get_simple_account_move_values(self, period_id, journal_id):
     sale_product_account_id = self.ref('account.a_sale')


### PR DESCRIPTION
It was not used in these tests anyway.

This commit removed it, breaking all tests depending on common.DB https://github.com/odoo/odoo/commit/2df9060d97a201c2f54c6d79af13ffca45f91cef
