### PR TITLE
8.0 asset remove fix

### DIFF
--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -243,7 +243,7 @@ class account_asset_asset(orm.Model):
                 raise orm.except_orm(
                     _('Invalid action!'),
                     _("You can only delete assets in draft state."))
-            if filter(lambda dl: dl.type == 'depreciate',
+            if filter(lambda dl: dl.type == 'depreciate' and dl.move_check,
                       asset.depreciation_line_ids):
                 raise orm.except_orm(
                     _('Error!'),
@@ -253,7 +253,8 @@ class account_asset_asset(orm.Model):
                 self.pool['account.move.line'].write(
                     cr, uid, [x.id for x in asset.account_move_line_ids],
                     {'asset_id': False},
-                    context=dict(context, allow_asset_removal=True))
+                    context=dict(context, allow_asset_removal=True,
+                                 from_parent_object=True))
             parent = asset.parent_id
             super(account_asset_asset, self).unlink(
                 cr, uid, [asset.id], context=context)

--- a/account_asset_management/account_move.py
+++ b/account_asset_management/account_move.py
@@ -136,10 +136,12 @@ class account_move_line(orm.Model):
         for move_line in self.browse(cr, uid, ids, context=context):
             if move_line.asset_id.id:
                 if set(vals).intersection(FIELDS_AFFECTS_ASSET_MOVE_LINE):
-                    raise orm.except_orm(
-                        _('Error!'),
-                        _("You cannot change an accounting item "
-                          "linked to an asset depreciation line."))
+                    if not (context.get('allow_asset_removal')
+                            and vals.keys() == ['asset_id']):
+                        raise orm.except_orm(
+                            _('Error!'),
+                            _("You cannot change an accounting item "
+                              "linked to an asset depreciation line."))
         if vals.get('asset_id'):
             raise orm.except_orm(
                 _('Error!'),


### PR DESCRIPTION
Currently, it's not possible to remove an asset without depreciation line.

This PR is an alternative to https://github.com/OCA/account-financial-tools/pull/298 to fix this issue.
