### PR TITLE
[ADD] account_reconcile_trace module

### DIFF
--- a/account_reconcile_trace/README.rst
+++ b/account_reconcile_trace/README.rst
@@ -1,0 +1,61 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+============================
+Account Reconciliation Trace
+============================
+
+This module was written to extend the functionality of accounting to support trace account entries and their reconciled entries and allow you to get this trace by account entries or by invoices.
+
+Usage
+=====
+
+To use this module, reconciliation trace can be seen from:
+
+* account entry, on "Trace" page in notebook.
+* invoice, on "Payment" page in notebook.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/account_financial_tools/8.0
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/account-financial-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/account-financial-tools/issues/new?body=module:%20account_reconcile_trace%0Aversion:%208.0.1.0.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Angel Moya - Domatix <angel.moya@domatix.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_reconcile_trace/__init__.py
+++ b/account_reconcile_trace/__init__.py
@@ -1,0 +1,4 @@
+# -*- encoding: utf-8 -*-
+
+from . import models
+from . import tests

--- a/account_reconcile_trace/__openerp__.py
+++ b/account_reconcile_trace/__openerp__.py
@@ -1,0 +1,40 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (c) 2015 Domatix Technologies  S.L. (http://www.domatix.com)
+#                       info <info@domatix.com>
+#                       Angel Moya <angel.moya@domatix.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Account Reconcile Trace',
+    'version': '8.0.1.0.0',
+    'category': 'Account',
+    'license': 'AGPL-3',
+    'author': 'Domatix,Odoo Community Association (OCA)',
+    'website': 'http://www.domatix.com',
+    'depends': ['account'],
+    'demo': [
+        'demo/account_reconcile_trace_demo.xml',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/account_view.xml',
+    ],
+    'installable': True,
+}

--- a/account_reconcile_trace/demo/account_reconcile_trace_demo.xml
+++ b/account_reconcile_trace/demo/account_reconcile_trace_demo.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        
+        <!--
+        Account Accountant
+        -->    
+        <record id="tdd" model="account.account">
+            <field name="code">X110010</field>
+            <field name="name">Transfer Debtors Debit</field>
+            <field ref="account.cas" name="parent_id"/>
+            <field name="type">receivable</field>
+            <field eval="True" name="reconcile"/>
+            <field name="user_type" ref="account.data_account_type_receivable"/>
+        </record>
+        
+        <record id="tcc" model="account.account">
+            <field name="code">X1115</field>
+            <field name="name">Transfer Creditors Credit</field>
+            <field ref="account.cli" name="parent_id"/>
+            <field name="type">payable</field>
+            <field eval="True" name="reconcile"/>
+            <field name="user_type" ref="account.data_account_type_payable"/>
+        </record>
+        
+        <!--
+        Account Journal
+        -->
+
+        <record id="checks_debit_journal" model="account.journal">
+            <field name="name">Checks Transfer Debit</field>
+            <field name="code">CTDJ</field>
+            <field name="type">bank</field>
+            <field name="sequence_id" ref="account.sequence_bank_journal"/>
+            <field name="default_credit_account_id" ref="tdd"/>
+            <field name="default_debit_account_id" ref="account.a_recv"/>
+            <field name="user_id" ref="base.user_root"/>
+        </record> 
+        
+        <record id="checks_credit_journal" model="account.journal">
+            <field name="name">Checks Transfer Credit</field>
+            <field name="code">CTCJ</field>
+            <field name="type">bank</field>
+            <field name="sequence_id" ref="account.sequence_bank_journal"/>
+            <field name="default_credit_account_id" ref="tcc"/>
+            <field name="default_debit_account_id" ref="account.a_pay"/>
+            <field name="user_id" ref="base.user_root"/>
+        </record> 
+
+    </data>
+</openerp>

