### PR TITLE
[7.0] [FIX] leap year resilience in account_asset_management tests

### DIFF
--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -140,27 +140,27 @@ class TestAssetManagement(common.TransactionCase):
             self.cr, self.uid, [asset.id])
         asset.refresh()
         if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 46.44,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount,
+                                   46.44, places=2)
         else:
-            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 47.33,
-                                   places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 55.55,
-                               places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55,
-                               places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[4].amount, 55.55,
-                               places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[5].amount, 55.55,
-                               places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[6].amount, 55.55,
-                               places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount,
+                                   47.33, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount,
+                               55.55, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount,
+                               55.55, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[4].amount,
+                               55.55, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[5].amount,
+                               55.55, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[6].amount,
+                               55.55, places=2)
         if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 9.11,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount,
+                                   9.11, places=2)
         else:
-            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 8.22,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount,
+                                   8.22, places=2)
 
     def test_3_proprata_init_prev_year(self):
         """Prorata temporis depreciation with init value in prev year."""
@@ -230,16 +230,16 @@ class TestAssetManagement(common.TransactionCase):
                                places=2)
         # I check computed values in the depreciation board
         if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 44.75,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount,
+                                   44.75, places=2)
         else:
-            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 45.64,
-                                   places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55,
-                               places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount,
+                                   45.64, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount,
+                               55.55, places=2)
         if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 9.11,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount,
+                                   9.11, places=2)
         else:
-            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 8.22,
-                                   places=2)
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount,
+                                   8.22, places=2)

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -21,7 +21,8 @@
 #
 ##############################################################################
 
-from datetime import datetime
+import calendar
+from datetime import date, datetime
 
 import openerp.tests.common as common
 
@@ -138,13 +139,28 @@ class TestAssetManagement(common.TransactionCase):
         self.asset_model.compute_depreciation_board(
             self.cr, self.uid, [asset.id])
         asset.refresh()
-        self.assertEquals(asset.depreciation_line_ids[1].amount, 47.33)
-        self.assertEquals(asset.depreciation_line_ids[2].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[3].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[4].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[5].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[6].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[-1].amount, 8.22)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 46.44,
+                                   places=2)
+        else:
+            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 47.33,
+                                   places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[4].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[5].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[6].amount, 55.55,
+                               places=2)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 9.11,
+                                   places=2)
+        else:
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 8.22,
+                                   places=2)
 
     def test_3_proprata_init_prev_year(self):
         """Prorata temporis depreciation with init value in prev year."""
@@ -174,11 +190,15 @@ class TestAssetManagement(common.TransactionCase):
             self.cr, self.uid, [asset.id])
         asset.refresh()
         # I check the depreciated value is the initial value
-        self.assertEquals(asset.value_depreciated, 325.08)
+        self.assertAlmostEqual(asset.value_depreciated, 325.08,
+                               places=2)
         # I check computed values in the depreciation board
-        self.assertEquals(asset.depreciation_line_ids[2].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[3].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[-1].amount, 8.22)
+        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55,
+                               places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 8.22,
+                               places=2)
 
     def test_4_prorata_init_cur_year(self):
         """Prorata temporis depreciation with init value in curent year."""
@@ -206,8 +226,20 @@ class TestAssetManagement(common.TransactionCase):
             self.cr, self.uid, [asset.id])
         asset.refresh()
         # I check the depreciated value is the initial value
-        self.assertEquals(asset.value_depreciated, 279.44)
+        self.assertAlmostEqual(asset.value_depreciated, 279.44,
+                               places=2)
         # I check computed values in the depreciation board
-        self.assertEquals(asset.depreciation_line_ids[2].amount, 45.64)
-        self.assertEquals(asset.depreciation_line_ids[3].amount, 55.55)
-        self.assertEquals(asset.depreciation_line_ids[-1].amount, 8.22)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 44.75,
+                                   places=2)
+        else:
+            self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 45.64,
+                                   places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55,
+                               places=2)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 9.11,
+                                   places=2)
+        else:
+            self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 8.22,
+                                   places=2)


### PR DESCRIPTION
backport from https://github.com/OCA/account-financial-tools/pull/369
