### PR TITLE
Fix frozendict error on context mutations

### DIFF
--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -424,6 +424,7 @@ class account_asset_asset(orm.Model):
     def _compute_depreciation_table(self, cr, uid, asset, context=None):
         if not context:
             context = {}
+        context = context.copy()
 
         table = []
         if not asset.method_number:
@@ -608,6 +609,7 @@ class account_asset_asset(orm.Model):
     def compute_depreciation_board(self, cr, uid, ids, context=None):
         if not context:
             context = {}
+        context = context.copy()
         depreciation_lin_obj = self.pool.get(
             'account.asset.depreciation.line')
         digits = self.pool.get('decimal.precision').precision_get(

--- a/async_move_line_importer/model/move_line_importer.py
+++ b/async_move_line_importer/model/move_line_importer.py
@@ -355,6 +355,7 @@ class move_line_importer(orm.Model):
             imp_id = imp_id[0]
         if context is None:
             context = {}
+        context = context.copy()
         current = self.read(cr, uid, imp_id, ['bypass_orm', 'company_id'],
                             load='_classic_write')
         context['company_id'] = current['company_id']


### PR DESCRIPTION
The context is no longer mutable in the V8 API, and when calling
V7 API methods from V8 API methods will result in an error:
NotImplementedError: '**setitem**' not supported on frozendict

To work around this, copy the context prior to mutation. See also
Xavier Morel's answer on https://github.com/odoo/odoo/issues/4333
which confirms this.