--- a/account_reconcile_trace/i18n/account_reconcile_trace.es
+++ b/account_reconcile_trace/i18n/account_reconcile_trace.es
@@ -1,0 +1,288 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_reconcile_trace
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-16 11:24+0000\n"
+"PO-Revision-Date: 2015-07-16 13:33+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.7.5\n"
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_move
+msgid "Account Entry"
+msgstr "Asiento"
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_reconcile_trace_direct
+msgid "Account Reconcile Trace Direct"
+msgstr "Trazabilidad de conciliación directa"
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_reconcile_trace_recursive
+msgid "Account Reconcile Trace Recursive"
+msgstr "Trazabilidad de concilidación recursiva"
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_move_reconcile
+msgid "Account Reconciliation"
+msgstr "Conciliación contable"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_move_id:0
+#: help:account.reconcile.trace.recursive,down_move_id:0
+msgid "Account entry on down reconciliation trace."
+msgstr "Asiento en la trazabilidad hacia abajo"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_move_id:0
+#: help:account.reconcile.trace.recursive,up_move_id:0
+msgid "Account entry on up reconciliation trace."
+msgstr "Asiento en la trazabilidad hacia arriba"
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Amount"
+msgstr "Importe"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_amount:0
+#: help:account.reconcile.trace.recursive,down_amount:0
+msgid "Amount on down reconciliation trace."
+msgstr "Importe en la trazabilidad hacia abajo"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_amount:0
+#: help:account.reconcile.trace.recursive,up_amount:0
+msgid "Amount on up reconciliation trace."
+msgstr "Importe en la trazabilidad hacia arriba"
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Date"
+msgstr "Fecha"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_date:0
+#: help:account.reconcile.trace.recursive,down_date:0
+msgid "Date on down reconciliation trace."
+msgstr "Fecha en la trazabilidad hacia abajo"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_date:0
+#: help:account.reconcile.trace.recursive,up_date:0
+msgid "Date on up reconciliation trace."
+msgstr "Fecha en la trazabilidad hacia arriba"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_amount:0
+#: field:account.reconcile.trace.recursive,down_amount:0
+msgid "Down Amount"
+msgstr "Importe abajo"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_date:0
+#: field:account.reconcile.trace.recursive,down_date:0
+msgid "Down Date"
+msgstr "Fecha Abajo"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_journal_id:0
+#: field:account.reconcile.trace.recursive,down_journal_id:0
+msgid "Down Journal"
+msgstr "Diario abajo"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_move_id:0
+#: field:account.reconcile.trace.recursive,down_move_id:0
+msgid "Down Move"
+msgstr "Asiento abajo"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_name:0
+#: field:account.reconcile.trace.recursive,down_name:0
+msgid "Down Name"
+msgstr "Nombre abajo"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_ref:0
+#: field:account.reconcile.trace.recursive,down_ref:0
+msgid "Down Ref"
+msgstr "Referencia abajo"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,super_up_move_id:0
+#: help:account.reconcile.trace.recursive,super_up_move_id:0
+msgid "First account entry on reconciliation trace."
+msgstr "Primer asiento en la conciliación hacia arriba"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,id:0
+#: field:account.reconcile.trace.recursive,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_invoice
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Journal"
+msgstr "Diario"
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_move_line
+msgid "Journal Items"
+msgstr "Apuntes"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_journal_id:0
+#: help:account.reconcile.trace.recursive,down_journal_id:0
+msgid "Journal on down reconciliation trace."
+msgstr "Diario en la trazabilidad hacia abajo"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_journal_id:0
+#: help:account.reconcile.trace.recursive,up_journal_id:0
+msgid "Journal on up reconciliation trace."
+msgstr "Diario en la trazabilidad hacia arriba"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,super_down_move_id:0
+#: help:account.reconcile.trace.recursive,super_down_move_id:0
+msgid "Last account entry on reconciliation trace."
+msgstr "Último asiento en la trazabilidad hacia abajo"
+
+#. module: account_reconcile_trace
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Move"
+msgstr "Asiento"
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Name"
+msgstr "Nombre"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_name:0
+#: help:account.reconcile.trace.recursive,down_name:0
+msgid "Name of journal item on down reconciliation trace."
+msgstr "Nombre del apunte en la trazabilidad hacia abajo"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_name:0
+#: help:account.reconcile.trace.recursive,up_name:0
+msgid "Name of journal item on up reconciliation trace."
+msgstr "Nombre del apunte en la trazabilidad hacia arriba"
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Ref"
+msgstr "Referencia"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_ref:0
+#: help:account.reconcile.trace.recursive,down_ref:0
+msgid "Reference of journal item on down reconciliation trace."
+msgstr "Referencia del apunte en la trazabilidad hacia abajo"
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_ref:0
+#: help:account.reconcile.trace.recursive,up_ref:0
+msgid "Reference of journal item on up reconciliation trace."
+msgstr "Referencia del apunte en la trazabilidad hacia abajo"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,super_down_move_id:0
+#: field:account.reconcile.trace.recursive,super_down_move_id:0
+msgid "Super Down Move"
+msgstr "Último asiento abajo"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,super_up_move_id:0
+#: field:account.reconcile.trace.recursive,super_up_move_id:0
+msgid "Super Up Move"
+msgstr "Primer asiento arriba"
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Trace"
+msgstr "Traza"
+
+#. module: account_reconcile_trace
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: field:account.move,trace_down_ids:0
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Trace Down"
+msgstr "Trazabilidad hacia abajo"
+
+#. module: account_reconcile_trace
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: field:account.move,trace_up_ids:0
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Trace Up"
+msgstr "Trazabilidad hacia arriba"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_amount:0
+#: field:account.reconcile.trace.recursive,up_amount:0
+msgid "Up Amount"
+msgstr "Importe arriba"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_date:0
+#: field:account.reconcile.trace.recursive,up_date:0
+msgid "Up Date"
+msgstr "Fecha Arriba"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_journal_id:0
+#: field:account.reconcile.trace.recursive,up_journal_id:0
+msgid "Up Journal"
+msgstr "Diario arriba"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_move_id:0
+#: field:account.reconcile.trace.recursive,up_move_id:0
+msgid "Up Move"
+msgstr "Asiento arriba"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_name:0
+#: field:account.reconcile.trace.recursive,up_name:0
+msgid "Up Name"
+msgstr "Nombre arriba"
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_ref:0
+#: field:account.reconcile.trace.recursive,up_ref:0
+msgid "Up Ref"
+msgstr "Referencia arriba"

--- a/account_reconcile_trace/i18n/account_reconcile_trace.pot
+++ b/account_reconcile_trace/i18n/account_reconcile_trace.pot
@@ -1,0 +1,288 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_reconcile_trace
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-16 11:24+0000\n"
+"PO-Revision-Date: 2015-07-16 13:33+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.7.5\n"
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_move
+msgid "Account Entry"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_reconcile_trace_direct
+msgid "Account Reconcile Trace Direct"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_reconcile_trace_recursive
+msgid "Account Reconcile Trace Recursive"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_move_reconcile
+msgid "Account Reconciliation"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_move_id:0
+#: help:account.reconcile.trace.recursive,down_move_id:0
+msgid "Account entry on down reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_move_id:0
+#: help:account.reconcile.trace.recursive,up_move_id:0
+msgid "Account entry on up reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Amount"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_amount:0
+#: help:account.reconcile.trace.recursive,down_amount:0
+msgid "Amount on down reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_amount:0
+#: help:account.reconcile.trace.recursive,up_amount:0
+msgid "Amount on up reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Date"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_date:0
+#: help:account.reconcile.trace.recursive,down_date:0
+msgid "Date on down reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_date:0
+#: help:account.reconcile.trace.recursive,up_date:0
+msgid "Date on up reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_amount:0
+#: field:account.reconcile.trace.recursive,down_amount:0
+msgid "Down Amount"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_date:0
+#: field:account.reconcile.trace.recursive,down_date:0
+msgid "Down Date"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_journal_id:0
+#: field:account.reconcile.trace.recursive,down_journal_id:0
+msgid "Down Journal"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_move_id:0
+#: field:account.reconcile.trace.recursive,down_move_id:0
+msgid "Down Move"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_name:0
+#: field:account.reconcile.trace.recursive,down_name:0
+msgid "Down Name"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,down_ref:0
+#: field:account.reconcile.trace.recursive,down_ref:0
+msgid "Down Ref"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,super_up_move_id:0
+#: help:account.reconcile.trace.recursive,super_up_move_id:0
+msgid "First account entry on reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,id:0
+#: field:account.reconcile.trace.recursive,id:0
+msgid "ID"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Journal"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: model:ir.model,name:account_reconcile_trace.model_account_move_line
+msgid "Journal Items"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_journal_id:0
+#: help:account.reconcile.trace.recursive,down_journal_id:0
+msgid "Journal on down reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_journal_id:0
+#: help:account.reconcile.trace.recursive,up_journal_id:0
+msgid "Journal on up reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,super_down_move_id:0
+#: help:account.reconcile.trace.recursive,super_down_move_id:0
+msgid "Last account entry on reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Move"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Name"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_name:0
+#: help:account.reconcile.trace.recursive,down_name:0
+msgid "Name of journal item on down reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_name:0
+#: help:account.reconcile.trace.recursive,up_name:0
+msgid "Name of journal item on up reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Ref"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,down_ref:0
+#: help:account.reconcile.trace.recursive,down_ref:0
+msgid "Reference of journal item on down reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: help:account.reconcile.trace.direct,up_ref:0
+#: help:account.reconcile.trace.recursive,up_ref:0
+msgid "Reference of journal item on up reconciliation trace."
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,super_down_move_id:0
+#: field:account.reconcile.trace.recursive,super_down_move_id:0
+msgid "Super Down Move"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,super_up_move_id:0
+#: field:account.reconcile.trace.recursive,super_up_move_id:0
+msgid "Super Up Move"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: view:account.invoice:account_reconcile_trace.invoice_supplier_trace_form
+#: view:account.invoice:account_reconcile_trace.invoice_trace_form
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Trace"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: field:account.move,trace_down_ids:0
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Trace Down"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: view:account.move:account_reconcile_trace.view_move_trace_form
+#: field:account.move,trace_up_ids:0
+#: view:account.reconcile.trace.recursive:account_reconcile_trace.view_trace_form
+msgid "Trace Up"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_amount:0
+#: field:account.reconcile.trace.recursive,up_amount:0
+msgid "Up Amount"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_date:0
+#: field:account.reconcile.trace.recursive,up_date:0
+msgid "Up Date"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_journal_id:0
+#: field:account.reconcile.trace.recursive,up_journal_id:0
+msgid "Up Journal"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_move_id:0
+#: field:account.reconcile.trace.recursive,up_move_id:0
+msgid "Up Move"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_name:0
+#: field:account.reconcile.trace.recursive,up_name:0
+msgid "Up Name"
+msgstr ""
+
+#. module: account_reconcile_trace
+#: field:account.reconcile.trace.direct,up_ref:0
+#: field:account.reconcile.trace.recursive,up_ref:0
+msgid "Up Ref"
+msgstr ""

