### PR TITLE
[FIX] fix security issue on account_invoice

### DIFF
--- a/account_credit_control/invoice.py
+++ b/account_credit_control/invoice.py
@@ -34,6 +34,9 @@ class AccountInvoice(models.Model):
              "setting.",
         readonly=True,
         copy=False,
+        groups="account_credit_control.group_account_credit_control_manager,"
+               "account_credit_control.group_account_credit_control_user,"
+               "account_credit_control.group_account_credit_control_info",
     )
 
     credit_control_line_ids = fields.One2many(


### PR DESCRIPTION
This fix seems ugly, but I can't figure why I've a security error when an invoice is  displayed for a user without right on credit_control despite the attribute 'groups' declared on the field definition in the form view.
![image](https://cloud.githubusercontent.com/assets/544090/8377250/037308c8-1c10-11e5-9dbe-64d795b05190.png)
