### PR TITLE
[FIX] account_reversal: correctly display the reversal move

### DIFF
--- a/account_reversal/account_view.xml
+++ b/account_reversal/account_view.xml
@@ -27,7 +27,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="to_be_reversed"/>
-                <field name="reversal_id" attrs="{'invisible': [('to_be_reversed', '=', False)]}"/>
+                <field name="reversal_id" attrs="{'invisible': [('to_be_reversed', '=', False), ('reversal_id', '=', False)]}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This issue was introduced by ac3744cbff4e43db749d194b141dfcd57a8d9460.

Before that commit, to_be_reversed remained true even after reversal so the invisible condition for reversal_id could depend only on to_be_reversed. Now, after reversal, to_be_reversed is false (which makes sense, since the move does not need to be reversed anymore). We must display the reversal move if it is present, though.
