### PR TITLE
[8.0] account_asset_management: fiscal years company specific

### DIFF
--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -447,7 +447,11 @@ class account_asset_asset(orm.Model):
             # with a duration equals to calendar year
             cr.execute(
                 "SELECT id, date_start, date_stop "
-                "FROM account_fiscalyear ORDER BY date_stop ASC LIMIT 1")
+                "FROM account_fiscalyear "
+                "WHERE company_id = %s "
+                "ORDER BY date_stop ASC LIMIT 1"
+                % asset.company_id.id
+            )
             first_fy = cr.dictfetchone()
             first_fy_date_start = datetime.strptime(
                 first_fy['date_start'], '%Y-%m-%d')


### PR DESCRIPTION
When no fiscal year is found for the start date on an asset, a query will be executed to search for the first available fiscal year in the system. But this query is not company specific. The company is found on the asset and this company id should be used in the query.
