### PR TITLE
[V9 Fix] account_credit_control:  Error access on partner form

### DIFF
--- a/account_credit_control/partner_view.xml
+++ b/account_credit_control/partner_view.xml
@@ -4,10 +4,10 @@
       <field name="name">partner.credit_control.form.view</field>
       <field name="model">res.partner</field>
       <field name="inherit_id" ref="account.view_partner_property_form" />
+      <field name="groups_id" eval="[[6, 0, [ref('account_credit_control.group_account_credit_control_manager'),ref('account_credit_control.group_account_credit_control_user')]]]" />
       <field name="arch" type="xml">
         <field name="credit_limit" position="after">
-          <field name="credit_policy_id" widget="selection"
-            groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_use"/>
+          <field name="credit_policy_id" widget="selection" />
         </field>
       </field>
     </record>


### PR DESCRIPTION
This generate an error when user is not in the groups so we directly limit the acces of the view instead of the field.

Error:
AccessError

Sorry, you are not allowed to access this document. Only users with the following access level are currently allowed to do that:
- Accounting & Finance/Credit Control Manager
- Accounting & Finance/Credit Control User
- Accounting & Finance/Credit Control Info

(Document model: credit.control.policy)
