### PR TITLE
[8.0][IMP][account_invoice_currency] Define cc_amount_* fields as store=True

### DIFF
--- a/account_invoice_currency/README.rst
+++ b/account_invoice_currency/README.rst
@@ -1,3 +1,8 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+====================================
 Account invoices in company currency
 ====================================
 
@@ -25,16 +30,19 @@ Contributors
 * Jordi Esteve <jesteve@zikzakmedia.com>
 * Joaquín Gutierrez <joaquing.pedrosa@gmail.com>
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Antonio Espinosa <antonioea@antiun.com>
 
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
-OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_invoice_currency/__init__.py
+++ b/account_invoice_currency/__init__.py
@@ -1,20 +1,9 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-# Copyright (C) 2004-2011 Zikzakmedia S.L. (http://zikzakmedia.com)
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2004-2011 Zikzakmedia S.L. (http://zikzakmedia.com)
+#             Jordi Esteve <jesteve@zikzakmedia.com>
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import models

--- a/account_invoice_currency/__openerp__.py
+++ b/account_invoice_currency/__openerp__.py
@@ -1,31 +1,15 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#  OpenERP - Account invoice currency
-#  Copyright (C) 2004-2011 Zikzakmedia S.L. (http://zikzakmedia.com)
-#                         Jordi Esteve <jesteve@zikzakmedia.com>
-#  Copyright (c) 2013 Joaquin Gutierrez (http://www.gutierrezweb.es)
-#  Copyright (c) 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
-#
-#  This program is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU Affero General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU Affero General Public License for more details.
-#
-#  You should have received a copy of the GNU Affero General Public License
-#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2004-2011 Zikzakmedia S.L. (http://zikzakmedia.com)
+#             Jordi Esteve <jesteve@zikzakmedia.com>
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': "Company currency in invoices",
-    'version': "8.0.1.0.0",
-    'author': "Zikzakmedia SL, ,Odoo Community Association (OCA)"
+    'version': "8.0.1.1.0",
+    'author': "Zikzakmedia SL, Odoo Community Association (OCA), "
               "Joaquín Gutierrez, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza",
     'website': "http://www.zikzakmedia.com, "

--- a/account_invoice_currency/models/__init__.py
+++ b/account_invoice_currency/models/__init__.py
@@ -1,20 +1,9 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-# Copyright (C) 2004-2011 Zikzakmedia S.L. (http://zikzakmedia.com)
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2004-2011 Zikzakmedia S.L. (http://zikzakmedia.com)
+#             Jordi Esteve <jesteve@zikzakmedia.com>
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import account_invoice

--- a/account_invoice_currency/models/account_invoice.py
+++ b/account_invoice_currency/models/account_invoice.py
@@ -1,24 +1,11 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-# Copyright (C) 2004-2011
-#     Pexego Sistemas Informáticos. (http://pexego.es)
-#     Zikzakmedia S.L. (http://zikzakmedia.com)
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2004-2011 Zikzakmedia S.L. (http://zikzakmedia.com)
+#             Jordi Esteve <jesteve@zikzakmedia.com>
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import models, fields, api
 import openerp.addons.decimal_precision as dp
 
@@ -26,52 +13,53 @@ import openerp.addons.decimal_precision as dp
 class AccountInvoice(models.Model):
     _inherit = "account.invoice"
 
-    @api.one
     @api.depends('amount_total', 'amount_untaxed', 'amount_tax',
                  'currency_id', 'move_id')
     def _cc_amount_all(self):
-        if self.company_id.currency_id == self.currency_id:
-            self.cc_amount_untaxed = self.amount_untaxed
-            self.cc_amount_tax = self.amount_tax
-            self.cc_amount_total = self.amount_total
-        else:
-            self.cc_amount_untaxed = 0.0
-            self.cc_amount_tax = 0.0
-            self.cc_amount_total = 0.0
-            # It could be computed only in open or paid invoices with a
-            # generated account move
-            if self.move_id:
-                # Accounts to compute amount_untaxed
-                line_accounts = set([x.account_id.id for x in
-                                     self.invoice_line])
-                # Accounts to compute amount_tax
-                tax_accounts = set([x.account_id.id for x in
-                                    self.tax_line if x.amount != 0])
-                # The company currency amounts are the debit-credit
-                # amounts in the account moves
-                for line in self.move_id.line_id:
-                    if line.account_id.id in line_accounts:
-                        self.cc_amount_untaxed += line.debit - line.credit
-                    if line.account_id.id in tax_accounts:
-                        self.cc_amount_tax += line.debit - line.credit
-                if self.type in ('out_invoice', 'in_refund'):
-                    self.cc_amount_untaxed = -self.cc_amount_untaxed
-                    self.cc_amount_tax = -self.cc_amount_tax
-                self.cc_amount_total = (self.cc_amount_tax +
-                                        self.cc_amount_untaxed)
+        for invoice in self:
+            if invoice.company_id.currency_id == invoice.currency_id:
+                invoice.cc_amount_untaxed = invoice.amount_untaxed
+                invoice.cc_amount_tax = invoice.amount_tax
+                invoice.cc_amount_total = invoice.amount_total
+            else:
+                invoice.cc_amount_untaxed = 0.0
+                invoice.cc_amount_tax = 0.0
+                invoice.cc_amount_total = 0.0
+                # It could be computed only in open or paid invoices with a
+                # generated account move
+                if invoice.move_id:
+                    # Accounts to compute amount_untaxed
+                    line_accounts = set([x.account_id.id for x in
+                                         invoice.invoice_line])
+                    # Accounts to compute amount_tax
+                    tax_accounts = set([x.account_id.id for x in
+                                        invoice.tax_line if x.amount != 0])
+                    # The company currency amounts are the debit-credit
+                    # amounts in the account moves
+                    for line in invoice.move_id.line_id:
+                        if line.account_id.id in line_accounts:
+                            invoice.cc_amount_untaxed += (
+                                line.debit - line.credit)
+                        if line.account_id.id in tax_accounts:
+                            invoice.cc_amount_tax += line.debit - line.credit
+                    if invoice.type in ('out_invoice', 'in_refund'):
+                        invoice.cc_amount_untaxed = -invoice.cc_amount_untaxed
+                        invoice.cc_amount_tax = -invoice.cc_amount_tax
+                    invoice.cc_amount_total = (invoice.cc_amount_tax +
+                                               invoice.cc_amount_untaxed)
 
     cc_amount_untaxed = fields.Float(
         compute="_cc_amount_all", digits_compute=dp.get_precision('Account'),
-        string='Company Cur. Untaxed',
+        string='Company Cur. Untaxed', store=True, readonly=True,
         help="Invoice untaxed amount in the company currency (useful when "
              "invoice currency is different from company currency).")
     cc_amount_tax = fields.Float(
         compute="_cc_amount_all", digits_compute=dp.get_precision('Account'),
-        string='Company Cur. Tax',
+        string='Company Cur. Tax', store=True, readonly=True,
         help="Invoice tax amount in the company currency (useful when invoice "
              "currency is different from company currency).")
     cc_amount_total = fields.Float(
         compute="_cc_amount_all", digits_compute=dp.get_precision('Account'),
-        string='Company Cur. Total',
+        string='Company Cur. Total', store=True, readonly=True,
         help="Invoice total amount in the company currency (useful when "
              "invoice currency is different from company currency).")

--- a/account_invoice_currency/models/account_invoice.py
+++ b/account_invoice_currency/models/account_invoice.py
@@ -49,17 +49,17 @@ class AccountInvoice(models.Model):
                                                invoice.cc_amount_untaxed)
 
     cc_amount_untaxed = fields.Float(
-        compute="_cc_amount_all", digits_compute=dp.get_precision('Account'),
+        compute="_cc_amount_all", digits=dp.get_precision('Account'),
         string='Company Cur. Untaxed', store=True, readonly=True,
         help="Invoice untaxed amount in the company currency (useful when "
              "invoice currency is different from company currency).")
     cc_amount_tax = fields.Float(
-        compute="_cc_amount_all", digits_compute=dp.get_precision('Account'),
+        compute="_cc_amount_all", digits=dp.get_precision('Account'),
         string='Company Cur. Tax', store=True, readonly=True,
         help="Invoice tax amount in the company currency (useful when invoice "
              "currency is different from company currency).")
     cc_amount_total = fields.Float(
-        compute="_cc_amount_all", digits_compute=dp.get_precision('Account'),
+        compute="_cc_amount_all", digits=dp.get_precision('Account'),
         string='Company Cur. Total', store=True, readonly=True,
         help="Invoice total amount in the company currency (useful when "
              "invoice currency is different from company currency).")


### PR DESCRIPTION
Make cc_amount_\* fields as store=True allows to not compute these values when reading from reports, when normally lots of invoices are sum, avg, ...
