### PR TITLE
[FIX] account_asset_asset: compute_depreciation_board

### DIFF
--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -724,6 +724,18 @@ class account_asset_asset(orm.Model):
                              entry['date_stop']))
                         res = cr.fetchone()
                         fy_amount_check = res[0]
+
+                        # ensure fy_amount_check contains depreciation for the
+                        # current entry period
+                        def diff_month(d1, d2):
+                            return (d1.year - d2.year) * 12 + \
+                                   d1.month - d2.month
+                        nb_months = diff_month(
+                            entry['date_start'],
+                            datetime.strptime(asset.date_start, "%Y-%m-%d"))
+                        if nb_months > 0:
+                            fy_amount_check -= nb_months * entry['period_amount']
+
                     else:
                         fy_amount_check = 0.0
                     lines = entry['lines']


### PR DESCRIPTION
When the date of the last depreciation line marked as init entry does not match the asset start date, the compute_depreciation_board method fails to a linear depreciation. This fix ensures the depreciation remains linear in such case.
For example, let's consider the following asset:
![selection_001](https://cloud.githubusercontent.com/assets/916109/8398238/b6a0036a-1de6-11e5-9a86-0fd3de61f4cd.png)

Some of the depreciation of this asset has already been accounted using another accounting software.
So we have a depreciation line marked as init_entry=True with a depreciation amount corresponding to:
- the depreciation from all the previous (closed) periods;
- the depreciation for the current (still opened) period.
  (see picture below)
  ![selection_002](https://cloud.githubusercontent.com/assets/916109/8398262/67cd53c2-1de7-11e5-834e-5b4504554adf.png)

In such case, when we hit the compute button, we have the following behaviour:
![selection_003](https://cloud.githubusercontent.com/assets/916109/8398266/72dfeaa4-1de7-11e5-8a65-2912856f5489.png)

As you can see, the last depreciation line of the current period is wrong. The method `compute_depreciation_board` from `account_asset_asset` has erroneously taken into account the depreciation coming from the previous period.

This fix just removes the depreciation part coming from the older periods to ensure a linear depreciation.
