### PR TITLE
[FIX] account_asset_management: Error on change duration

### DIFF
--- a/account_asset_management/wizard/account_asset_change_duration.py
+++ b/account_asset_management/wizard/account_asset_change_duration.py
@@ -54,7 +54,8 @@ class asset_modify(orm.TransientModel):
             toolbar=toolbar, submenu=submenu)
         asset_id = context.get('active_id', False)
         active_model = context.get('active_model', '')
-        if active_model == 'account.asset.asset' and asset_id:
+        if active_model == 'account.asset.asset' and asset_id \
+                and view_type == 'form':
             asset = asset_obj.browse(cr, uid, asset_id, context=context)
             doc = etree.XML(result['arch'])
             if asset.method_time == 'number':


### PR DESCRIPTION
  File "../account_asset_management/wizard/account_asset_change_duration.py", line 67, in fields_view_get
    node_me = doc.xpath("//field[@name='method_end']")[0]
IndexError: list index out of range
