### PR TITLE
[ADD] account_type_multi_company

### DIFF
--- a/account_type_multi_company/README.rst
+++ b/account_type_multi_company/README.rst
@@ -1,0 +1,60 @@
+==========================
+Multi company account type
+==========================
+
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+This module was written to extend the functionality of account type 
+and make them multi company aware.
+
+It also adds an active flag on account types.
+
+Installation
+============
+
+There is no specific installation procedure for this module.
+
+Configuration
+=============
+
+There is no specific configuration for this module.
+
+Usage
+=====
+
+To use this module, you need to:
+
+ * go to Accounting > Configuration > Accounts > Account Types.
+
+For further information, please visit:
+
+ * https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+ * N/A
+
+Credits
+=======
+
+Contributors
+------------
+
+* Luc De Meyer <luc.demeyer@noviat.be>
+* Stephane Bidoul <stephane.bidoul@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_type_multi_company/__init__.py
+++ b/account_type_multi_company/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/account_type_multi_company/__openerp__.py
+++ b/account_type_multi_company/__openerp__.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of account_type_multi_company,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#     Copyright (c) 2015 Noviat (<http://acsone.eu>)
+#
+#     account_type_multi_company is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     account_type_multi_company is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with account_type_multi_company.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Multi company account types",
+    'summary': """
+        Make account types multi-company aware""",
+    'author': "ACSONE SA/NV,"
+              "Noviat,"
+              "Odoo Community Association (OCA)",
+    'category': 'Accounting & Finance',
+    'version': '8.0.1.0',
+    'license': 'AGPL-3',
+    'depends': [
+        'account',
+    ],
+    'data': [
+        'security/multi_company.xml',
+        'views/account_type.xml',
+    ],
+}

--- a/account_type_multi_company/models/__init__.py
+++ b/account_type_multi_company/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import account_type

--- a/account_type_multi_company/models/account_type.py
+++ b/account_type_multi_company/models/account_type.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of account_type_multi_company,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     account_type_multi_company is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     account_type_multi_company is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with account_type_multi_company.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class AccountAccountType(models.Model):
+    _inherit = 'account.account.type'
+
+    active = fields.Boolean(string='Active', select=True, default=True)
+    company_id = fields.Many2one('res.company', string='Company')

--- a/account_type_multi_company/security/multi_company.xml
+++ b/account_type_multi_company/security/multi_company.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data noupdate="1">
+    <record model="ir.rule" id="account_type_mc_rule">
+      <field name="name">Account Type Multi Company rule</field>
+      <field name="model_id" ref="model_account_account_type"/>
+      <field name="global" eval="True"/>
+      <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+    </record>
+  </data>
+</openerp>

--- a/account_type_multi_company/views/account_type.xml
+++ b/account_type_multi_company/views/account_type.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_account_type_form_inherit" model="ir.ui.view">
+          <field name="name">account.account.type.form.inherit</field>
+          <field name="model">account.account.type</field>
+          <field name="inherit_id" ref="account.view_account_type_form"/>
+          <field name="arch" type="xml">
+            <field name="code" position="after">
+              <field name="company_id" groups="base.group_multi_company"/>
+              <field name="active"/>
+            </field>
+          </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
This module makes account.account.type multi-company aware and adds an active flags.

It was originally written by @luc-demeyer in l10n_be_coa_multilang.

Done during OCA/l10n-belgium code sprint on 2015-08-28.
