### PR TITLE
Add 'api.one' to function setting model values

### DIFF
--- a/account_credit_control/wizard/credit_control_communication.py
+++ b/account_credit_control/wizard/credit_control_communication.py
@@ -81,6 +81,7 @@ class CreditCommunication(models.TransientModel):
         balance_field = 'credit_control_line_ids.balance_due'
         return sum(self.mapped(balance_field))
 
+    @api.one
     @api.depends('credit_control_line_ids',
                  'credit_control_line_ids.amount_due',
                  'credit_control_line_ids.balance_due')


### PR DESCRIPTION
This PR is to add the decorator 'api.one' on the method `compute_total` ; otherwise, `self` could be a record list and fail, creating empty totals in the report.