--- a/account_reconcile_trace/models/__init__.py
+++ b/account_reconcile_trace/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- encoding: utf-8 -*-
+
+from . import account_reconcile_trace
+from . import account

--- a/account_reconcile_trace/models/account.py
+++ b/account_reconcile_trace/models/account.py
@@ -1,0 +1,28 @@
+# -*- encoding: utf-8 -*-
+from openerp import models, fields
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    trace_down_ids = fields.One2many(
+        comodel_name='account.reconcile.trace.recursive',
+        inverse_name='super_up_move_id',
+        string='Trace Down')
+    trace_up_ids = fields.One2many(
+        comodel_name='account.reconcile.trace.recursive',
+        inverse_name='super_down_move_id',
+        string='Trace Up')
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    trace_down_ids = fields.One2many(
+        'account.reconcile.trace.recursive',
+        related='move_id.trace_down_ids',
+        string='Trace Down')
+    trace_up_ids = fields.One2many(
+        'account.reconcile.trace.recursive',
+        related='move_id.trace_up_ids',
+        string='Trace Up')

--- a/account_reconcile_trace/models/account_reconcile_trace.py
+++ b/account_reconcile_trace/models/account_reconcile_trace.py
@@ -1,0 +1,198 @@
+# -*- encoding: utf-8 -*-
+from openerp import models, fields, tools
+
+
+class AccountReconcileTraceDirect(models.Model):
+    _name = 'account.reconcile.trace.direct'
+    _description = "Account Reconcile Trace Direct"
+    _auto = False
+
+    super_up_move_id = fields.Many2one(
+        comodel_name='account.move',
+        string='Super Up Move',
+        help='First account entry on reconciliation trace.')
+    super_down_move_id = fields.Many2one(
+        comodel_name='account.move',
+        string='Super Down Move',
+        help='Last account entry on reconciliation trace.')
+    up_move_id = fields.Many2one(
+        comodel_name='account.move',
+        string='Up Move',
+        help='Account entry on up reconciliation trace.')
+    down_move_id = fields.Many2one(
+        comodel_name='account.move',
+        string='Down Move',
+        help='Account entry on down reconciliation trace.')
+    up_journal_id = fields.Many2one(
+        comodel_name='account.journal',
+        string='Up Journal',
+        help='Journal on up reconciliation trace.')
+    down_journal_id = fields.Many2one(
+        comodel_name='account.journal',
+        string='Down Journal',
+        help='Journal on down reconciliation trace.')
+    up_amount = fields.Float(
+        string='Up Amount',
+        help='Amount on up reconciliation trace.')
+    down_amount = fields.Float(
+        string='Down Amount',
+        help='Amount on down reconciliation trace.')
+    up_date = fields.Date(
+        string='Up Date',
+        help='Date on up reconciliation trace.')
+    down_date = fields.Date(
+        string='Down Date',
+        help='Date on down reconciliation trace.')
+    up_ref = fields.Char(
+        string='Up Ref',
+        help='Reference of journal item on up reconciliation trace.')
+    down_ref = fields.Char(
+        string='Down Ref',
+        help='Reference of journal item on down reconciliation trace.')
+    up_name = fields.Char(
+        string='Up Name',
+        help='Name of journal item on up reconciliation trace.')
+    down_name = fields.Char(
+        string='Down Name',
+        help='Name of journal item on down reconciliation trace.')
+
+    def init(self, cr):
+        tools.drop_view_if_exists(cr, 'account_reconcile_trace_direct')
+        cr.execute("""
+            create or replace view account_reconcile_trace_direct as (
+                select  distinct up.id,
+                        up.move_id as super_up_move_id,
+                        down.move_id as super_down_move_id,
+                        up.move_id as up_move_id,
+                        down.move_id as down_move_id,
+                        up.journal_id as up_journal_id,
+                        down.journal_id as down_journal_id,
+                        up.debit as up_amount,
+                        down.credit as down_amount,
+                        up.date as up_date,
+                        down.date as down_date,
+                        up.ref as up_ref,
+                        down.ref as down_ref,
+                        up.name as up_name,
+                        down.name as down_name
+                from    account_move_line up,
+                        account_move_reconcile  rec,
+                        account_move_line down
+                where   up.debit > 0
+                        and up.reconcile_id = rec.id
+                        and down.credit > 0
+                        and down.reconcile_id = rec.id
+                order by up.move_id
+        )""")
+
+
+class AccountReconcileTraceRecursive(models.Model):
+    _name = 'account.reconcile.trace.recursive'
+    _description = "Account Reconcile Trace Recursive"
+    _auto = False
+
+    super_up_move_id = fields.Many2one(
+        comodel_name='account.move',
+        string='Super Up Move',
+        help='First account entry on reconciliation trace.')
+    super_down_move_id = fields.Many2one(
+        comodel_name='account.move',
+        string='Super Down Move',
+        help='Last account entry on reconciliation trace.')
+    up_move_id = fields.Many2one(
+        comodel_name='account.move',
+        string='Up Move',
+        help='Account entry on up reconciliation trace.')
+    down_move_id = fields.Many2one(
+        comodel_name='account.move',
+        string='Down Move',
+        help='Account entry on down reconciliation trace.')
+    up_journal_id = fields.Many2one(
+        comodel_name='account.journal',
+        string='Up Journal',
+        help='Journal on up reconciliation trace.')
+    down_journal_id = fields.Many2one(
+        comodel_name='account.journal',
+        string='Down Journal',
+        help='Journal on down reconciliation trace.')
+    up_amount = fields.Float(
+        string='Up Amount',
+        help='Amount on up reconciliation trace.')
+    down_amount = fields.Float(
+        string='Down Amount',
+        help='Amount on down reconciliation trace.')
+    up_date = fields.Date(
+        string='Up Date',
+        help='Date on up reconciliation trace.')
+    down_date = fields.Date(
+        string='Down Date',
+        help='Date on down reconciliation trace.')
+    up_ref = fields.Char(
+        string='Up Ref',
+        help='Reference of journal item on up reconciliation trace.')
+    down_ref = fields.Char(
+        string='Down Ref',
+        help='Reference of journal item on down reconciliation trace.')
+    up_name = fields.Char(
+        string='Up Name',
+        help='Name of journal item on up reconciliation trace.')
+    down_name = fields.Char(
+        string='Down Name',
+        help='Name of journal item on down reconciliation trace.')
+
+    def init(self, cr):
+        tools.drop_view_if_exists(cr, 'account_reconcile_trace_recursive')
+        cr.execute("""
+            create or replace view account_reconcile_trace_recursive as (
+                WITH RECURSIVE trace AS(
+                    SELECT super_up_move_id,
+                        super_down_move_id,
+                        up_move_id,
+                        down_move_id,
+                        up_journal_id,
+                        down_journal_id,
+                        up_amount,
+                        down_amount,
+                        up_date,
+                        down_date,
+                        up_ref,
+                        down_ref,
+                        up_name,
+                        down_name
+                    FROM account_reconcile_trace_direct
+                UNION
+                    SELECT t.super_up_move_id,
+                        rt.super_down_move_id,
+                        rt.up_move_id,
+                        rt.down_move_id,
+                        t.up_journal_id,
+                        rt.down_journal_id,
+                        t.up_amount,
+                        rt.down_amount,
+                        t.up_date,
+                        rt.down_date,
+                        t.up_ref,
+                        rt.down_ref,
+                        t.up_name,
+                        rt.down_name
+                    FROM account_reconcile_trace_direct rt,
+                        trace t
+                    WHERE rt.up_move_id = t.down_move_id
+                )
+                SELECT row_number() OVER () as id,
+                    super_up_move_id,
+                    super_down_move_id,
+                    up_move_id,
+                    down_move_id,
+                    up_journal_id,
+                    down_journal_id,
+                    up_amount,
+                    down_amount,
+                    up_date,
+                    down_date,
+                    up_ref,
+                    down_ref,
+                    up_name,
+                    down_name
+                FROM trace
+        )""")

