### PR TITLE
[CHG][account_invoice_currency] Change xpath expression for account_invoice_period_usability

### DIFF
--- a/account_invoice_currency/views/account_invoice_view.xml
+++ b/account_invoice_currency/views/account_invoice_view.xml
@@ -12,7 +12,7 @@
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_supplier_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='period_id']/.." position="after">
+                <xpath expr="//field[@name='move_id']/.." position="after">
                     <group string="Amounts in company currency">
                         <field name="cc_amount_untaxed"/>
                         <field name="cc_amount_tax"/>


### PR DESCRIPTION
Use move_id instead of period_id that is moved out of other info page in account_invoice_period_usability from OCA/account-invoicing
