### PR TITLE
New module account_permanent_lock_move

### DIFF
--- a/account_permanent_lock_move/README.rst
+++ b/account_permanent_lock_move/README.rst
@@ -8,15 +8,16 @@ Permanent Lock Move
 
 This module extends the functionality of the basic "lock date"
 functionality in invoicing, in order to add a more definitive
-lock date (which does not allow to be set at a previous date,
-or emptied, and only accepts unposted moves)
+lock date (which cannot be empty or set in the past, and only
+accepts unposted moves)
 
 Configuration
 =============
 
 To configure this module, you need to:
 
-* Go to Invoicing -> Settings, and set the Permanent Lock Date.
+#. Go to Invoicing -> Settings
+#. Set the Permanent Lock Date.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/account_permanent_lock_move/README.rst
+++ b/account_permanent_lock_move/README.rst
@@ -1,0 +1,59 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================
+Permanent Lock Move
+===================
+
+This module extends the functionality of the basic "lock date"
+functionality in invoicing, in order to add a more definitive
+lock date (which does not allow to be set at a previous date,
+or emptied, and only accepts unposted moves)
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+* Go to Invoicing -> Settings, and set the Permanent Lock Date.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/92/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-financial-tools/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Matthieu Dietrich <matthieu.dietrich@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_permanent_lock_move/__init__.py
+++ b/account_permanent_lock_move/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import models
+from . import wizard

--- a/account_permanent_lock_move/__openerp__.py
+++ b/account_permanent_lock_move/__openerp__.py
@@ -11,7 +11,6 @@
     "data": [
         "views/res_config_view.xml",
         "wizard/permanent_lock_date_wizard.xml",
-        "security/ir.model.access.csv",
     ],
     'license': 'AGPL-3',
     "auto_install": False,

--- a/account_permanent_lock_move/__openerp__.py
+++ b/account_permanent_lock_move/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016 Camptocamp SA (Matthieu Dietrich)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Permanent Lock Move",
+    "version": "9.0.1.0.0",
+    "depends": ["account"],
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "website": "http://www.camptocamp.com/",
+    "category": "Finance",
+    "data": [
+        "views/res_config_view.xml",
+        "wizard/permanent_lock_date_wizard.xml",
+        "security/ir.model.access.csv",
+    ],
+    'license': 'AGPL-3',
+    "auto_install": False,
+    'installable': True,
+}

--- a/account_permanent_lock_move/models/__init__.py
+++ b/account_permanent_lock_move/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from . import account_move
+from . import company
+from . import res_config

--- a/account_permanent_lock_move/models/account_move.py
+++ b/account_permanent_lock_move/models/account_move.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# © 2016 Camptocamp SA (Matthieu Dietrich)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import _, api, models
+from openerp.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.multi
+    def _check_lock_date(self):
+        for move in self:
+            if move.date <= move.company_id.permanent_lock_date:
+                raise UserError(_(
+                    "You cannot add/modify entries prior to and inclusive "
+                    "of the permanent lock date."))
+        return super(AccountMove, self)._check_lock_date()
+
+    @api.multi
+    def button_cancel(self):
+        # Add check for button_cancel, as it does not use ORM
+        self._check_lock_date()
+        return super(AccountMove, self).button_cancel()

--- a/account_permanent_lock_move/models/account_move.py
+++ b/account_permanent_lock_move/models/account_move.py
@@ -23,7 +23,7 @@ class AccountMove(models.Model):
         self._check_lock_date()
         return super(AccountMove, self).button_cancel()
 
-    @api.multi
+    @api.model
     def create(self, vals):
         # Add _check_lock_date for create of account.move,
         # as it is not done by default

--- a/account_permanent_lock_move/models/account_move.py
+++ b/account_permanent_lock_move/models/account_move.py
@@ -22,3 +22,20 @@ class AccountMove(models.Model):
         # Add check for button_cancel, as it does not use ORM
         self._check_lock_date()
         return super(AccountMove, self).button_cancel()
