### PR TITLE
account_asset_management : import asset

### DIFF
--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -1480,6 +1480,21 @@ class account_asset_depreciation_line(orm.Model):
                 'remaining_value': asset_value - depreciated_value - amount}
         return res
 
+    def create(self, cr, uid, vals, context=None):
+        if not context:
+            context = {}
+        if not vals.get('previous_id') and vals.get('asset_id'):
+            # check if there is a previous line and set the previous line
+            cr.execute(
+                "SELECT id FROM account_asset_depreciation_line "
+                "WHERE asset_id = %s "
+                "ORDER BY type, line_date" % vals.get('asset_id'))
+            previous = cr.fetchone()
+            if previous:
+                vals['previous_id'] = previous
+        return super(account_asset_depreciation_line, self).create(
+            cr, uid, vals, context=context)
+
     def unlink(self, cr, uid, ids, context=None):
         for dl in self.browse(cr, uid, ids, context):
             if dl.type == 'create':

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -614,12 +614,9 @@ class account_asset_asset(orm.Model):
         for asset in self.browse(cr, uid, ids, context=context):
             if asset.value_residual == 0.0:
                 continue
-            domain = [
-                ('asset_id', '=', asset.id),
-                ('type', '=', 'depreciate'),
-                '|', ('move_check', '=', True), ('init_entry', '=', True)]
-            posted_depreciation_line_ids = depreciation_lin_obj.search(
-                cr, uid, domain, order='line_date desc')
+            posted_depreciation_line_ids = \
+                depreciation_lin_obj._get_posted_depreciation_line_ids(
+                    cr, uid, asset.id, context=context)
             if (len(posted_depreciation_line_ids) > 0):
                 last_depreciation_line = depreciation_lin_obj.browse(
                     cr, uid, posted_depreciation_line_ids[0], context=context)
@@ -1480,18 +1477,23 @@ class account_asset_depreciation_line(orm.Model):
                 'remaining_value': asset_value - depreciated_value - amount}
         return res
 
+    def _get_posted_depreciation_line_ids(self, cr, uid, asset_id, context=None):
+        domain = [('asset_id', '=', asset_id),
+                  ('type', '=', 'depreciate'),
+                  '|', ('move_check', '=', True), ('init_entry', '=', True)]
+        return self.search(
+            cr, uid, domain, order='line_date desc', context=context)
+
     def create(self, cr, uid, vals, context=None):
         if not context:
             context = {}
         if not vals.get('previous_id') and vals.get('asset_id'):
             # check if there is a previous line and set the previous line
-            cr.execute(
-                "SELECT id FROM account_asset_depreciation_line "
-                "WHERE asset_id = %s "
-                "ORDER BY type, line_date" % vals.get('asset_id'))
-            previous = cr.fetchone()
-            if previous:
-                vals['previous_id'] = previous
+            posted_depreciation_line_ids = \
+                self._get_posted_depreciation_line_ids(
+                    cr, uid, vals.get('asset_id'), context=context)
+            if (len(posted_depreciation_line_ids) > 0):
+                vals['previous_id'] = posted_depreciation_line_ids[0]
         return super(account_asset_depreciation_line, self).create(
             cr, uid, vals, context=context)
 

--- a/account_asset_management/tests/test_account_asset_management.csv
+++ b/account_asset_management/tests/test_account_asset_management.csv
@@ -1,0 +1,2 @@
+Test Account,Normal,4978.48,2014-01-27,1253.03,2014-12-31,True,Month,linear,year
+,,,,388.03,2015-04-30,True,,,

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -140,27 +140,27 @@ class TestAssetManagement(common.TransactionCase):
             self.cr, self.uid, [asset.id])
         asset.refresh()
         if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 46.44,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount,
+                                   46.44, places=2)
         else:
-            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 47.33,
-                                   places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 55.55,
-                               places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55,
-                               places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[4].amount, 55.55,
-                               places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[5].amount, 55.55,
-                               places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[6].amount, 55.55,
-                               places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount,
+                                   47.33, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount,
+                               55.55, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount,
+                               55.55, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[4].amount,
+                               55.55, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[5].amount,
+                               55.55, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[6].amount,
+                               55.55, places=2)
         if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 9.11,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount,
+                                   9.11, places=2)
         else:
-            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 8.22,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount,
+                                   8.22, places=2)
 
     def test_3_proprata_init_prev_year(self):
         """Prorata temporis depreciation with init value in prev year."""