--- a/account_reconcile_trace/security/ir.model.access.csv
+++ b/account_reconcile_trace/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_reconcile_trace_direct,access_account_reconcile_trace_direct,model_account_reconcile_trace_direct,account.group_account_invoice,1,0,0,0
+access_account_reconcile_trace_recursive,access_account_reconcile_trace_recursive,model_account_reconcile_trace_recursive,account.group_account_invoice,1,0,0,0

--- a/account_reconcile_trace/tests/__init__.py
+++ b/account_reconcile_trace/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_account_reconcile_trace

--- a/account_reconcile_trace/tests/common.py
+++ b/account_reconcile_trace/tests/common.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+from openerp.tests import common
+
+
+class TestCommon(common.TransactionCase):
+
+    def setUp(self):
+        super(TestCommon, self).setUp()
+
+        self.ProductObj = self.env['product.product']
+        self.PartnerObj = self.env['res.partner']
+        self.JournalObj = self.env['account.journal']
+        self.ModelDataObj = self.env['ir.model.data']
+        self.InvoiceObj = self.env['account.invoice']
+        self.MoveObj = self.env['account.move']
+        self.MoveLineObj = self.env['account.move.line']
+        self.PeriodObj = self.env['account.period']
+        self.TraceDirectObj = self.env['account.reconcile.trace.direct']
+        self.TraceRecursiveObj = self.env['account.reconcile.trace.direct']
+
+        # Model Data
+        self.main_company = self.ModelDataObj.xmlid_to_res_id(
+            'base.main_company'
+        )
+        self.main_customer = self.ModelDataObj.xmlid_to_res_id(
+            'base.res_partner_2'
+        )
+        self.main_supplier = self.ModelDataObj.xmlid_to_res_id(
+            'base.res_partner_1'
+        )
+        self.product_consultant = self.ModelDataObj.xmlid_to_res_id(
+            'product.product_product_consultant'
+        )
+        self.uom_hour = self.ModelDataObj.xmlid_to_res_id(
+            'product.product_uom_hour'
+        )
+        self.debit_journal = self.ModelDataObj.xmlid_to_res_id(
+            'account_reconcile_trace.checks_debit_journal'
+        )
+        self.credit_journal = self.ModelDataObj.xmlid_to_res_id(
+            'account_reconcile_trace.checks_credit_journal'
+        )
+        self.debit_account = self.ModelDataObj.xmlid_to_res_id(
+            'account_reconcile_trace.tdd'
+        )
+        self.credit_account = self.ModelDataObj.xmlid_to_res_id(
+            'account_reconcile_trace.tcc'
+        )
+        self.sales_journal = self.ModelDataObj.xmlid_to_res_id(
+            'account.sales_journal'
+        )
+        self.purchase_journal = self.ModelDataObj.xmlid_to_res_id(
+            'account.expenses_journal'
+        )
+        self.receive_account = self.ModelDataObj.xmlid_to_res_id(
+            'account.a_recv'
+        )
+        self.payable_account = self.ModelDataObj.xmlid_to_res_id(
+            'account.a_pay'
+        )
+        self.sale_account = self.ModelDataObj.xmlid_to_res_id(
+            'account.a_sale'
+        )
+        self.expense_account = self.ModelDataObj.xmlid_to_res_id(
+            'account.a_expense'
+        )
+        self.pay_account_id = self.ModelDataObj.xmlid_to_res_id(
+            'account.cash'
+        )
+        self.journal_id = self.ModelDataObj.xmlid_to_res_id(
+            'account.bank_journal'
+        )

