### PR TITLE
[8.0][account_credit_control] Add custom message after details.

### DIFF
--- a/account_credit_control/policy.py
+++ b/account_credit_control/policy.py
@@ -241,6 +241,8 @@ class CreditControlPolicyLevel(models.Model):
                               translate=True)
     custom_mail_text = fields.Html(string='Custom Mail Message',
                                    required=True, translate=True)
+    custom_text_after_details = fields.Text(
+        string='Custom Message after details', translate=True)
 
     _sql_constraint = [('unique level',
                         'UNIQUE (policy_id, level)',

--- a/account_credit_control/policy_view.xml
+++ b/account_credit_control/policy_view.xml
@@ -40,6 +40,8 @@
                         <newline/>
                         <field name="custom_text" colspan="4"/>
                         <newline/>
+                        <field name="custom_text_after_details" colspan="4"/>
+                        <newline/>
                         <field name="custom_mail_text" colspan="4"/>
                       </group>
                     </page>

--- a/account_credit_control/report/report_credit_control_summary.xml
+++ b/account_credit_control/report/report_credit_control_summary.xml
@@ -83,7 +83,9 @@
               </table>
             </div>
           </div>
-
+        <t t-if="o.current_policy_level.custom_text_after_details">
+            <p class="mt32 mb32" t-field="o.current_policy_level.custom_text_after_details"/>
+        </t>
         </div>
       </t>
     </template>


### PR DESCRIPTION
Add the possibility to defnied a custom message that to be displayed after the details table on credit control report.