@@ -230,16 +230,16 @@ class TestAssetManagement(common.TransactionCase):
                                places=2)
         # I check computed values in the depreciation board
         if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 44.75,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount,
+                                   44.75, places=2)
         else:
-            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 45.64,
-                                   places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55,
-                               places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount,
+                                   45.64, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount,
+                               55.55, places=2)
         if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 9.11,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount,
+                                   9.11, places=2)
         else:
-            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 8.22,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount,
+                                   8.22, places=2)

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -143,9 +143,17 @@ class TestAssetManagement(common.TransactionCase):
         if calendar.isleap(date.today().year):
             self.assertAlmostEqual(asset.depreciation_line_ids[1].amount,
                                    46.44, places=2)
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[2].depreciated_value,
+                46.44, places=2)
         else:
             self.assertAlmostEqual(asset.depreciation_line_ids[1].amount,
                                    47.33, places=2)
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[2].depreciated_value,
+                47.33, places=2)
+        self.assertAlmostEqual(
+            asset.depreciation_line_ids[1].depreciated_value, 0, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[2].amount,
                                55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[3].amount,
@@ -270,3 +278,7 @@ class TestAssetManagement(common.TransactionCase):
         self.assertEquals(len(asset.depreciation_line_ids), 3)
         self.assertEquals(asset.depreciation_line_ids[1].amount, 1253.03)
         self.assertEquals(asset.depreciation_line_ids[2].amount, 388.03)
+        self.assertEquals(
+            asset.depreciation_line_ids[1].depreciated_value, 0)
+        self.assertEquals(
+            asset.depreciation_line_ids[2].depreciated_value, 1253.03)

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -21,7 +21,8 @@
 #
 ##############################################################################
 
-from datetime import datetime
+import calendar
+from datetime import date, datetime
 
 import openerp.tests.common as common
 
@@ -138,13 +139,28 @@ class TestAssetManagement(common.TransactionCase):
         self.asset_model.compute_depreciation_board(
             self.cr, self.uid, [asset.id])
         asset.refresh()
-        self.assertEquals(asset.depreciation_line_ids[1].amount, 47.33)
-        self.assertEquals(asset.depreciation_line_ids[2].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[3].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[4].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[5].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[6].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[-1].amount, 8.22)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 46.44,
+                                   places=2)
+        else:
+            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 47.33,
+                                   places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[4].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[5].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[6].amount, 55.55,
+                               places=2)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 9.11,
+                                   places=2)
+        else:
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 8.22,
+                                   places=2)
 
     def test_3_proprata_init_prev_year(self):
         """Prorata temporis depreciation with init value in prev year."""
@@ -174,11 +190,15 @@ class TestAssetManagement(common.TransactionCase):
             self.cr, self.uid, [asset.id])
         asset.refresh()
         # I check the depreciated value is the initial value
-        self.assertEquals(asset.value_depreciated, 325.08)
+        self.assertAlmostEqual(asset.value_depreciated, 325.08,
+                               places=2)
         # I check computed values in the depreciation board
-        self.assertEquals(asset.depreciation_line_ids[2].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[3].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[-1].amount, 8.22)
+        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 8.22,
+                               places=2)
 
     def test_4_prorata_init_cur_year(self):
         """Prorata temporis depreciation with init value in curent year."""
@@ -206,8 +226,20 @@ class TestAssetManagement(common.TransactionCase):
             self.cr, self.uid, [asset.id])
         asset.refresh()
         # I check the depreciated value is the initial value
-        self.assertEquals(asset.value_depreciated, 279.44)
+        self.assertAlmostEqual(asset.value_depreciated, 279.44,
+                               places=2)
         # I check computed values in the depreciation board
-        self.assertEquals(asset.depreciation_line_ids[2].amount, 45.64)
-        self.assertEquals(asset.depreciation_line_ids[3].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[-1].amount, 8.22)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 44.75,
+                                   places=2)
+        else:
+            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 45.64,
+                                   places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55,
+                               places=2)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 9.11,
+                                   places=2)
+        else:
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 8.22,
+                                   places=2)


### PR DESCRIPTION
When import asset with many depreciation lines, I get the following errors :

Unknown error during import: <type 'exceptions.TypeError'>: unsupported operand type(s) for +=: 'float' and 'NoneType' between rows 2 and 3
Resolve other errors first

After exploration it seems that comes from here :

https://github.com/OCA/account-financial-tools/blob/7.0/account_asset_management/account_asset.py#L1388

And it is not possible to set previous_id in CSV as it is a readonly field.
So I override create to try to set a previous_id.