+
+    @api.multi
+    def create(self, vals):
+        # Add _check_lock_date for create of account.move,
+        # as it is not done by default
+        result = super(AccountMove, self).create(vals)
+        result._check_lock_date()
+        return result
+
+    @api.multi
+    def write(self, vals):
+        # Add _check_lock_date for write of account.move,
+        # as it is not done by default
+        self._check_lock_date()
+        result = super(AccountMove, self).write(vals)
+        self._check_lock_date()
+        return result

--- a/account_permanent_lock_move/models/company.py
+++ b/account_permanent_lock_move/models/company.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# © 2016 Camptocamp SA (Matthieu Dietrich)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import _, api, fields, models
+from openerp.exceptions import UserError
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    permanent_lock_date = fields.Date(
+        string="Permanent Lock Date",
+        help="Non-revertible closing of accounts prior to and inclusive of "
+        "this date. Use it for fiscal year locking instead of ""Lock Date"".")

--- a/account_permanent_lock_move/models/company.py
+++ b/account_permanent_lock_move/models/company.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2016 Camptocamp SA (Matthieu Dietrich)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from openerp import _, api, fields, models
-from openerp.exceptions import UserError
+from openerp import fields, models
 
 
 class ResCompany(models.Model):

--- a/account_permanent_lock_move/models/res_config.py
+++ b/account_permanent_lock_move/models/res_config.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# © 2016 Camptocamp SA (Matthieu Dietrich)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import api, fields, models
+
+
+class AccountConfigSettings(models.TransientModel):
+    _inherit = 'account.config.settings'
+
+    permanent_lock_date = fields.Date(
+        string="Permanent Lock Date",
+        related='company_id.permanent_lock_date',
+        help="Non-revertible closing of accounts prior to and inclusive of "
+        "this date. Use it for fiscal year locking instead of ""Lock Date"".")
+
+    @api.multi
+    def change_permanent_lock_date(self):
+        wizard = self.env['permanent.lock.date.wizard'].create({
+            'company_id': self.company_id.id
+        })
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'permanent.lock.date.wizard',
+            'view_mode': 'form',
+            'view_type': 'form',
+            'res_id': wizard.id,
+            'target': 'new',
+        }

--- a/account_permanent_lock_move/models/res_config.py
+++ b/account_permanent_lock_move/models/res_config.py
@@ -10,8 +10,8 @@ class AccountConfigSettings(models.TransientModel):
     permanent_lock_date = fields.Date(
         string="Permanent Lock Date",
         related='company_id.permanent_lock_date',
-        help="Non-revertible closing of accounts prior to and inclusive of "
-        "this date. Use it for fiscal year locking instead of ""Lock Date"".")
+        help='Non-revertible closing of accounts prior to and inclusive of '
+        'this date. Use it for fiscal year locking instead of "Lock Date".')
 
     @api.multi
     def change_permanent_lock_date(self):

--- a/account_permanent_lock_move/security/ir.model.access.csv
+++ b/account_permanent_lock_move/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_permanent_lock_date_wizard,account.permanent.lock.move,model_permanent_lock_date_wizard,account.group_account_manager,1,1,1,1

--- a/account_permanent_lock_move/security/ir.model.access.csv
+++ b/account_permanent_lock_move/security/ir.model.access.csv
@@ -1,2 +1,0 @@
-id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_account_permanent_lock_date_wizard,account.permanent.lock.move,model_permanent_lock_date_wizard,account.group_account_manager,1,1,1,1

--- a/account_permanent_lock_move/tests/__init__.py
+++ b/account_permanent_lock_move/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2016 Camptocamp SA (Matthieu Dietrich)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import test_permanent_lock

