### PR TITLE
[FIX] account_chart_update: Call mapping function instead of removed cache. Closes #240

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -966,7 +966,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                               mapping_accounts):
         root_account_id = self.chart_template_id.account_root_id.id
         # Get the taxes
-        taxes = [self._tax_mapping[tax_template]
+        taxes = [self.map_tax_template(tax_template, mapping_taxes)
                  for tax_template in account_template.tax_ids
                  if self.map_tax_template(tax_template, mapping_taxes)]
         # Calculate the account code (we need to add zeros to non-view


### PR DESCRIPTION
Some remainder from the cache system that I finally removed.
