### PR TITLE
[FIX] account_asset_asset: compute_depreciation_board

### DIFF
--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -606,6 +606,20 @@ class account_asset_asset(orm.Model):
         return (asset.code or str(asset.id)) + '/' + str(seq)
 
     def compute_depreciation_board(self, cr, uid, ids, context=None):
+        """
+        Computes and stores depreciation lines for the given asset ids.
+
+        CAUTION: make sure the last depreciation line with init_entry=True
+        contains only depreciated amount for its respective fiscal year or this
+        method may compute wrong depreciation lines.
+
+        :param cr: database cursor
+        :param uid: current user id
+        :param ids: ids of account.asset
+        :param context: context arguments, like lang, time zone
+        :type context: dictionary
+        :return: Returns True
+        """
         if not context:
             context = {}
         depreciation_lin_obj = self.pool.get(


### PR DESCRIPTION
When the date of the last depreciation line marked as init entry does not match the asset start date, the compute_depreciation_board method fails to a linear depreciation. This fix ensures the depreciation remains linear in such case.
For example, let's consider the following asset:
![selection_001](https://cloud.githubusercontent.com/assets/916109/8398238/b6a0036a-1de6-11e5-9a86-0fd3de61f4cd.png)

Some of the depreciation of this asset has already been accounted using another accounting software.
So we have a depreciation line marked as init_entry=True with a depreciation amount corresponding to:
- the depreciation from all the previous (closed) periods;
- the depreciation for the current (still opened) period.
  (see picture below)
  ![selection_002](https://cloud.githubusercontent.com/assets/916109/8398262/67cd53c2-1de7-11e5-834e-5b4504554adf.png)

In such case, when we hit the compute button, we have the following behaviour:
![selection_003](https://cloud.githubusercontent.com/assets/916109/8398266/72dfeaa4-1de7-11e5-8a65-2912856f5489.png)

As you can see, the last depreciation line of the current period is wrong. The method `compute_depreciation_board` from `account_asset_asset` has erroneously taken into account the depreciation coming from the previous period.

This fix just removes the depreciation part coming from the older periods to ensure a linear depreciation.