--- a/account_reconcile_trace/tests/test_account_reconcile_trace.py
+++ b/account_reconcile_trace/tests/test_account_reconcile_trace.py
@@ -1,0 +1,562 @@
+# -*- coding: utf-8 -*-
+
+from openerp.addons.account_reconcile_trace.tests.common \
+    import TestCommon
+from openerp.tools import mute_logger
+import time
+
+
+class TestReconcileTrace(TestCommon):
+
+    @mute_logger('openerp.addons.base.ir.ir_model', 'openerp.models')
+    def test_00_reconcile_trace(self):
+        """ In order to create a Customer Invoice"""
+
+        # I create a invoice line values
+        invoice_lines = []
+
+        line_values = {'quantity': 1.0,
+                       'price_unit': 75.0,
+                       'name': 'test',
+                       'product_id': self.product_consultant,
+                       'uos_id': self.uom_hour,
+                       'account_id': self.sale_account}
+        invoice_lines.append((0, 0, line_values))
+        # I create a invoice using invoice line data and invoice values
+        invoice_values = {
+            'partner_id': self.main_customer,
+            'account_id': self.receive_account,
+            'journal_id': self.sales_journal,
+            'date_invoice': time.strftime('%Y-%m-%d'),
+            'invoice_line': invoice_lines,
+            'type': 'out_invoice',
+            'company_id': self.main_company
+        }
+        self.invoice = self.InvoiceObj.create(invoice_values)
+        # I check if the invoice was created
+        self.assertTrue(self.invoice, "Invoice no created")
+        # I active the invoice workflow to validate the invoice and
+        # create the account move associate to this invoice
+        self.invoice.signal_workflow('invoice_open')
+
+        # In order to create a Account move to reconcile the
+        # invoice account move
+
+        # I create the first move line values
+        move_lines = []
+
+        move_values1 = {'name': 'move line 1',
+                        'account_id': self.receive_account,
+                        'partner_id': self.main_customer,
+                        'credit': 75,
+                        'company_id': self.main_company}
+        move_lines.append((0, 0, move_values1))
+        # I create the second move line values
+        move_values2 = {'name': 'move line 2',
+                        'account_id': self.debit_account,
+                        'debit': 75,
+                        'company_id': self.main_company}
+        move_lines.append((0, 0, move_values2))
+
+        # I find a period using current date
+        period_id = self.PeriodObj.find(time.strftime('%Y-%m-%d'))
+        if period_id:
+            period_id = period_id[0].id
+
+        # I create a account move using move line data and move values dict
+        move_values = {
+            'journal_id': self.debit_journal,
+            'date': time.strftime('%Y-%m-%d'),
+            'period_id': period_id,
+            'line_id': move_lines}
+        self.move = self.MoveObj.create(move_values)
+        # I check if the account move was created
+        self.assertTrue(self.move, "Account move no created")
+
+        # I validate the account move
+        self.move.button_validate()
+
+        # I check the invoice and move amount
+        assert self.invoice.amount_total == self.move.amount, \
+            'The amount could be 75.0'
+
+        # In order to reconcile the first Account Moves
+        invoice_move_id = self.invoice.move_id
+        move_line_to_reconcile = False
+        for invoice_move_line in invoice_move_id.line_id:
+            for move_line in self.move.line_id:
+                if invoice_move_line.account_id == move_line.account_id:
+                    move_line_to_reconcile = invoice_move_line
+                    move_line_to_reconcile += move_line
+        if move_line_to_reconcile:
+            move_line_to_reconcile.reconcile(
+                type='test',
+                writeoff_acc_id=self.receive_account,
+                writeoff_period_id=period_id,
+                writeoff_journal_id=self.debit_journal)
+
+        # In order to pay and reconcile the Account invoice(second move)
+        l1 = {
+            'name': "Payment test customer invoice",
+            'credit': 75.0,
+            'account_id': self.debit_account,
+            'partner_id': self.main_customer,
+            'company_id': self.main_company,
+        }
+        l2 = {
+            'name': "Payment test customer invoice",
+            'debit': 75.0,
+            'account_id': self.pay_account_id,
+            'partner_id': self.main_customer,
+            'company_id': self.main_company,
+        }
+        self.move2 = self.MoveObj.create({'line_id': [(0, 0, l1), (0, 0, l2)],
+                                          'journal_id': self.journal_id,
+                                          'period_id': period_id,
+                                          'date': time.strftime('%Y-%m-%d')})
+
+        # I check if the account move was created
+        self.assertTrue(self.move2, "Account move no created")
+        # I validate the account move
+        self.move2.button_validate()
+        # I check the invoice and move amount
+        assert self.move.amount == self.move2.amount, \
+            'The amount could be 75.0'
+        move_line_to_reconcile = False
+        for move_line1 in self.move.line_id:
+            for move_line2 in self.move2.line_id:
+                if move_line1.account_id == move_line2.account_id:
+                    move_line_to_reconcile = move_line1
+                    move_line_to_reconcile += move_line2
+        if move_line_to_reconcile:
+            move_line_to_reconcile.reconcile(
+                type='test',
+                writeoff_acc_id=self.debit_account,
+                writeoff_period_id=period_id,
+                writeoff_journal_id=self.journal_id)
+
+        # In order to check the account.reconcile.trace.direct moves
+        #  up_move_id = asiento de factura,
+        #  down_move_id = asiento de "Checks Transfer Debit"
+        trace_direct1 = self.TraceDirectObj.search(
+            [('up_move_id', '=', invoice_move_id.id),
+             ('down_move_id', '=', self.move.id)])
+
+        assert len(trace_direct1) == 1, \
+            'The quantity of registry in TraceDirect is not correct.'
+
+        # In order to check every account.reconcile.trace.direct fields
+        assert trace_direct1.super_up_move_id == invoice_move_id, \
+            'The super_up_move_id is wrong.'
+        assert trace_direct1.super_down_move_id == self.move, \
+            'The super_down_move_id is wrong.'
+        assert trace_direct1.up_journal_id == invoice_move_id.journal_id, \
+            'The up_journal_id is wrong.'
+        assert trace_direct1.down_journal_id == self.move.journal_id, \
+            'The down_journal_id is wrong.'
+        assert trace_direct1.up_amount == invoice_move_id.amount, \
+            'The up_amount is wrong.'
+        assert trace_direct1.down_amount == self.move.amount, \
+            'The down_amount is wrong.'
+        assert trace_direct1.up_date == invoice_move_id.date, \
+            'The up_date is wrong.'
+        assert trace_direct1.down_date == self.move.date, \
+            'The down_date is wrong.'
+        assert trace_direct1.up_ref == invoice_move_id.ref, \
+            'The up_ref is wrong.'
+        assert trace_direct1.down_ref == self.move.ref, \
+            'The down_ref is wrong.'
+
+        # up_move_id = asiento de "Checks Transfer Debit",
+        # down_move_id = asiento de "pago" del asiento anterior.
+        trace_direct2 = self.TraceDirectObj.search(
+            [('up_move_id', '=', self.move.id),
+             ('down_move_id', '=', self.move2.id)])
+
+        assert len(trace_direct2) == 1, \
+            'The quantity of registry in TraceDirect is not correct.'
+
+        # In order to check every account.reconcile.trace.direct fields
+        assert trace_direct2.super_up_move_id == self.move, \
+            'The super_up_move_id is wrong.'
+        assert trace_direct2.super_down_move_id == self.move2, \
+            'The super_down_move_id is wrong.'
+        assert trace_direct2.up_journal_id == self.move.journal_id, \
+            'The up_journal_id is wrong.'
+        assert trace_direct2.down_journal_id == self.move2.journal_id, \
+            'The down_journal_id is wrong.'
+        assert trace_direct2.up_amount == self.move.amount, \
+            'The up_amount is wrong.'
+        assert trace_direct2.down_amount == self.move2.amount, \
+            'The down_amount is wrong.'
+        assert trace_direct2.up_date == self.move.date, \
+            'The up_date is wrong.'
+        assert trace_direct2.down_date == self.move2.date, \
+            'The down_date is wrong.'
+        assert trace_direct2.up_ref == self.move.ref, \
+            'The up_ref is wrong.'
+        assert trace_direct2.down_ref == self.move2.ref, \
+            'The down_ref is wrong.'
+
+        # In order to check the account.reconcile.trace.recursive moves
+        #  up_move_id = asiento de factura,
+        #  down_move_id = asiento de "Checks Transfer Debit"
+        trace_recursive1 = self.TraceRecursiveObj.search(
+            [('up_move_id', '=', invoice_move_id.id),
+             ('down_move_id', '=', self.move.id)])
+        assert len(trace_recursive1) == 1, \
+            'The quantity of registry in TraceRecursive is not correct.'
+
+        # In order to check every account.reconcile.trace.recursive fields
+        assert trace_recursive1.super_up_move_id == \
+            trace_direct1.super_up_move_id, \
+            'The super_up_move_id is wrong.'
+        assert trace_recursive1.super_down_move_id == \
+            trace_direct1.super_down_move_id, \
+            'The super_down_move_id is wrong.'
+        assert trace_recursive1.up_journal_id == \
+            trace_direct1.up_journal_id, \
+            'The up_journal_id is wrong.'
+        assert trace_recursive1.down_journal_id == \
+            trace_recursive1.down_journal_id, \
+            'The down_journal_id is wrong.'
+        assert trace_recursive1.up_amount == trace_direct1.up_amount, \
+            'The up_amount is wrong.'
+        assert trace_recursive1.down_amount == trace_recursive1.down_amount, \
+            'The down_amount is wrong.'
+        assert trace_recursive1.up_date == trace_direct1.up_date, \
+            'The up_date is wrong.'
+        assert trace_recursive1.down_date == trace_recursive1.down_date, \
+            'The down_date is wrong.'
+        assert trace_recursive1.up_ref == trace_direct1.up_ref, \
+            'The up_ref is wrong.'
+        assert trace_recursive1.down_ref == trace_recursive1.down_ref, \
+            'The down_ref is wrong.'
+        # up_move_id = asiento de "Checks Transfer Debit",
+        # down_move_id = asiento de "pago" del asiento anterior.
+        trace_recursive2 = self.TraceRecursiveObj.search(
+            [('up_move_id', '=', self.move.id),
+             ('down_move_id', '=', self.move2.id)])
+
+        assert len(trace_recursive2) == 1, \
+            'The quantity of registry in TraceRecursive is not correct.'
+
+        # In order to check every account.reconcile.trace.direct fields
+        assert trace_recursive2.super_up_move_id == \
+            trace_direct1.super_down_move_id, \
+            'The super_up_move_id is wrong.'
+        assert trace_recursive2.super_down_move_id == \
+            trace_direct2.super_down_move_id, \
+            'The super_down_move_id is wrong.'
+        assert trace_recursive2.up_journal_id == \
+            trace_direct1.down_journal_id, \
+            'The up_journal_id is wrong.'
+        assert trace_recursive2.down_journal_id == \
+            trace_direct2.down_journal_id, \
+            'The down_journal_id is wrong.'
+        assert trace_recursive2.up_amount == trace_direct1.down_amount, \
+            'The up_amount is wrong.'
+        assert trace_recursive2.down_amount == trace_direct2.down_amount, \
+            'The down_amount is wrong.'
+        assert trace_recursive2.up_date == trace_direct1.down_date, \
+            'The up_date is wrong.'
+        assert trace_recursive2.down_date == trace_direct2.down_date, \
+            'The down_date is wrong.'
+        assert trace_recursive2.up_ref == trace_direct1.down_ref, \
+            'The up_ref is wrong.'
+        assert trace_recursive2.down_ref == trace_direct2.down_ref, \
+            'The down_ref is wrong.'
+
+#
+#         trace_recursive3 = self.TraceRecursiveObj.search([
+#                                                           ('up_move_id',
+#                                                            '=',
+#                                                           invoice_move_id.id),
+#                                                           ('down_move_id',
+#                                                            '=',
+#                                                            self.move2.id)])
+#        assert len(trace_recursive3) == 1 , \
+#            'The quantity of registry in TraceRecursive is not correct.)
+#        """In order to check the trace recursive in invoice"""
+#        self.invoice.trace_down_ids
+#        self.invoice.trace_up_ids
+#        """In order to check the trace recursive in account moves"""
+#        self.move.trace_down_ids
+#        self.move.trace_up_ids
+#
+#        self.move2.trace_down_ids
+#        self.move2.trace_up_ids
+
+    @mute_logger('openerp.addons.base.ir.ir_model', 'openerp.models')
+    def test_01_reconcile_trace(self):
+        """ In order to create a Supplier Invoice"""
+
+        # I create a invoice line values
+        invoice_lines = []
+
+        line_values = {'quantity': 1.0,
+                       'price_unit': 30.0,
+                       'name': 'test',
+                       'product_id': self.product_consultant,
+                       'uos_id': self.uom_hour,
+                       'account_id': self.expense_account}
+        invoice_lines.append((0, 0, line_values))
+        # I create a invoice using invoice line data and invoice values
+        invoice_values = {'partner_id': self.main_supplier,
+                          'account_id': self.payable_account,
+                          'journal_id': self.purchase_journal,
+                          'date_invoice': time.strftime('%Y-%m-%d'),
+                          'invoice_line': invoice_lines,
+                          'type': 'in_invoice',
+                          'company_id': self.main_company}
+        self.invoice = self.InvoiceObj.create(invoice_values)
+        # I check if the invoice was created
+        self.assertTrue(self.invoice, "Invoice no created")
+        # I active the invoice workflow to validate the invoice and
+        # create the account move associate to this invoice
+        self.invoice.signal_workflow('invoice_open')
+
+        # In order to create a Account move to reconcile the
+        # invoice account move
+
+        # I create the first move line values
+        move_lines = []
+
+        move_values1 = {'name': 'move line 1',
+                        'account_id': self.payable_account,
+                        'partner_id': self.main_supplier,
+                        'debit': 30,
+                        'company_id': self.main_company}
+        move_lines.append((0, 0, move_values1))
+        # I create the second move line values
+        move_values2 = {'name': 'move line 2',
+                        'account_id': self.credit_account,
+                        'credit': 30,
+                        'company_id': self.main_company}
+        move_lines.append((0, 0, move_values2))
+
+        # I find a period using current date
+        period_id = self.PeriodObj.find(time.strftime('%Y-%m-%d'))
+        if period_id:
+            period_id = period_id[0].id
+        # I create a account move using move line data and move values dict
+        move_values = {'journal_id': self.credit_journal,
+                       'date': time.strftime('%Y-%m-%d'),
+                       'period_id': period_id,
+                       'line_id': move_lines}
+        self.move = self.MoveObj.create(move_values)
+        # I check if the account move was created
+        self.assertTrue(self.move, "Account move no created")
+        # I validate the account move
+        self.move.button_validate()
+        # I check the invoice and move amount
+        assert self.invoice.amount_total == self.move.amount, \
+            'The amount could be 30.0'
+
+        #  In order to reconcile the Account Moves
+        invoice_move_id = self.invoice.move_id
+        move_line_to_reconcile = False
+        for invoice_move_line in invoice_move_id.line_id:
+            for move_line in self.move.line_id:
+                if invoice_move_line.account_id == move_line.account_id:
+                    move_line_to_reconcile = invoice_move_line
+                    move_line_to_reconcile += move_line
+        if move_line_to_reconcile:
+            move_line_to_reconcile.reconcile(
+                type='test',
+                writeoff_acc_id=self.payable_account,
+                writeoff_period_id=period_id,
+                writeoff_journal_id=self.credit_journal)
+
+        #  In order to pay and reconcile the Account invoice
+        l1 = {
+            'name': "Payment test supplier invoice",
+            'debit': 30.0,
+            'account_id': self.credit_account,
+            'partner_id': self.main_supplier,
+            'company_id': self.main_company,
+        }
+        l2 = {
+            'name': "Payment test supplier invoice",
+            'credit': 30.0,
+            'account_id': self.pay_account_id,
+            'partner_id': self.main_supplier,
+            'company_id': self.main_company,
+        }
+        self.move2 = self.MoveObj.create({'line_id': [(0, 0, l1), (0, 0, l2)],
+                                          'journal_id': self.journal_id,
+                                          'period_id': period_id,
+                                          'date': time.strftime('%Y-%m-%d')})
+        # I check if the account move was created
+        self.assertTrue(self.move2, "Account move no created")
+        # I validate the account move
+        self.move2.button_validate()
+        # I check the invoice and move amount
+        assert self.move.amount == self.move2.amount, \
+            'The amount could be 30.0'
+        move_line_to_reconcile = False
+        for move_line1 in self.move.line_id:
+            for move_line2 in self.move2.line_id:
+                if move_line1.account_id == move_line2.account_id:
+                    move_line_to_reconcile = move_line1
+                    move_line_to_reconcile += move_line2
+        if move_line_to_reconcile:
+            move_line_to_reconcile.reconcile(
+                type='test',
+                writeoff_acc_id=self.credit_account,
+                writeoff_period_id=period_id,
+                writeoff_journal_id=self.journal_id)
+
+        # In order to check the account.reconcile.trace.direct moves
+        #  down_move_id = asiento de factura,
+        #  up_move_id = asiento de "Checks Transfer Debit"
+        trace_direct1 = self.TraceDirectObj.search(
+            [('down_move_id', '=', invoice_move_id.id),
+             ('up_move_id', '=', self.move.id)])
+
+        assert len(trace_direct1) == 1, \
+            'The quantity of registry in TraceDirect is not correct.'
+
+        # In order to check every account.reconcile.trace.direct fields
+        assert trace_direct1.super_up_move_id == self.move, \
+            'The super_up_move_id is wrong.'
+        assert trace_direct1.super_down_move_id == invoice_move_id, \
+            'The super_down_move_id is wrong.'
+        assert trace_direct1.up_journal_id == self.move.journal_id, \
+            'The up_journal_id is wrong.'
+        assert trace_direct1.down_journal_id == invoice_move_id.journal_id, \
+            'The down_journal_id is wrong.'
+        assert trace_direct1.up_amount == self.move.amount, \
+            'The up_amount is wrong.'
+        assert trace_direct1.down_amount == invoice_move_id.amount, \
+            'The down_amount is wrong.'
+        assert trace_direct1.up_date == self.move.date, \
+            'The up_date is wrong.'
+        assert trace_direct1.down_date == invoice_move_id.date, \
+            'The down_date is wrong.'
+        assert trace_direct1.up_ref == self.move.ref, \
+            'The up_ref is wrong.'
+        assert trace_direct1.down_ref == invoice_move_id.ref, \
+            'The down_ref is wrong.'
+
+        # down_move_id = asiento de "Checks Transfer Debit",
+        # up_move_id = asiento de "pago" del asiento anterior.
+        trace_direct2 = self.TraceDirectObj.search(
+            [('down_move_id', '=', self.move.id),
+             ('up_move_id', '=', self.move2.id)])
+
+        assert len(trace_direct2) == 1, \
+            'The quantity of registry TraceDirect is not correct.'
+
+        # In order to check every account.reconcile.trace.direct fields
+        assert trace_direct2.super_up_move_id == self.move2, \
+            'The super_up_move_id is wrong.'
+        assert trace_direct2.super_down_move_id == self.move, \
+            'The super_down_move_id is wrong.'
+        assert trace_direct2.up_journal_id == self.move2.journal_id, \
+            'The up_journal_id is wrong.'
+        assert trace_direct2.down_journal_id == self.move.journal_id, \
+            'The down_journal_id is wrong.'
+        assert trace_direct2.up_amount == self.move2.amount, \
+            'The up_amount is wrong.'
+        assert trace_direct2.down_amount == self.move.amount, \
+            'The down_amount is wrong.'
+        assert trace_direct2.up_date == self.move2.date, \
+            'The up_date is wrong.'
+        assert trace_direct2.down_date == self.move.date, \
+            'The down_date is wrong.'
+        assert trace_direct2.up_ref == self.move2.ref, \
+            'The up_ref is wrong.'
+        assert trace_direct2.down_ref == self.move.ref, \
+            'The down_ref is wrong.'
+
+        # In order to check the account.reconcile.trace.recursive moves
+        #  down_move_id = asiento de factura,
+        #  up_move_id = asiento de "Checks Transfer Debit"
+        trace_recursive1 = self.TraceRecursiveObj.search(
+            [('down_move_id', '=', invoice_move_id.id),
+             ('up_move_id', '=', self.move.id)])
+
+        assert len(trace_recursive1) == 1, \
+            'The quantity of registry in TraceRecursive is not correct.'
+
+        # In order to check every account.reconcile.trace.recursive fields
+        assert trace_recursive1.super_up_move_id == \
+            trace_direct1.super_up_move_id, \
+            'The super_up_move_id is wrong.'
+        assert trace_recursive1.super_down_move_id == \
+            trace_direct1.super_down_move_id, \
+            'The super_down_move_id is wrong.'
+        assert trace_recursive1.up_journal_id == \
+            trace_recursive1.up_journal_id, \
+            'The up_journal_id is wrong.'
+        assert trace_recursive1.down_journal_id == \
+            trace_direct1.down_journal_id, \
+            'The down_journal_id is wrong.'
+        assert trace_recursive1.up_amount == trace_recursive1.up_amount, \
+            'The up_amount is wrong.'
+        assert trace_recursive1.down_amount == trace_direct1.down_amount, \
+            'The down_amount is wrong.'
+        assert trace_recursive1.up_date == trace_recursive1.up_date, \
+            'The up_date is wrong.'
+        assert trace_recursive1.down_date == trace_direct1.down_date, \
+            'The down_date is wrong.'
+        assert trace_recursive1.up_ref == trace_recursive1.up_ref, \
+            'The up_ref is wrong.'
+        assert trace_recursive1.down_ref == trace_direct1.down_ref, \
+            'The down_ref is wrong.'
+        # down_move_id = asiento de "Checks Transfer Debit",
+        # up_move_id = asiento de "pago" del asiento anterior.
+        trace_recursive2 = self.TraceRecursiveObj.search(
+            [('down_move_id', '=', self.move.id),
+             ('up_move_id', '=', self.move2.id)])
+
+        assert len(trace_recursive2) == 1, \
+            'The quantity of registry in TraceRecursive is not correct.'
+
+        # In order to check every account.reconcile.trace.direct fields
+        assert trace_recursive2.super_up_move_id == \
+            trace_direct2.super_up_move_id, \
+            'The super_up_move_id is wrong.'
+        assert trace_recursive2.super_down_move_id == \
+            trace_direct1.super_up_move_id, \
+            'The super_down_move_id is wrong.'
+        assert trace_recursive2.up_journal_id == \
+            trace_direct2.up_journal_id, \
+            'The up_journal_id is wrong.'
+        assert trace_recursive2.down_journal_id == \
+            trace_direct1.up_journal_id, \
+            'The down_journal_id is wrong.'
+        assert trace_recursive2.up_amount == trace_direct2.up_amount, \
+            'The up_amount is wrong.'
+        assert trace_recursive2.down_amount == trace_direct1.up_amount, \
+            'The down_amount is wrong.'
+        assert trace_recursive2.up_date == trace_direct2.up_date, \
+            'The up_date is wrong.'
+        assert trace_recursive2.down_date == trace_direct1.up_date, \
+            'The down_date is wrong.'
+        assert trace_recursive2.up_ref == trace_direct2.up_ref, \
+            'The up_ref is wrong.'
+        assert trace_recursive2.down_ref == trace_direct1.up_ref, \
+            'The down_ref is wrong.'
+#
+#         trace_recursive3 = self.TraceRecursiveObj.search(
+#                                                          [
+#                                                           ('down_move_id',
+#                                                            '=',
+#                                                            invoice_move_id.id),
+#                                                           ('up_move_id',
+#                                                            '=',
+#                                                            self.move2.id)])
+#        assert len(trace_recursive3) == 1 , \
+#            'The quantity of registry in this model not is correct.'
+
+#        """In order to check the trace recursive in invoice"""
+#        self.invoice.trace_down_ids
+#        self.invoice.trace_up_ids
+#        """In order to check the trace recursive in account moves"""
+#        self.move.trace_down_ids
+#        self.move.trace_up_ids
+#
+#        self.move2.trace_down_ids
+#        self.move2.trace_up_ids

