### PR TITLE
[8.0][FIX] account_asset: entries from assets

### DIFF
--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -1563,7 +1563,7 @@ class account_asset_depreciation_line(orm.Model):
                          period_id, context):
         asset = depreciation_line.asset_id
         move_data = {
-            'name': asset.name,
+            'name': "/",
             'date': depreciation_date,
             'ref': depreciation_line.name,
             'period_id': period_id,


### PR DESCRIPTION
When an entry is generated from an asset, the number of this entry must be
the sequence number linked to the journal of the asset and the reference of
this entry is the name of the asset.

opw:639760

SHA 443605ce (open)
by Goffin Simon, 05/25/2015 06:35 PM
parent 5c690d37