--- a/account_permanent_lock_move/tests/test_permanent_lock.py
+++ b/account_permanent_lock_move/tests/test_permanent_lock.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# © 2016 Camptocamp SA (Matthieu Dietrich)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import datetime
+from openerp import fields, tools
+from openerp.modules import get_module_resource
+from openerp.tests import common
+from openerp.exceptions import UserError
+
+
+class PermanentLock(common.TransactionCase):
+
+    def setUp(self):
+        super(PermanentLock, self).setUp()
+        tools.convert_file(self.cr, 'account',
+                           get_module_resource('account', 'test',
+                                               'account_minimal_test.xml'),
+                           {}, 'init', False, 'test')
+        self.account_move_obj = self.env["account.move"]
+        self.account_move_line_obj = \
+            self.env["account.move.line"]
+        self.company_id = self.ref('base.main_company')
+        self.partner = self.browse_ref("base.res_partner_12")
+        self.account_id = self.ref("account.a_recv")
+        self.account_id2 = self.ref("account.a_expense")
+        self.journal_id = self.ref("account.bank_journal")
+        self.wizard_obj = self.env["permanent.lock.date.wizard"]
+
+    def test_name_completion(self):
+        """Test complete partner_id from statement line label
+        Test the automatic completion of the partner_id based if the name of
+        the partner appears in the statement line label
+        """
+
+        # Create a move
+        self.move = self.account_move_obj.create({
+            'date': fields.Date.today(),
+            'journal_id': self.journal_id,
+            'line_ids': [(0, 0, {
+                'account_id': self.account_id,
+                'credit': 1000.0,
+                'name': 'Credit line',
+            }), (0, 0, {
+                'account_id': self.account_id2,
+                'debit': 1000.0,
+                'name': 'Debit line',
+            })]
+        })
+
+        # Call lock wizard on entry
+        raised_lock_error = False
+        try:
+            self.wizard = self.wizard_obj.create({
+                'company_id': self.company_id,
+                'lock_date': fields.Date.today()
+            })
+            self.wizard.confirm_date()
+        except UserError as ue:
+            if 'entries are still unposted' in ue.name:
+                raised_lock_error = True
+
+        self.assertTrue(raised_lock_error,
+                        "Permanent lock done even with unposted entry.")
+
+        # Post entry and lock
+        self.move.post()
+
+        moves = self.env['account.move'].search(
+            [('company_id', '=', self.company_id),
+             ('date', '<=', fields.Date.today()),
+             ('state', '=', 'draft')])
+        moves.post()
+
+        self.wizard = self.wizard_obj.create({
+            'company_id': self.company_id,
+            'lock_date': fields.Date.today()
+        })
+        self.wizard.confirm_date()
+
+        # Try to lock the day before
+        raised_lock_error = False
+        try:
+            yesterday = fields.Date.to_string(
+                fields.Date.from_string(
+                    fields.Date.today()) +
+                datetime.timedelta(days=-1))
+            self.wizard = self.wizard_obj.create({
+                'company_id': self.company_id,
+                'lock_date': yesterday
+            })
+            self.wizard.confirm_date()
+        except UserError as ue:
+            if 'permanent lock date in the past' in ue.name:
+                raised_lock_error = True
+
+        self.assertTrue(raised_lock_error,
+                        "Permanent lock set the day before.")
+
+        # Test that the move cannot be created, written, or cancelled
+        raised_create_error = False
+        raised_write_error = False
+        raised_cancel_error = False
+        try:
+            self.move2 = self.account_move_obj.create({
+                'date': fields.Date.today(),
+                'journal_id': self.journal_id,
+                'line_ids': [(0, 0, {
+                    'account_id': self.account_id,
+                    'credit': 1000.0,
+                    'name': 'Credit line',
+                }), (0, 0, {
+                    'account_id': self.account_id2,
+                    'debit': 1000.0,
+                    'name': 'Debit line',
+                })]
+            })
+        except UserError as ue:
+            if 'permanent lock date' in ue.name:
+                raised_create_error = True
+
+        self.assertTrue(raised_create_error,
+                        "Journal Entry could be created after locking!")
+
+        try:
+            self.move.write({'name': 'TEST'})
+        except UserError as ue:
+            if 'permanent lock date' in ue.name:
+                raised_write_error = True
+
+        self.assertTrue(raised_write_error,
+                        "Journal Entry could be modified after locking!")
+
+        try:
+            self.move.button_cancel()
+        except UserError as ue:
+            if 'permanent lock date' in ue.name:
+                raised_cancel_error = True
+
+        self.assertTrue(raised_cancel_error,
+                        "Journal Entry could be cancelled after locking!")

