### PR TITLE
[ADD] [8.0] account_voucher_number_to_move

### DIFF
--- a/account_voucher_number_to_move/README.rst
+++ b/account_voucher_number_to_move/README.rst
@@ -1,0 +1,63 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Account Voucher Number to Move
+==============================
+This module extends the Vouchers so that any change made to the voucher
+number is copied to the Account Move's reference field.
+
+This is going to be useful in checks, where the check number is usually
+entered manually to the system once it has been printed, for reference
+purposes.
+
+Installation
+============
+
+No additional installation instructions are required.
+
+
+Configuration
+=============
+
+This module does not require any additional configuration.
+
+Usage
+=====
+
+No specific usage instructions are required.
+
+Known issues / Roadmap
+======================
+No issues have been detected.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/{project_repo}/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/{project_repo}/issues/new?body=module:%20{module_name}%0Aversion:%20{version}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+- Jordi Ballester Alomar (Eficent)
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_voucher_number_to_move/__init__.py
+++ b/account_voucher_number_to_move/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import model

--- a/account_voucher_number_to_move/__openerp__.py
+++ b/account_voucher_number_to_move/__openerp__.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Account Voucher Number to Move",
+    "version": "0.1",
+    "license": "AGPL-3",
+    "author": "Eficent, "
+              "Odoo Community Association (OCA)",
+    "website": "www.eficent.com",
+    "contributors": [
+        "Jordi Ballester Alomar <jordi.ballester@eficent.com>",
+    ],
+    "category": "Accounting & Finance",
+    "depends": ["account_voucher"],
+    "installable": True,
+}

--- a/account_voucher_number_to_move/model/__init__.py
+++ b/account_voucher_number_to_move/model/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+##############################################################################
+from . import account_voucher

--- a/account_voucher_number_to_move/model/account_voucher.py
+++ b/account_voucher_number_to_move/model/account_voucher.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, api
+
+class AccountVoucher(models.Model):
+
+    _inherit = 'account.voucher'
+
+    @api.multi
+    def write(self, vals):
+        for voucher in self:
+            number = vals.get('number', False)
+            if number and voucher.move_id:
+                voucher.move_id.ref = number
+                for move_line in voucher.move_id.line_id:
+                    move_line.ref = number
+        return super(AccountVoucher, self).write(vals)


### PR DESCRIPTION
# Account Voucher Number to Move

This module extends the Vouchers so that any change made to the voucher
number is copied to the Account Move's reference field.

This is going to be useful in checks, where the check number is usually
entered manually to the system once it has been printed, for reference
purposes.
