### PR TITLE
[ADD][7.0] account_voucher_number_to_move

### DIFF
--- a/account_voucher_number_to_move/__init__.py
+++ b/account_voucher_number_to_move/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import model

--- a/account_voucher_number_to_move/__openerp__.py
+++ b/account_voucher_number_to_move/__openerp__.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Account Voucher Number to Move",
+    "version": "0.1",
+    "license": "AGPL-3",
+    "author": "Eficent",
+    "website": "www.eficent.com",
+    "category": "'Accounting & Finance",
+    "depends": ["account_voucher"],
+    "description": """
+Account Voucher Number to Move
+==============================
+This module extend the Vouchers so that any change made to the voucher
+number is copied to the Account Move's reference field.
+
+This is going to be useful in checks, where the check number is usually
+entered manually to the system once it has been printed, for reference
+purposes.
+
+
+Installation
+============
+
+No additional installation instructions are required.
+
+
+Configuration
+=============
+
+This module does not require any additional configuration.
+
+Usage
+=====
+
+No specific usage instructions are required.
+
+Known issues / Roadmap
+======================
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+    """,
+    "init_xml": [],
+    "update_xml": [],
+    'demo_xml': [],
+    'test': [],
+    'installable': True,
+    'active': False,
+    'certificate': '',
+}

--- a/account_voucher_number_to_move/model/__init__.py
+++ b/account_voucher_number_to_move/model/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+##############################################################################
+from . import account_voucher

--- a/account_voucher_number_to_move/model/account_voucher.py
+++ b/account_voucher_number_to_move/model/account_voucher.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import fields, orm
+
+
+class AccountVoucher(orm.Model):
+
+    _inherit = 'account.voucher'
+
+    def write(self, cr, uid, ids, vals, context=None):
+        move_obj = self.pool['account.move']
+        move_line_obj = self.pool['account.move.line']
+        for voucher in self.browse(cr, uid, ids, context=context):
+            if vals.get('number') and voucher.move_id:
+                if vals['number']:
+                    move_obj.write(cr, uid, [voucher.move_id.id],
+                                   {'ref': vals.get('number')},
+                                   context=context)
+                    move_line_ids = []
+                    name = vals.get('number')
+                    for move_line in voucher.move_id.line_id:
+                        move_line_ids.append(move_line.id)
+                    move_line_obj.write(cr, uid, move_line_ids,
+                                        {'ref': name},
+                                        context=context)
+        return super(AccountVoucher, self).write(cr, uid, ids, vals,
+                                                 context=context)


### PR DESCRIPTION
# Account Voucher Number to Move

This module extends the Vouchers so that any change made to the voucher
number is copied to the Account Move's reference field.

This is going to be useful in checks, where the check number is usually
entered manually to the system once it has been printed, for reference
purposes.