--- a/account_permanent_lock_move/views/res_config_view.xml
+++ b/account_permanent_lock_move/views/res_config_view.xml
@@ -7,10 +7,10 @@
             <xpath expr="//field[@name='fiscalyear_lock_date']/parent::div" position="after">
                 <div>
                     <label for="permanent_lock_date"/>
-                    <field name="permanent_lock_date" class="oe_inline" readonly="1"/>
+                    <field name="permanent_lock_date" readonly="1"/>
                 </div>
                 <div>
-                    <button type="object" name="change_permanent_lock_date" string="Permanently Lock Entries" class="oe_inline"/>
+                    <button type="object" name="change_permanent_lock_date" string="Permanently Lock Entries" class="btn-primary"/>
                 </div>
             </xpath>
         </field>

--- a/account_permanent_lock_move/views/res_config_view.xml
+++ b/account_permanent_lock_move/views/res_config_view.xml
@@ -10,7 +10,7 @@
                     <field name="permanent_lock_date" class="oe_inline" readonly="1"/>
                 </div>
                 <div>
-                    <button type="object" name="change_permanent_lock_date" string="Permanently Lock Entries" class="oe_inline oe_stat_button"/>
+                    <button type="object" name="change_permanent_lock_date" string="Permanently Lock Entries" class="oe_inline"/>
                 </div>
             </xpath>
         </field>

--- a/account_permanent_lock_move/views/res_config_view.xml
+++ b/account_permanent_lock_move/views/res_config_view.xml
@@ -1,0 +1,18 @@
+<odoo>
+    <record id="view_account_config_settings_permanent_lock" model="ir.ui.view">
+        <field name="name">account settings permanent lock</field>
+        <field name="model">account.config.settings</field>
+        <field name="inherit_id" ref="account.view_account_config_settings"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='fiscalyear_lock_date']/parent::div" position="after">
+                <div>
+                    <label for="permanent_lock_date"/>
+                    <field name="permanent_lock_date" class="oe_inline" readonly="1"/>
+                </div>
+                <div>
+                    <button type="object" name="change_permanent_lock_date" string="Permanently Lock Entries" class="oe_inline oe_stat_button"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/account_permanent_lock_move/wizard/__init__.py
+++ b/account_permanent_lock_move/wizard/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import permanent_lock_date_wizard

--- a/account_permanent_lock_move/wizard/permanent_lock_date_wizard.py
+++ b/account_permanent_lock_move/wizard/permanent_lock_date_wizard.py
@@ -19,7 +19,7 @@ class PermanentLockDateWizard(models.TransientModel):
         if (company.permanent_lock_date and
                 self.lock_date < company.permanent_lock_date):
             raise UserError(
-                _("You cannot set the permanent lock date in the past!")
+                _("You cannot set the permanent lock date in the past.")
             )
         # Then check if unposted moves are present before the date
         moves = self.env['account.move'].search(
@@ -29,7 +29,7 @@ class PermanentLockDateWizard(models.TransientModel):
         if moves:
             raise UserError(
                 _("You cannot permanently lock since entries "
-                  "are still unposted before this date!")
+                  "are still unposted before this date.")
             )
 
         company.permanent_lock_date = self.lock_date

