### PR TITLE
[CHG] account_default_draft_move: make Post button visible on account moves

### DIFF
--- a/account_default_draft_move/README.rst
+++ b/account_default_draft_move/README.rst
@@ -25,16 +25,12 @@ accountants validate them and correct the corresponding invoices before posting
 the moves.
 * It hides the Cancel button on account moves unless account_cancel is installed
 and cancellation is allowed on the corresponding journal. 
-* Additionnaly, the Post button is hidden on account moves, therefore providing
-a framework where the user work with draft moves until everything is correct,
-and validates all account moves at once and the end. [2]
 
 [1] provided the parameter is set in Settings > Configuration, if this
 parameter is not set the moves generated from invoices and bank statement
 always remain in draft state ignoring the "Skip draft move flag" on
 account journal. This parameter is not set by default for backward
 compatibility with previous versions of account_default_draft_move.
-[2] this behaviour will be made configurable in the near future.
 
 Installation
 ============

--- a/account_default_draft_move/account_view.xml
+++ b/account_default_draft_move/account_view.xml
@@ -7,7 +7,6 @@
       <field name="inherit_id" ref="account.view_move_form"/>
       <field name="arch" type="xml">
         <data>
-          <button name="button_validate" position="replace"/>
           <button name="button_cancel" position="after">
             <field name="update_posted" invisible="1"/>
           </button>


### PR DESCRIPTION
I believe it does not harm to keep the Post button visible when account_default_draft_move is installed.

This PR is to discuss it's reenablement, so @fclementic2c and other account_default_draft_move users (if any), your input is welcome. Should this be an issue, we can make this configurable.
