### PR TITLE
[FIX] account_move_batch_validate: Protect connector import, define empty decorator if needed. Fixes #280

### DIFF
--- a/account_move_batch_validate/account.py
+++ b/account_move_batch_validate/account.py
@@ -25,11 +25,19 @@ import logging
 from openerp.osv import fields, orm
 from openerp.tools.translate import _
 
-from openerp.addons.connector.queue.job import job
-from openerp.addons.connector.session import ConnectorSession
-from openerp.addons.connector.queue.job import OpenERPJobStorage
-
 _logger = logging.getLogger(__name__)
+
+try:
+    from openerp.addons.connector.queue.job import job
+    from openerp.addons.connector.session import ConnectorSession
+    from openerp.addons.connector.queue.job import OpenERPJobStorage
+except ImportError:
+    _logger.debug('Can not `import connector`.')
+    import functools
+
+    def empty_decorator_factory(*argv, **kwargs):
+        return functools.partial
+    job = empty_decorator_factory
 
 # do a massive write on account moves BLOCK_SIZE at a time
 BLOCK_SIZE = 1000

--- a/account_move_batch_validate/wizard/move_marker.py
+++ b/account_move_batch_validate/wizard/move_marker.py
@@ -20,9 +20,21 @@
 ###############################################################################
 """Wizards for batch posting."""
 
+import logging
+
 from openerp.osv import fields, orm
-from openerp.addons.connector.session import ConnectorSession
-from openerp.addons.connector.queue.job import job
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from openerp.addons.connector.session import ConnectorSession
+    from openerp.addons.connector.queue.job import job
+except ImportError:
+    _logger.debug('Can not `import connector`.')
+
+    def empty_decorator(func):
+        return func
+    job = empty_decorator
 
 
 class AccountMoveMarker(orm.TransientModel):


### PR DESCRIPTION
https://github.com/OCA/account-financial-tools/pull/281
