### PR TITLE
Fix special needs for handling account moves for service import tax in Switzerland.

### DIFF
--- a/account_compute_tax_amount/account_move_line.py
+++ b/account_compute_tax_amount/account_move_line.py
@@ -21,7 +21,7 @@
 ##############################################################################
 
 from openerp import models, fields, api
-
+from openerp.tools import float_is_zero
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
@@ -31,7 +31,8 @@ class AccountMoveLine(models.Model):
 
     @api.one
     def force_compute_tax_amount(self):
-        if self.tax_code_id:
+        precision_digits = self.env['decimal.precision'].precision_get('Account')
+        if self.tax_code_id and not float_is_zero(self.credit - self.debit, precision_digits):
             self.tax_amount = self.credit - self.debit
 
     @api.cr_uid_context


### PR DESCRIPTION
This change will fix create of tax entries when "service import tax" (in German "Bezugssteuer") is used.
## Problem

when using service import tax, it is necessary to create tax lines for sale and purchase on same time. So this works, but the second line (e.G. sales line) does not have a debit or credit amount. It only has a tax base amount calculated with sub entries of tax codes. But this module does not allow any amount other than credit - debit.
## Solution

When the amount _credit - debit_ is zero, the tax base amount will not be changed.

This fix is used on 10+ customer installations in switzerland.