--- a/account_permanent_lock_move/wizard/permanent_lock_date_wizard.py
+++ b/account_permanent_lock_move/wizard/permanent_lock_date_wizard.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# © 2016 Camptocamp SA (Matthieu Dietrich)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import _, api, fields, models
+from openerp.exceptions import UserError
+
+
+class PermanentLockDateWizard(models.TransientModel):
+    _name = 'permanent.lock.date.wizard'
+
+    lock_date = fields.Date(string="Lock Date")
+    company_id = fields.Many2one(comodel_name='res.company',
+                                 string='Company')
+
+    @api.multi
+    def confirm_date(self):
+        self.ensure_one()
+        company = self.company_id
+        if (company.permanent_lock_date and
+                self.lock_date < company.permanent_lock_date):
+            raise UserError(
+                _("You cannot set the permanent lock date in the past!")
+            )
+        # Then check if unposted moves are present before the date
+        moves = self.env['account.move'].search(
+            [('company_id', '=', self.id),
+                ('date', '<=', self.lock_date),
+                ('state', '=', 'draft')])
+        if moves:
+            raise UserError(
+                _("You cannot permanently lock since entries "
+                  "are still unposted before this date!")
+            )
+
+        company.permanent_lock_date = self.lock_date
+        return {'type': 'ir.actions.act_window_close'}

--- a/account_permanent_lock_move/wizard/permanent_lock_date_wizard.py
+++ b/account_permanent_lock_move/wizard/permanent_lock_date_wizard.py
@@ -23,9 +23,9 @@ class PermanentLockDateWizard(models.TransientModel):
             )
         # Then check if unposted moves are present before the date
         moves = self.env['account.move'].search(
-            [('company_id', '=', self.id),
-                ('date', '<=', self.lock_date),
-                ('state', '=', 'draft')])
+            [('company_id', '=', company.id),
+             ('date', '<=', self.lock_date),
+             ('state', '=', 'draft')])
         if moves:
             raise UserError(
                 _("You cannot set the permanent lock date since entries are "

--- a/account_permanent_lock_move/wizard/permanent_lock_date_wizard.py
+++ b/account_permanent_lock_move/wizard/permanent_lock_date_wizard.py
@@ -28,8 +28,8 @@ class PermanentLockDateWizard(models.TransientModel):
                 ('state', '=', 'draft')])
         if moves:
             raise UserError(
-                _("You cannot permanently lock since entries "
-                  "are still unposted before this date.")
+                _("You cannot set the permanent lock date since entries are "
+                  "still unposted before this date.")
             )
 
         company.permanent_lock_date = self.lock_date

--- a/account_permanent_lock_move/wizard/permanent_lock_date_wizard.xml
+++ b/account_permanent_lock_move/wizard/permanent_lock_date_wizard.xml
@@ -1,0 +1,19 @@
+<odoo>
+    <record id="permanent_lock_date_wizard_form" model="ir.ui.view">
+        <field name="name">permanent.lock.date.wizard.form</field>
+        <field name="model">permanent.lock.date.wizard</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <form string="Lock permanently entries">
+                <label string="All journal entries prior to and included at this date will be permanently locked!"/>
+                <group>
+                    <field name="lock_date" required="1"/>
+                </group>
+                <footer>
+                    <button string="Lock Journal Entries" name="confirm_date" type="object" default_focus="1" class="btn-primary"/>
+                    <button string="Cancel" class="btn-default" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/account_permanent_lock_move/wizard/permanent_lock_date_wizard.xml
+++ b/account_permanent_lock_move/wizard/permanent_lock_date_wizard.xml
@@ -5,7 +5,7 @@
         <field name="type">form</field>
         <field name="arch" type="xml">
             <form string="Lock permanently entries">
-                <label string="All journal entries prior to and included at this date will be permanently locked!"/>
+                <label string="All journal entries prior to and included at this date will be permanently locked."/>
                 <group>
                     <field name="lock_date" required="1"/>
                 </group>


### PR DESCRIPTION
New module, which adds a new lock date in Invoicing Settings.
This date is a more "permanent" lock, as it cannot be unset nor set back in the past ; once it is set, the moves prior to and including at this date cannot be created, modified, deleted in any way.
