### PR TITLE
[ADD] base_currency_rate_exchange_method

### DIFF
--- a/base_currency_rate_exchange_method/README.rst
+++ b/base_currency_rate_exchange_method/README.rst
@@ -1,0 +1,78 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License
+
+Currency Exchange Rate Method
+=============================
+
+Allow company to choose between (1) direct exchange rate method, 
+and (2) indirect exchange rate method
+
+Direct Method:
+With the direct method of foreign exchange quotation, the exchange rate is expressed as the 
+number of units of the domestic currency needed to acquire one (1.0) unit of the 
+pertinent foreign currency. Within the U.S., this method is also referred to 
+as quoting exchange rates in American (U.S.) terms.
+
+Indirect Method:
+With the indirect method of foreign exchange quotation, the exchange rate is expressed 
+as the number of units of the pertinent foreign currency needed to acquire 
+one (1.0) unit of the domestic currency. In the U.S., this method is 
+referred to as quoting the exchange rate in foreign terms.
+
+http://www.investopedia.com/exam-guide/cfa-level-1/global-economic-analysis/foreign-exchange.asp
+
+Configuration
+=============
+
+Exchange rate method can be set under company form
+
+
+Usage
+=====
+
+The exchange rate mtehod will affect the way you input currency rate
+e.g:
+
+* Given company currency equal is USD (USD = 1.0)
+* Suppose you are given the direct quote, in U.S. terms, between the U.S. dollar and the euro as:
+  1 EUR = 1.2830 USD
+* If you use indirect method than You should input EUR rate: 1 / 1.2830 = 0.779423227
+  If you use direct method than you should input EUR rate: 1.2830
+
+
+Know issues / Roadmap
+=====================
+
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/account-financial-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/account-financial-tools/issues/new?body=module:%20currency_rate_update%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Andhitia Rama <andhitia.r@gmail.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/base_currency_rate_exchange_method/__init__.py
+++ b/base_currency_rate_exchange_method/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) 2015 Andhitia Rama. All rights reserved.
+#    @author Andhitia Rama
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/base_currency_rate_exchange_method/__openerp__.py
+++ b/base_currency_rate_exchange_method/__openerp__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) 2009 CamptoCamp. All rights reserved.
+#    @author Nicolas Bessi
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Currency Rate Exchange Method",
+    "version": "8.0.1.0.0",
+    "author": "Andhitia Rama,Odoo Community Association (OCA)",
+    "website": "http://andhitiarama.wordpress.com",
+    "license": "AGPL-3",
+    "category": "Financial Management/Configuration",
+    "depends": [
+        "base",
+    ],
+    "data": [
+        "views/res_company_view.xml",
+    ],
+    "demo": [],
+    "active": False,
+    'installable': True
+}

--- a/base_currency_rate_exchange_method/models/__init__.py
+++ b/base_currency_rate_exchange_method/models/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) 2015 Andhitia Rama. All rights reserved.
+#    @author Andhitia Rama
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import res_company
+from . import res_currency

--- a/base_currency_rate_exchange_method/models/res_company.py
+++ b/base_currency_rate_exchange_method/models/res_company.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) 2015 Andhitia Rama. All rights reserved.
+#    @author Andhitia Rama
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class res_company(models.Model):
+    """override company to add exchange rate method"""
+    _inherit = 'res.company'
+    _name = 'res.company'
+
+    exchange_rate_method = fields.Selection(
+        string='Exchange Rate Method',
+        selection=[
+            ('indirect', 'Indirect'),
+            ('direct', 'Direct'),
+            ],
+        required=True,
+        default='indirect',
+        )

--- a/base_currency_rate_exchange_method/models/res_currency.py
+++ b/base_currency_rate_exchange_method/models/res_currency.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) 2009 Andhitia Rama. All rights reserved.
+#    @author Andhitia Rama
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models
+from openerp.addons.base.res.res_currency import res_currency
+import time
+from openerp.tools.translate import _
+from openerp.osv import osv
+
+
+def _get_conversion_rate(
+        self, cr, uid, from_currency, to_currency, context=None):
+    if context is None:
+        context = {}
+    ctx = context.copy()
+    from_currency = self.browse(cr, uid, from_currency.id, context=ctx)
+    to_currency = self.browse(cr, uid, to_currency.id, context=ctx)
+    obj_user = self.pool.get('res.users')
+    user = obj_user.browse(cr, uid, uid)
+    exchange_rate_method = user.company_id.exchange_rate_method
+
+    if from_currency.rate == 0 or to_currency.rate == 0:
+        date = context.get('date', time.strftime('%Y-%m-%d'))
+        if from_currency.rate == 0:
+            currency_symbol = from_currency.symbol
+        else:
+            currency_symbol = to_currency.symbol
+        msg = _("""No rate found \n
+                for the currency: %s \n
+                at the date %s
+                """) % (currency_symbol, date)
+
+        raise osv.except_osv(_('Error'), msg)
+    if exchange_rate_method == 'direct':
+        return from_currency.rate / to_currency.rate
+    else:
+        return to_currency.rate / from_currency.rate
+
+
+class ResCurrencyHookGetConversionRate(models.AbstractModel):
+    _name = 'res.company.hook.get.conversion.rate'
+    _description = 'Provide hook point to res.company\'s _get_conversion_rate'
+
+    def _register_hook(self, cr):
+        res_currency._get_conversion_rate = _get_conversion_rate

--- a/base_currency_rate_exchange_method/views/res_company_view.xml
+++ b/base_currency_rate_exchange_method/views/res_company_view.xml
@@ -1,0 +1,17 @@
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="currency_exchange_method">
+            <field name="name">res.company.form.inherit</field>
+            <field name="model">res.company</field>
+            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="arch" type="xml">
+                <data>
+                    <xpath expr="//field[@name='currency_id']" position="after">
+                        <field name="exchange_rate_method"/>
+                    </xpath>
+                </data>
+            </field>
+        </record>
+    </data>
+</openerp>
+


### PR DESCRIPTION
This module will give an option to use (1) direct method, or (2) indirect method for currency conversion. Odoo use indirect method for it currency conversion. Indirect method is hard to implement in country that has week currency exchange like Indonesia.

e.g:
- 1 USD = 13,833.00 IDR
- Using indirect method USD rate = 1 / 13.833,00 = 0.072290899
- Odoo currency rate only support 6 digit behind decimal. If we use indirect above we can only input it as 0.072290. This will cause inaccuracy.
- Using direct method, USD rate = 13,833.00

Indirect method is set to default (Odoo default conversion method)
