### PR TITLE
company_id on currency.rate.update.service needs to have a default value

### DIFF
--- a/currency_rate_update/model/currency_rate_update.py
+++ b/currency_rate_update/model/currency_rate_update.py
@@ -212,7 +212,10 @@ class Currency_rate_update_service(models.Model):
                                           string='Currencies to update with '
                                           'this service')
     # Link with company
-    company_id = fields.Many2one('res.company', 'Company')
+    company_id = fields.Many2one(
+        'res.company', 'Company',
+        default=lambda self: self.env['res.company']._company_default_get(
+            'currency.rate.update.service'))
     # Note fileds that will be used as a logger
     note = fields.Text('Update logs')
     max_delta_days = fields.Integer(


### PR DESCRIPTION
If you try to create a currency.rate.update.service via the new menu entry in Accounting > Configuration > Misc > Currency Rate Update, you create blocked when you try to save because the field company_id doesn't have a default value.

This PR fixes this problem.
