### PR TITLE
[ADD] account_move_locking V7

### DIFF
--- a/account_move_locking/README.rst
+++ b/account_move_locking/README.rst
@@ -1,0 +1,52 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Module name
+===========
+
+This module add the ability to lock move for modification 
+
+Configuration
+=============
+
+
+
+Usage
+=====
+In order the locked the move you need to follow this process
+    * You need to post your move, with the standard wizard Post Journal Entries
+      (Invoicing -> Periodic Processing -> Draft Entries -> Post Journal Entries) 
+    * After the you can use the wizard Lock Journal Entries 
+      (Invoicing -> Periodic Processing -> Draft Entries -> Lock Journal Entries) 
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/account-financial-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/account-financial-tools/issues/new?body=module:%20account_move_locking%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Vincent renaville <vincen.renaville@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_move_locking/README.rst
+++ b/account_move_locking/README.rst
@@ -1,8 +1,8 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
     :alt: License: AGPL-3
 
-Module name
-===========
+Account move locking
+====================
 
 This module add the ability to lock move for modification 
 
@@ -13,10 +13,10 @@ Configuration
 
 Usage
 =====
-In order the locked the move you need to follow this process
+In order to lock the move you need to follow this process:
     * You need to post your move, with the standard wizard Post Journal Entries
       (Invoicing -> Periodic Processing -> Draft Entries -> Post Journal Entries) 
-    * After the you can use the wizard Lock Journal Entries 
+    * After that you can use the wizard Lock Journal Entries 
       (Invoicing -> Periodic Processing -> Draft Entries -> Lock Journal Entries) 
 
 Bug Tracker
@@ -34,7 +34,7 @@ Credits
 Contributors
 ------------
 
-* Vincent renaville <vincen.renaville@camptocamp.com>
+* Vincent Renaville <vincent.renaville@camptocamp.com>
 
 Maintainer
 ----------

--- a/account_move_locking/README.rst
+++ b/account_move_locking/README.rst
@@ -17,7 +17,10 @@ In order to lock the move you need to follow this process:
     * You need to post your move, with the standard wizard Post Journal Entries
       (Invoicing -> Periodic Processing -> Draft Entries -> Post Journal Entries) 
     * After that you can use the wizard Lock Journal Entries 
-      (Invoicing -> Periodic Processing -> Draft Entries -> Lock Journal Entries) 
+      (Invoicing -> Periodic Processing -> Draft Entries -> Lock Journal Entries)
+
+Warning This action cannot be undo, if you need to undo locking you will
+need to update SQL directly
 
 Bug Tracker
 ===========

--- a/account_move_locking/__init__.py
+++ b/account_move_locking/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author Vincent Renaville. Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import account
+from . import wizard

--- a/account_move_locking/__openerp__.py
+++ b/account_move_locking/__openerp__.py
@@ -28,11 +28,12 @@
     Usage
     =====
     In order to lock the move you need to follow this process:
