### PR TITLE
account_default_draft_move : display button cancel on supplier invoice

### DIFF
--- a/account_default_draft_move/account.py
+++ b/account_default_draft_move/account.py
@@ -38,6 +38,16 @@ class AccountInvoice(models.Model):
                 inv.move_id.state = 'draft'
         return res
 
+    @api.multi
+    def _is_update_posted(self):
+        ir_module = self.env['ir.module.module']
+        can_cancel = ir_module.search([('name', '=', 'account_cancel'),
+                                       ('state', '=', 'installed')])
+        self.write({'update_posted': can_cancel})
+
+    update_posted = fields.Boolean(compute='_is_update_posted',
+                                   string='Allow Cancelling Entries')
+
 
 class AccountMove(models.Model):
     _inherit = 'account.move'

--- a/account_default_draft_move/invoice_view.xml
+++ b/account_default_draft_move/invoice_view.xml
@@ -22,7 +22,9 @@
       <field name="type">form</field>
       <field name="arch" type="xml">
         <xpath expr="//button[@name='invoice_cancel']" position="after">
-          <button name="invoice_cancel" states="open" string="Cancel Invoice" groups="account.group_account_invoice"/>
+          <field name="update_posted" invisible="1"/>
+          <button name="invoice_cancel" states="open" string="Cancel Invoice" groups="account.group_account_invoice"
+                  attrs="{'invisible': ['|', ('update_posted', '=', False)]}"/>
         </xpath>
       </field>
     </record>

--- a/account_default_draft_move/invoice_view.xml
+++ b/account_default_draft_move/invoice_view.xml
@@ -24,7 +24,7 @@
         <xpath expr="//button[@name='invoice_cancel']" position="after">
           <field name="update_posted" invisible="1"/>
           <button name="invoice_cancel" states="open" string="Cancel Invoice" groups="account.group_account_invoice"
-                  attrs="{'invisible': [('update_posted', '=', False)]}"/>
+                  attrs="{'invisible': ['|', ('update_posted', '=', False)]}"/>
         </xpath>
       </field>
     </record>

--- a/account_default_draft_move/invoice_view.xml
+++ b/account_default_draft_move/invoice_view.xml
@@ -24,7 +24,7 @@
         <xpath expr="//button[@name='invoice_cancel']" position="after">
           <field name="update_posted" invisible="1"/>
           <button name="invoice_cancel" states="open" string="Cancel Invoice" groups="account.group_account_invoice"
-                  attrs="{'invisible': ['|', ('update_posted', '=', False)]}"/>
+                  attrs="{'invisible': [('update_posted', '=', False)]}"/>
         </xpath>
       </field>
     </record>


### PR DESCRIPTION
On supplier invoice, avoid to display 2 cancel buttons if account_cancel is installed.
