### PR TITLE
[FIX][account_reversal] When period is set on the reversal wizard. reversal_period_id is never transformed to a recordset

### DIFF
--- a/account_reversal/account_reversal.py
+++ b/account_reversal/account_reversal.py
@@ -61,9 +61,9 @@ class account_move(models.Model):
         period_obj = self.env['account.period']
 
         if reversal_period_id:
-            reversal_period_id = period_obj.browse([reversal_period_id])[0]
+            reversal_period = period_obj.browse([reversal_period_id])[0]
         else:
-            reversal_period_id = period_obj.with_context(
+            reversal_period = period_obj.with_context(
                 company_id=self.company_id.id,
                 account_period_prefer_normal=True).find(reversal_date)[0]
         if not reversal_journal_id:
@@ -73,7 +73,7 @@ class account_move(models.Model):
                 reversal_journal_id]).company_id != self.company_id:
             raise Warning(_('Wrong company Journal is %s but we have %s') % (
                 reversal_journal_id.company_id.name, self.company_id.name))
-        if reversal_period_id.company_id != self.company_id:
+        if reversal_period.company_id != self.company_id:
             raise Warning(_('Wrong company Period is %s but we have %s') % (
                 reversal_journal_id.company_id.name, self.company_id.name))
 
@@ -81,7 +81,7 @@ class account_move(models.Model):
         reversal_move = self.copy(default={
             'company_id': self.company_id.id,
             'date': reversal_date,
-            'period_id': reversal_period_id.id,
+            'period_id': reversal_period.id,
             'ref': reversal_ref,
             'journal_id': reversal_journal_id,
             'to_be_reversed': False,

--- a/account_reversal/account_reversal.py
+++ b/account_reversal/account_reversal.py
@@ -60,7 +60,9 @@ class account_move(models.Model):
         self.ensure_one()
         period_obj = self.env['account.period']
 
-        if not reversal_period_id:
+        if reversal_period_id:
+            reversal_period_id = period_obj.browse([reversal_period_id])[0]
+        else:
             reversal_period_id = period_obj.with_context(
                 company_id=self.company_id.id,
                 account_period_prefer_normal=True).find(reversal_date)[0]


### PR DESCRIPTION
The system attempts to read company_id from reversal_period_id that is an integer.
https://github.com/OCA/account-financial-tools/blob/8.0/account_reversal/account_reversal.py#L74