-        * You need to post your move, with the standard wizard Post Journal Entries
-        (Invoicing -> Periodic Processing -> Draft Entries -> Post Journal Entries)
-        * After that you can use the wizard Lock Journal Entries
-        (Invoicing -> Periodic Processing -> Draft Entries -> Lock Journal Entries)
-    """
+    * You need to post your move, with the standard
+    wizard Post Journal Entries
+    (Invoicing -> Periodic Processing -> Draft Entries -> Post Journal Entries)
+    * After that you can use the wizard Lock Journal Entries
+    (Invoicing -> Periodic Processing -> Draft Entries -> Lock Journal Entries)
+    """,
     'license': 'AGPL-3',
     'website': 'http://www.camptocamp.com',
     'data': ['account_view.xml',

--- a/account_move_locking/__openerp__.py
+++ b/account_move_locking/__openerp__.py
@@ -22,6 +22,17 @@
     "version": "1.0",
     "depends": ["base", "account"],
     "author": "Camptocamp,Odoo Community Association (OCA)",
+    "description": """
+    This module add the ability to lock move for modification
+
+    Usage
+    =====
+    In order to lock the move you need to follow this process:
+        * You need to post your move, with the standard wizard Post Journal Entries
+        (Invoicing -> Periodic Processing -> Draft Entries -> Post Journal Entries)
+        * After that you can use the wizard Lock Journal Entries
+        (Invoicing -> Periodic Processing -> Draft Entries -> Lock Journal Entries)
+    """
     'license': 'AGPL-3',
     'website': 'http://www.camptocamp.com',
     'data': ['account_view.xml',

--- a/account_move_locking/__openerp__.py
+++ b/account_move_locking/__openerp__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author Vincent Renaville.
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+##############################################################################
+{
+    "name": "Move locked to prevent modification",
+    "version": "1.0",
+    "depends": ["base", "account"],
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    'license': 'AGPL-3',
+    'website': 'http://www.camptocamp.com',
+    'data': ['account_view.xml',
+             'wizard/account_lock_move_view.xml'],
+    'installable': True,
+}
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_move_locking/account.py
+++ b/account_move_locking/account.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author Vincent Renaville.
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+##############################################################################
+
+from openerp.osv import fields, orm
+from tools.translate import _
+
+
+class AccountMove(orm.Model):
+    _inherit = 'account.move'
+
+    _columns = {
+        'locked': fields.boolean('Locked', readonly=True),
+    }
+
+    def write(self, cr, uid, ids, vals, context=None):
+        for move in self.browse(cr, uid, ids, context=context):
+            if move.locked:
+                raise orm.except_orm(
+                    _(u'Move Locked!'), move.name)
+        return super(AccountMove, self).write(cr, uid,
+                                              ids, vals, context=context)
+
+    def unlink(self, cr, uid, ids, context=None):
+        for move in self.browse(cr, uid, ids, context=context):
+            if move.locked:
+                raise orm.except_orm(
+                    _(u'Move Locked!'), move.name)
+        return super(AccountMove, self).unlink(cr, uid,
+                                               ids, context=context)
+
+    def button_cancel(self, cr, uid, ids, context=None):
+        # Cancel a move was done directly in SQL
+        # so we need to test manualy if the move is locked
+        for move in self.browse(cr, uid, ids, context=context):
+            if move.locked:
+                raise orm.except_orm(
+                    _(u'Move Locked!'), move.name)
+        return super(AccountMove, self).button_cancel(cr, uid,
+                                                      ids, context=context)

--- a/account_move_locking/account.py
+++ b/account_move_locking/account.py
@@ -29,28 +29,25 @@ class AccountMove(orm.Model):
         'locked': fields.boolean('Locked', readonly=True),
     }
 
-    def write(self, cr, uid, ids, vals, context=None):
+    def check_locked(self, cr, uid, ids, context=None):
         for move in self.browse(cr, uid, ids, context=context):
             if move.locked:
                 raise orm.except_orm(
                     _(u'Move Locked!'), move.name)
+
+    def write(self, cr, uid, ids, vals, context=None):
+        self.check_locked(cr=cr, uid=uid, ids=ids, context=context)
         return super(AccountMove, self).write(cr, uid,
                                               ids, vals, context=context)
 
     def unlink(self, cr, uid, ids, context=None):
-        for move in self.browse(cr, uid, ids, context=context):
-            if move.locked:
-                raise orm.except_orm(
-                    _(u'Move Locked!'), move.name)
+        self.check_locked(cr=cr, uid=uid, ids=ids, context=context)
         return super(AccountMove, self).unlink(cr, uid,
                                                ids, context=context)
 
     def button_cancel(self, cr, uid, ids, context=None):
         # Cancel a move was done directly in SQL
         # so we need to test manualy if the move is locked
-        for move in self.browse(cr, uid, ids, context=context):
-            if move.locked:
-                raise orm.except_orm(
-                    _(u'Move Locked!'), move.name)
+        self.check_locked(cr=cr, uid=uid, ids=ids, context=context)
         return super(AccountMove, self).button_cancel(cr, uid,
                                                       ids, context=context)

--- a/account_move_locking/account_view.xml
+++ b/account_move_locking/account_view.xml
@@ -1,0 +1,16 @@
+<openerp>
+  <data>
+
+    <record id="view_move_form_locked" model="ir.ui.view">
+      <field name="name">account.move.form.locked</field>
+      <field name="model">account.move</field>
+      <field name="inherit_id" ref="account.view_move_form"/>
+      <field name="arch" type="xml">
+        <field name="to_check" position="after">
+            <field name="locked" />
+        </field>
+      </field>
+    </record>
+
+  </data>
+</openerp>

--- a/account_move_locking/i18n/account_move_locking.pot
+++ b/account_move_locking/i18n/account_move_locking.pot
@@ -1,0 +1,95 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_move_locking
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-10 12:01+0000\n"
+"PO-Revision-Date: 2015-07-10 12:01+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_move_locking
+#: code:_description:0
+#: model:ir.model,name:account_move_locking.model_account_move
+#, python-format
+msgid "Account Entry"
+msgstr ""
+
+#. module: account_move_locking
+#: view:lock.account.move:0
+msgid "Approve"
+msgstr ""
+
+#. module: account_move_locking
+#: view:lock.account.move:0
+msgid "Cancel"
+msgstr ""
+
+#. module: account_move_locking
+#: field:lock.account.move,journal_ids:0
+msgid "Journal"
+msgstr ""
+
+#. module: account_move_locking
+#: code:_description:0
+#: model:ir.model,name:account_move_locking.model_lock_account_move
+#, python-format
+msgid "Lock Account Move"
+msgstr ""
+
+#. module: account_move_locking
+#: model:ir.actions.act_window,name:account_move_locking.action_lock_account_move
+#: model:ir.ui.menu,name:account_move_locking.menu_lock_account_moves
+#: view:lock.account.move:0
+msgid "Lock Journal Entries"
+msgstr ""
+
+#. module: account_move_locking
+#: field:account.move,locked:0
+msgid "Locked"
+msgstr ""
+
+#. module: account_move_locking
+#: code:addons/account_move_locking/account.py:37
+#: code:addons/account_move_locking/account.py:44
+#: code:addons/account_move_locking/account.py:53
+#, python-format
+msgid "Move Locked!"
+msgstr ""
+
+#. module: account_move_locking
+#: code:addons/account_move_locking/wizard/account_lock_account_move.py:73
+#, python-format
+msgid "No move to locked found"
+msgstr ""
+
+#. module: account_move_locking
+#: field:lock.account.move,period_ids:0
+msgid "Period"
+msgstr ""
+
+#. module: account_move_locking
+#: code:addons/account_move_locking/wizard/account_lock_account_move.py:59
+#, python-format
+msgid "Unposted move in period/jounal                    selected, please post it before                    locking them"
+msgstr ""
+
+#. module: account_move_locking
+#: code:addons/account_move_locking/wizard/account_lock_account_move.py:58
+#: code:addons/account_move_locking/wizard/account_lock_account_move.py:72
+#, python-format
+msgid "Warning"
+msgstr ""
+
+#. module: account_move_locking
+#: view:lock.account.move:0
+msgid "or"
+msgstr ""
+

--- a/account_move_locking/i18n/fr.po
+++ b/account_move_locking/i18n/fr.po
@@ -1,0 +1,95 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_move_locking
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-10 12:01+0000\n"
+"PO-Revision-Date: 2015-07-10 12:01+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_move_locking
+#: code:_description:0
+#: model:ir.model,name:account_move_locking.model_account_move
+#, python-format
+msgid "Account Entry"
+msgstr "Entrée comptable"
+
+#. module: account_move_locking
+#: view:lock.account.move:0
+msgid "Approve"
+msgstr "Valider"
+
+#. module: account_move_locking
+#: view:lock.account.move:0
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: account_move_locking
+#: field:lock.account.move,journal_ids:0
+msgid "Journal"
+msgstr "Journal"
+
+#. module: account_move_locking
+#: code:_description:0
+#: model:ir.model,name:account_move_locking.model_lock_account_move
+#, python-format
+msgid "Lock Account Move"
+msgstr "Verrouiller mouvement comptable"
+
+#. module: account_move_locking
+#: model:ir.actions.act_window,name:account_move_locking.action_lock_account_move
+#: model:ir.ui.menu,name:account_move_locking.menu_lock_account_moves
+#: view:lock.account.move:0
+msgid "Lock Journal Entries"
+msgstr "Verrouiller les écritues comptables"
+
+#. module: account_move_locking
+#: field:account.move,locked:0
+msgid "Locked"
+msgstr "Verrouillé"
+
+#. module: account_move_locking
+#: code:addons/account_move_locking/account.py:37
+#: code:addons/account_move_locking/account.py:44
+#: code:addons/account_move_locking/account.py:53
+#, python-format
+msgid "Move Locked!"
+msgstr "Ecriture verrouillée"
+
+#. module: account_move_locking
+#: code:addons/account_move_locking/wizard/account_lock_account_move.py:73
+#, python-format
+msgid "No move to locked found"
+msgstr "Pas d'écriture à verrouiller"
+
+#. module: account_move_locking
+#: field:lock.account.move,period_ids:0
+msgid "Period"
+msgstr "Période"
+
+#. module: account_move_locking
+#: code:addons/account_move_locking/wizard/account_lock_account_move.py:59
+#, python-format
+msgid "Unposted move in period/jounal                    selected, please post it before                    locking them"
+msgstr "Ecritures non postées dans la sélection journal/période, Il faut poster les écritures avant de les verrouiller"
+
+#. module: account_move_locking
+#: code:addons/account_move_locking/wizard/account_lock_account_move.py:58
+#: code:addons/account_move_locking/wizard/account_lock_account_move.py:72
+#, python-format
+msgid "Warning"
+msgstr "Attention!"
+
+#. module: account_move_locking
+#: view:lock.account.move:0
+msgid "or"
+msgstr "ou"
+

--- a/account_move_locking/i18n/fr.po
+++ b/account_move_locking/i18n/fr.po
@@ -49,7 +49,7 @@ msgstr "Verrouiller mouvement comptable"
 #: model:ir.ui.menu,name:account_move_locking.menu_lock_account_moves
 #: view:lock.account.move:0
 msgid "Lock Journal Entries"
-msgstr "Verrouiller les écritues comptables"
+msgstr "Verrouiller les écritures comptables"
 
 #. module: account_move_locking
 #: field:account.move,locked:0
@@ -79,7 +79,7 @@ msgstr "Période"
 #: code:addons/account_move_locking/wizard/account_lock_account_move.py:59
 #, python-format
 msgid "Unposted move in period/jounal                    selected, please post it before                    locking them"
-msgstr "Ecritures non postées dans la sélection journal/période, Il faut poster les écritures avant de les verrouiller"
+msgstr "Ecritures non postées dans la sélection journal/période, il faut poster les écritures avant de les verrouiller"
 
 #. module: account_move_locking
 #: code:addons/account_move_locking/wizard/account_lock_account_move.py:58

--- a/account_move_locking/wizard/__init__.py
+++ b/account_move_locking/wizard/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author Vincent Renaville.
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+##############################################################################
+
+from . import account_lock_account_move

--- a/account_move_locking/wizard/account_lock_account_move.py
+++ b/account_move_locking/wizard/account_lock_account_move.py
@@ -43,15 +43,12 @@ class lock_account_move(orm.TransientModel):
         data = self.browse(cr, uid, ids, context=context)[0]
         journal_ids = [journal.id for journal in data.journal_ids]
         period_ids = [period.id for period in data.period_ids]
-        draft_move_ids = obj_move.search(cr, uid,
-                                         [('state', '=', 'draft'),
-                                          ('journal_id',
-                                           'in',
-                                           journal_ids),
-                                          ('period_id', 'in',
-                                           period_ids)],
-                                         order='date',
-                                         context=context)
+        draft_move_ids = obj_move.search(
+            cr, uid, [('state', '=', 'draft'),
+                      ('journal_id', 'in', journal_ids),
+                      ('period_id', 'in', period_ids)],
+            order='date',
+            context=context)
         if draft_move_ids:
             raise orm.except_orm(
                 _(u'Warning'),

--- a/account_move_locking/wizard/account_lock_account_move.py
+++ b/account_move_locking/wizard/account_lock_account_move.py
@@ -48,6 +48,7 @@ class lock_account_move(orm.TransientModel):
                       ('journal_id', 'in', journal_ids),
                       ('period_id', 'in', period_ids)],
             order='date',
+            limit=1,
             context=context)
         if draft_move_ids:
             raise orm.except_orm(

--- a/account_move_locking/wizard/account_lock_account_move.py
+++ b/account_move_locking/wizard/account_lock_account_move.py
@@ -28,7 +28,6 @@ class lock_account_move(orm.TransientModel):
 
     _columns = {
         'journal_ids': fields.many2many('account.journal',
-
                                         rel='wizard_lock_account_move_journal',
                                         string='Journal',
                                         required=True),
@@ -60,13 +59,14 @@ class lock_account_move(orm.TransientModel):
                    selected, please post it before \
                    locking them'))
 
-        move_ids = obj_move.search(cr, uid,
-                                   [('state', '=', 'posted'),
-                                    ('locked', '=', False),
-                                    ('journal_id', 'in', journal_ids),
-                                    ('period_id', 'in', period_ids)],
-                                   order='date',
-                                   context=context)
+        move_ids = obj_move.search(
+            cr, uid,
+            [('state', '=', 'posted'),
+             ('locked', '=', False),
+             ('journal_id', 'in', journal_ids),
+             ('period_id', 'in', period_ids)],
+            order='date',
+            context=context)
         if not move_ids:
             raise orm.except_orm(
                 _(u'Warning'),

--- a/account_move_locking/wizard/account_lock_account_move.py
+++ b/account_move_locking/wizard/account_lock_account_move.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author Vincent Renaville.
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+##############################################################################
+
+from openerp.osv import fields, orm
+from tools.translate import _
+
+
+class lock_account_move(orm.TransientModel):
+    _name = "lock.account.move"
+    _description = "Lock Account Move"
+
+    _columns = {
+        'journal_ids': fields.many2many('account.journal',
+
+                                        rel='wizard_lock_account_move_journal',
+                                        string='Journal',
+                                        required=True),
+        'period_ids': fields.many2many('account.period',
+                                       rel='wizard_lock_account_move_period',
+                                       string='Period',
+                                       required=True,
+                                       domain=[('state', '<>', 'done')])
+    }
+
+    def lock_move(self, cr, uid, ids, context=None):
+        obj_move = self.pool['account.move']
+        data = self.browse(cr, uid, ids, context=context)[0]
+        journal_ids = [journal.id for journal in data.journal_ids]
+        period_ids = [period.id for period in data.period_ids]
+        draft_move_ids = obj_move.search(cr, uid,
+                                         [('state', '=', 'draft'),
+                                          ('journal_id',
+                                           'in',
+                                           journal_ids),
+                                          ('period_id', 'in',
+                                           period_ids)],
+                                         order='date',
+                                         context=context)
+        if draft_move_ids:
+            raise orm.except_orm(
+                _(u'Warning'),
+                _('Unposted move in period/jounal \
+                   selected, please post it before \
+                   locking them'))
+
+        move_ids = obj_move.search(cr, uid,
+                                   [('state', '=', 'posted'),
+                                    ('locked', '=', False),
+                                    ('journal_id', 'in', journal_ids),
+                                    ('period_id', 'in', period_ids)],
+                                   order='date',
+                                   context=context)
+        if not move_ids:
+            raise orm.except_orm(
+                _(u'Warning'),
+                _('No move to locked found'))
+        obj_move.write(cr, uid, move_ids, {'locked': True}, context=context)
+        return {'type': 'ir.actions.act_window_close'}

--- a/account_move_locking/wizard/account_lock_move_view.xml
+++ b/account_move_locking/wizard/account_lock_move_view.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!--Account Moves-->
+        <record id="lock_account_move_view" model="ir.ui.view">
+            <field name="name">lock Journal Entries</field>
+            <field name="model">lock.account.move</field>
+            <field name="arch" type="xml">
+                <form string="Lock Journal Entries" version="7.0">
+                    <group>
+                        <field name="journal_ids"/>
+                        <field name="period_ids"/>
+                    </group>
+                    <footer>
+                        <button string="Approve" name="lock_move" type="object" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_lock_account_move" model="ir.actions.act_window">
+            <field name="name">Lock Journal Entries</field>
+            <field name="res_model">lock.account.move</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="lock_account_move_view"/>
+            <field name="target">new</field>
+        </record>
+
+        <menuitem
+            name="Lock Journal Entries"
+            parent="account.periodical_processing_journal_entries_validation"
+            action="action_lock_account_move"
+            id="menu_lock_account_moves"
+           />
+
+    </data>
+</openerp>


### PR DESCRIPTION
It's a backport a account_move_locking from V8

It's allow to lock a move to prevent it to be modified, even if you have account_cancel installed