--- a/account_reconcile_trace/views/account_view.xml
+++ b/account_reconcile_trace/views/account_view.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_move_trace_form" model="ir.ui.view">
+            <field name="name">account.move.trace.form</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_move_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//page[@string='Journal Items']" position="after">
+                    <page string="Trace">
+                        <group string="Trace Down">
+                            <field name="trace_down_ids" nolabel="1"
+                                readonly="1">
+                                <tree>
+                                    <field name="down_date" string="Date" />
+                                    <field name="up_move_id" />
+                                    <field name="down_move_id" />
+                                    <field name="down_ref" string="Ref" />
+                                    <field name="down_name" string="Name" />
+                                    <field name="down_journal_id" string="Journal" />
+                                    <field name="down_amount" string="Amount" />
+                                </tree>
+                            </field>
+                        </group>
+                        <group string="Trace Up">
+                            <field name="trace_up_ids" nolabel="1"
+                                readonly="1">
+                                <tree>
+                                    <field name="up_date" string="Date" />
+                                    <field name="up_move_id" />
+                                    <field name="down_move_id" />
+                                    <field name="up_ref" string="Ref" />
+                                    <field name="up_name" string="Name" />
+                                    <field name="up_journal_id" string="Journal" />
+                                    <field name="up_amount" string="Amount" />
+                                </tree>
+                            </field>
+                        </group>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+
+
+        <record id="invoice_trace_form" model="ir.ui.view">
+            <field name="name">account.invoice.trace.form</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//page[@string='Payments']" position="inside">
+                    <group string="Trace">
+                        <field name="trace_down_ids" nolabel="1" readonly="1">
+                            <tree string="Trace">
+                                <field name="down_date" string="Date" />
+                                <field name="up_move_id" />
+                                <field name="down_move_id" />
+                                <field name="down_ref" string="Ref" />
+                                <field name="down_name" string="Name" />
+                                <field name="down_journal_id" string="Journal" />
+                                <field name="down_amount" string="Amount" />
+                            </tree>
+                        </field>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="invoice_supplier_trace_form" model="ir.ui.view">
+            <field name="name">account.invoice.supplier.trace.form</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_supplier_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//page[@string='Payments']" position="inside">
+                    <group string="Trace">
+                        <field name="trace_up_ids" nolabel="1" readonly="1">
+                            <tree string="Trace">
+                                <field name="up_date" string="Date" />
+                                <field name="up_move_id" />
+                                <field name="down_move_id" />
+                                <field name="up_ref" string="Ref" />
+                                <field name="up_name" string="Name" />
+                                <field name="up_journal_id" string="Journal" />
+                                <field name="up_amount" string="Amount" />
+                            </tree>
+                        </field>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_trace_form" model="ir.ui.view">
+            <field name="name">view.trace.form</field>
+            <field name="model">account.reconcile.trace.recursive</field>
+            <field name="arch" type="xml">
+                <form string="Trace">
+                    <group name="main">
+                        <group string="Trace Up">
+                            <field name="up_date" string="Date" />
+                            <field name="up_move_id" string="Move" />
+                            <field name="up_ref" string="Ref" />
+                            <field name="up_name" string="Name" />
+                            <field name="up_journal_id" string="Journal" />
+                            <field name="up_amount" string="Amount" />
+                        </group>
+                        <group string="Trace Down">
+                            <field name="down_date" string="Date" />
+                            <field name="down_move_id" string="Move" />
+                            <field name="down_ref" string="Ref" />
+                            <field name="down_name" string="Name" />
+                            <field name="down_journal_id" string="Journal" />
+                            <field name="down_amount" string="Amount" />
+                        </group>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+
+    </data>
+</openerp>


### PR DESCRIPTION
# Account Reconciliation Trace

account_reconcile_trace module support trace account entries and their reconciled entries and allow you to get this trace by account entries or by invoices.

It's usefull when you pay an invoice by a check, and you want to know the state of this check, this information is recursive so you can pay a check with another check, or set as unpayable. So on down trace you can know one check witch invoice is payed from.
# Usage

To use this module, reconciliation trace can be seen from:
- account entry, on "Trace" page in notebook.
- invoice, on "Payment" page in notebook.
