### PR TITLE
Revaluation feature (version 1.0)

### DIFF
--- a/account_asset_management/__init__.py
+++ b/account_asset_management/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/__init__.py
+++ b/account_asset_management/__init__.py
@@ -29,5 +29,3 @@ from . import account_move
 from . import wizard
 from . import report
 from . import res_config
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/__openerp__.py
+++ b/account_asset_management/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
@@ -22,7 +22,8 @@
 ##############################################################################
 {
     'name': 'Assets Management',
-    'version': '2.4',
+    'version': '(7.0) 2.4.0',
+    'license': 'AGPL-3',
     'depends': ['account'],
     'conflicts': ['account_asset'],
     'author': "OpenERP & Noviat,Odoo Community Association (OCA)",

--- a/account_asset_management/__openerp__.py
+++ b/account_asset_management/__openerp__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 {
     'name': 'Assets Management',
-    'version': '(7.0) 2.4.0',
+    'version': '7.0.2.4.0',
     'license': 'AGPL-3',
     'depends': ['account'],
     'conflicts': ['account_asset'],

--- a/account_asset_management/__openerp__.py
+++ b/account_asset_management/__openerp__.py
@@ -80,4 +80,3 @@ Contributors
     'installable': True,
     'application': True,
 }
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/__openerp__.py
+++ b/account_asset_management/__openerp__.py
@@ -66,6 +66,7 @@ Contributors
     'data': [
         'security/account_asset_security.xml',
         'security/ir.model.access.csv',
+        'wizard/account_asset_revaluation_view.xml',
         'wizard/account_asset_change_duration_view.xml',
         'wizard/wizard_asset_compute_view.xml',
         'wizard/account_asset_remove_view.xml',

--- a/account_asset_management/account.py
+++ b/account_asset_management/account.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -403,7 +403,7 @@ class account_asset_asset(orm.Model):
         elif asset.method_time == 'rate':
             months = int(fy_duration_months // asset.method_rate)
             depreciation_stop_date = depreciation_start_date + \
-            relativedelta(months=months, days=-1)
+                relativedelta(months=months, days=-1)
         return depreciation_stop_date
 
     def _compute_year_amount(self, cr, uid, asset, amount_to_depr,
@@ -751,7 +751,7 @@ class account_asset_asset(orm.Model):
                           "posted depreciation table entry dates."))
 
                 for table_i, entry in enumerate(table):
- 
+
                     residual_amount_table = \
                         entry['lines'][-1]['remaining_value']
                     if entry['date_start'] <= last_depreciation_date \
@@ -905,7 +905,7 @@ class account_asset_asset(orm.Model):
             if asset.date_revaluation:
                 rev_obj = self.pool.get('account.asset.revaluation')
                 rev_ids = rev_obj.search(
-                    cr, uid, [('asset_id', '=', asset.id)], 
+                    cr, uid, [('asset_id', '=', asset.id)],
                     order='id desc', limit=1)
                 rev_id = rev_obj.browse(cr, uid, rev_ids[0])
                 asset_value = rev_id.revaluated_value - asset.salvage_value
@@ -958,8 +958,8 @@ class account_asset_asset(orm.Model):
             if asset.date_revaluation:
                 rev_obj = self.pool.get('account.asset.revaluation')
                 rev_ids = rev_obj.search(
-                        cr, uid, [('asset_id', '=', asset.id)],
-                        order='id desc', limit=1)
+                    cr, uid, [('asset_id', '=', asset.id)],
+                    order='id desc', limit=1)
                 rev_id = rev_obj.browse(
                     cr, uid, rev_ids[0])
                 asset_value = rev_id.revaluated_value - asset.salvage_value
@@ -1137,14 +1137,14 @@ class account_asset_asset(orm.Model):
                  "for which accounting entries need to be generated."),
         'date_remove': fields.date('Asset Removal Date', readonly=True),
         'profit_loss_disposal': fields.float(
-            'Profit / (Loss) from Disposal', 
+            'Profit / (Loss) from Disposal',
             digits_compute=dp.get_precision('Account')
             ),
         'sale_value': fields.float(
             'Sale Value', digits_compute=dp.get_precision('Account')
             ),
         'date_revaluation': fields.date(
-            'Asset Revaluation Date', 
+            'Asset Revaluation Date',
             readonly=True),
         'state': fields.selection([
             ('draft', 'Draft'),
@@ -1774,8 +1774,8 @@ class account_asset_depreciation_line(orm.Model):
             period_id = period_ids and period_ids[0] or False
             move_id = move_obj.create(
                 cr, uid, self._setup_move_data(
-                    cr, uid, line, depreciation_date, period_id, context),
-                    context=context)
+                cr, uid, line, depreciation_date, period_id, context),
+                context=context)
             depr_acc_id = asset.category_id.account_depreciation_id.id
             exp_acc_id = asset.category_id.account_expense_depreciation_id.id
             ctx = dict(context, allow_asset=True)
@@ -1841,7 +1841,8 @@ class account_asset_depreciation_line(orm.Model):
                         rev_id.previous_value_residual,
                     'profit_loss_disposal': False,
                     'purchase_value':
-                        purchase_value,  # needed to trigeer fields recalculation
+                        # needed to trigeer fields recalculation
+                        purchase_value,
                     })
                 self.unlink(cr, uid, [line.id])
                 if line.previous_id:

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -331,8 +331,13 @@ class account_asset_asset(orm.Model):
                 depreciation_date_start = datetime.strptime(
                     asset.date_revaluation or asset.date_start, '%Y-%m-%d')
                 fy_date_stop = entry['date_stop']
-                fy_duration = self._get_fy_duration(
-                    cr, uid, fy_id, option='months')
+                fy_date_start = entry['fy_date_start']
+                if fy_id:
+                    fy_duration = self._get_fy_duration(
+                        cr, uid, fy_id, option='months')
+                else: # the fiscal year was 'undefined' (dummy_fy is used)
+                    fy_duration = relativedelta(fy_date_stop, 
+                                                fy_date_start).months
                 delta = relativedelta(fy_date_stop, depreciation_date_start)
                 months_remaining = delta.months + 1
                 duration_factor = float(months_remaining) / fy_duration

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -331,7 +331,7 @@ class account_asset_asset(orm.Model):
                 depreciation_date_start = datetime.strptime(
                     asset.date_revaluation or asset.date_start, '%Y-%m-%d')
                 fy_date_stop = entry['date_stop']
-                fy_date_start = entry['fy_date_start']
+                fy_date_start = entry['date_start']
                 if fy_id:
                     fy_duration = self._get_fy_duration(
                         cr, uid, fy_id, option='months')

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -1104,6 +1104,8 @@ class account_asset_asset(orm.Model):
             type='many2one',
             relation='res.currency',
             store=True, readonly=True,),
+        'account_analytic_id': fields.many2one(
+            'account.analytic.account', 'Analytic account'),
     }
 
     _defaults = {
@@ -1176,6 +1178,7 @@ class account_asset_asset(orm.Model):
                 'method_period': category_obj.method_period,
                 'method_progress_factor': category_obj.method_progress_factor,
                 'prorata': category_obj.prorata,
+                'account_analytic_id' : category_obj.account_analytic_id.id,
             }
         return res
 
@@ -1585,7 +1588,7 @@ class account_asset_depreciation_line(orm.Model):
         elif type == 'expense':
             debit = amount > 0 and amount or 0.0
             credit = amount < 0 and -amount or 0.0
-            analytic_id = asset.category_id.account_analytic_id.id
+            analytic_id = asset.account_analytic_id.id
         move_line_data = {
             'name': asset.name,
             'ref': depreciation_line.name,

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -964,7 +964,7 @@ class account_asset_asset(orm.Model):
                     res[asset.id] = True
                     continue
         return res
-
+    
     def onchange_purchase_salvage_value(
             self, cr, uid, ids, purchase_value,
             salvage_value, date_start, date_purchase, context=None):
@@ -1688,11 +1688,11 @@ class account_asset_depreciation_line(orm.Model):
             'tag': 'reload',
         }
 
-    def _setup_move_data(self, depreciation_line, depreciation_date,
+    def _setup_move_data(self, cr, uid, depreciation_line, depreciation_date,
                          period_id, context):
         asset = depreciation_line.asset_id
         move_data = {
-            'name': asset.name,
+            'name': self.pool.get('ir.sequence')._next(cr, uid, [asset.category_id.journal_id.sequence_id.id]),
             'date': depreciation_date,
             'ref': depreciation_line.name,
             'period_id': period_id,
@@ -1750,7 +1750,7 @@ class account_asset_depreciation_line(orm.Model):
             period_ids = period_obj.find(
                 cr, uid, depreciation_date, context=ctx)
             period_id = period_ids and period_ids[0] or False
-            move_id = move_obj.create(cr, uid, self._setup_move_data(
+            move_id = move_obj.create(cr, uid, self._setup_move_data(cr, uid, 
                 line, depreciation_date, period_id, context),
                 context=context)
             depr_acc_id = asset.category_id.account_depreciation_id.id

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -1791,8 +1791,9 @@ class account_asset_depreciation_line(orm.Model):
                     revaluation_id = revaluation_obj.browse(cr, uid, revaluation_ids[0])
                     
                     purchase_value = line.asset_id.purchase_value
-                    line.asset_id.write({'date_revaluation': False,
+                line.asset_id.write({'date_revaluation': revaluation_id.previous_date_revaluation,
                                          'value_residual': revaluation_id.previous_value_residual,
+                                     'profit_loss_disposal': False,
                                          'purchase_value': purchase_value, #needed to trigeer fields recalculation 
                                          })
                     self.unlink(cr, uid, [line.id])

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -324,25 +324,36 @@ class account_asset_asset(orm.Model):
                 depreciation_date_start = datetime.strptime(
                     asset.date_start, '%Y-%m-%d')
                 fy_date_stop = entry['date_stop']
-                first_fy_asset_days = \
-                    (fy_date_stop - depreciation_date_start).days + 1
-                if fy_id:
-                    first_fy_duration = self._get_fy_duration(
-                        cr, uid, fy_id, option='days')
-                    first_fy_year_factor = self._get_fy_duration(
-                        cr, uid, fy_id, option='years')
-                    duration_factor = \
-                        float(first_fy_asset_days) / first_fy_duration \
-                        * first_fy_year_factor
-                else:
-                    first_fy_duration = \
-                        calendar.isleap(entry['date_start'].year) \
-                        and 366 or 365
-                    duration_factor = \
-                        float(first_fy_asset_days) / first_fy_duration
+                fy_duration = self._get_fy_duration(cr, uid, fy_id, option='months')
+                delta = relativedelta(fy_date_stop, depreciation_date_start)
+                months_remaining = delta.months + 1
+                duration_factor = float(months_remaining) / fy_duration
+                
+                _logger.debug('==> fy_duration      : %s', fy_duration)
+                _logger.debug('==> delta            : %s', delta)
+                _logger.debug('==> months_remaining : %s', months_remaining)
+                _logger.debug('==> duration_factor  : %s', duration_factor)
+                
+                
+#                 first_fy_asset_days = \
+#                     (fy_date_stop - depreciation_date_start).days + 1
+#                 if fy_id:
+#                     first_fy_duration = self._get_fy_duration(
+#                         cr, uid, fy_id, option='days')
+#                     first_fy_year_factor = self._get_fy_duration(
+#                         cr, uid, fy_id, option='years')
+#                     duration_factor = \
+#                         float(first_fy_asset_days) / first_fy_duration * first_fy_year_factor
+#                 else:
+#                     first_fy_duration = \
+#                         calendar.isleap(entry['date_start'].year) \
+#                         and 366 or 365
+#                     duration_factor = \
+#                         float(first_fy_asset_days) / first_fy_duration
             elif fy_id:
-                duration_factor = self._get_fy_duration(
-                    cr, uid, fy_id, option='years')
+#                 duration_factor = self._get_fy_duration(
+#                     cr, uid, fy_id, option='years')
+                duration_factor = 1.0
         elif fy_id:
             fy_months = self._get_fy_duration(
                 cr, uid, fy_id, option='months')

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -408,7 +408,7 @@ class account_asset_asset(orm.Model):
             except:
                 raise orm.except_orm(
                     _('Asset Error!'),
-                    _("Illegal value %s in asset.method_rate for [%s] %s.") 
+                    _("Illegal value %s in asset.method_rate for [%s] %s.")
                     % (asset.method_rate, asset.code, asset.name))
         return depreciation_stop_date
 

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -1107,6 +1107,9 @@ class account_asset_asset(orm.Model):
                  "if the Depreciation Start Date is different from the date "
                  "for which accounting entries need to be generated."),
         'date_remove': fields.date('Asset Removal Date', readonly=True),
+        'profit_loss_disposal': fields.float(
+            'Profit / (Loss) from Disposal', digits_compute=dp.get_precision('Account')
+            ),
         'date_revaluation': fields.date('Asset Revaluation Date', readonly=True),
         'state': fields.selection([
             ('draft', 'Draft'),
@@ -1794,8 +1797,9 @@ class account_asset_depreciation_line(orm.Model):
                     return self.reload_page(
                         cr, uid, line.asset_id.id, context)
             elif line.parent_state == 'removed' and line.type == 'remove':
-                line.asset_id.write({'state': 'close'})
+                line.asset_id.write({'state': 'open', 'date_remove': False, 'profit_loss_disposal': False})
                 self.unlink(cr, uid, [line.id])
+                self.unlink_move(cr, uid, [line.previous_id.id])
             if len(ids) == 1:
                 return self.reload_page(cr, uid, line.asset_id.id, context)
         return True

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -408,7 +408,8 @@ class account_asset_asset(orm.Model):
             except:
                 raise orm.except_orm(
                     _('Asset Error!'),
-                    _("Illegal value %s in asset.method_rate for [%s] %s.") % (asset.method_rate, asset.code, asset.name))
+                    _("Illegal value %s in asset.method_rate for [%s] %s.") 
+                    % (asset.method_rate, asset.code, asset.name))
         return depreciation_stop_date
 
     def _compute_year_amount(self, cr, uid, asset, amount_to_depr,
@@ -1317,7 +1318,7 @@ class account_asset_asset(orm.Model):
                 'parent_id': category_obj.parent_id.id,
                 'method': category_obj.method,
                 'method_number': category_obj.method_number,
-                'method_rate' : category_obj.method_rate,
+                'method_rate': category_obj.method_rate,
                 'method_time': category_obj.method_time,
                 'method_period': category_obj.method_period,
                 'method_progress_factor': category_obj.method_progress_factor,
@@ -1780,7 +1781,7 @@ class account_asset_depreciation_line(orm.Model):
             period_id = period_ids and period_ids[0] or False
             move_id = move_obj.create(
                 cr, uid, self._setup_move_data(
-                cr, uid, line, depreciation_date, period_id, context),
+                    cr, uid, line, depreciation_date, period_id, context),
                 context=context)
             depr_acc_id = asset.category_id.account_depreciation_id.id
             exp_acc_id = asset.category_id.account_expense_depreciation_id.id

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -163,7 +163,7 @@ class account_asset_category(orm.Model):
         "Degressive-Linear is only supported for Time Method = Year.",
         ['method']
     )]
-
+    
     def onchange_method_time(self, cr, uid, ids,
                              method_time='number', context=None):
         res = {'value': {}}
@@ -490,7 +490,7 @@ class account_asset_asset(orm.Model):
                     % asset_ref)
             while asset_date_start < fy_date_start:
                 fy_date_start = fy_date_start - relativedelta(years=1)
-            fy_duration_months = self._get_fy_duration(cr, uid, fy_id, option='months')
+            fy_duration_months = self._get_fy_duration(cr, uid, first_fy['id'], option='months')
             fy_date_stop = fy_date_start + relativedelta(months=fy_duration_months)
             fy_id = False
             fy = dummy_fy(
@@ -1015,7 +1015,7 @@ class account_asset_asset(orm.Model):
     def _get_company(self, cr, uid, context=None):
         return self.pool.get('res.company')._company_default_get(
             cr, uid, 'account.asset.asset', context=context)
-
+    
     _columns = {
         'account_move_line_ids': fields.one2many(
             'account.move.line', 'asset_id', 'Entries', readonly=True),
@@ -1239,7 +1239,7 @@ class account_asset_asset(orm.Model):
          "Degressive-Linear is only supported for Time Method = Year.",
          ['method']),
     ]
-
+    
     def onchange_type(self, cr, uid, ids, asset_type, context=None):
         res = {'value': {}}
         if asset_type == 'view':
@@ -1785,18 +1785,18 @@ class account_asset_depreciation_line(orm.Model):
             move_obj.unlink(cr, uid, [move.id], context=ctx)
             # trigger store function
             self.write(cr, uid, [line.id], {'move_id': False}, context=ctx)
-                if line.type == 'revaluate':
-                    revaluation_obj = self.pool.get('account.asset.revaluation')
-                    revaluation_ids = revaluation_obj.search(cr, uid, [('depr_id', '=', line.id)])
-                    revaluation_id = revaluation_obj.browse(cr, uid, revaluation_ids[0])
-                    
-                    purchase_value = line.asset_id.purchase_value
+            if line.type == 'revaluate':
+                revaluation_obj = self.pool.get('account.asset.revaluation')
+                revaluation_ids = revaluation_obj.search(cr, uid, [('depr_id', '=', line.id)])
+                revaluation_id = revaluation_obj.browse(cr, uid, revaluation_ids[0])
+                
+                purchase_value = line.asset_id.purchase_value
                 line.asset_id.write({'date_revaluation': revaluation_id.previous_date_revaluation,
-                                         'value_residual': revaluation_id.previous_value_residual,
+                                     'value_residual': revaluation_id.previous_value_residual,
                                      'profit_loss_disposal': False,
-                                         'purchase_value': purchase_value, #needed to trigeer fields recalculation 
-                                         })
-                    self.unlink(cr, uid, [line.id])
+                                     'purchase_value': purchase_value, #needed to trigeer fields recalculation 
+                                     })
+                self.unlink(cr, uid, [line.id])
                 if line.previous_id:
                     self.unlink_move(cr, uid, [line.previous_id.id])
                 line.asset_id.write({'state': 'open'})
@@ -1815,7 +1815,7 @@ class account_asset_depreciation_line(orm.Model):
                                      'sale_value': False})
                 self.unlink(cr, uid, [line.id])
                 if line.previous_id:
-                self.unlink_move(cr, uid, [line.previous_id.id])
+                    self.unlink_move(cr, uid, [line.previous_id.id])
             if len(ids) == 1:
                 return self.reload_page(cr, uid, line.asset_id.id, context)
         return True

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -32,6 +32,7 @@ from openerp import tools
 from openerp.tools.translate import _
 from openerp import SUPERUSER_ID
 
+
 class dummy_fy(object):
     def __init__(self, *args, **argv):
         for key, arg in argv.items():
@@ -168,7 +169,7 @@ class account_asset_category(orm.Model):
         "Degressive-Linear is only supported for Time Method = Year.",
         ['method']
     )]
-    
+
     def onchange_method_time(self, cr, uid, ids,
                              method_time='number', context=None):
         res = {'value': {}}
@@ -298,9 +299,9 @@ class account_asset_asset(orm.Model):
             fy_year_stop = int(fy_vals['date_stop'][:4])
             year = fy_year_start
             cnt = fy_year_stop - fy_year_start + 1
-            
+
             for i in range(cnt):
-                #cy_days = calendar.isleap(year) and 366 or 365
+                # cy_days = calendar.isleap(year) and 366 or 365
                 if i == 0:  # first year
                     if fy_date_stop.year == year:
                         duration = (fy_date_stop - fy_date_start).days + 1
@@ -330,11 +331,12 @@ class account_asset_asset(orm.Model):
                 depreciation_date_start = datetime.strptime(
                     asset.date_revaluation or asset.date_start, '%Y-%m-%d')
                 fy_date_stop = entry['date_stop']
-                fy_duration = self._get_fy_duration(cr, uid, fy_id, option='months')
+                fy_duration = self._get_fy_duration(cr, uid, fy_id, 
+                                                    option='months')
                 delta = relativedelta(fy_date_stop, depreciation_date_start)
                 months_remaining = delta.months + 1
                 duration_factor = float(months_remaining) / fy_duration
-                
+
                 first_fy_asset_days = \
                     (fy_date_stop - depreciation_date_start).days + 1
                 if fy_id:
@@ -343,7 +345,8 @@ class account_asset_asset(orm.Model):
                     first_fy_year_factor = self._get_fy_duration(
                         cr, uid, fy_id, option='years')
                     duration_factor = \
-                        float(first_fy_asset_days) / first_fy_duration * first_fy_year_factor
+                        float(first_fy_asset_days) / first_fy_duration \
+                        * first_fy_year_factor
                 else:
 
                     first_fy_duration = \
@@ -351,16 +354,16 @@ class account_asset_asset(orm.Model):
                         and 366 or 365
                     duration_factor = \
                         float(first_fy_asset_days) / first_fy_duration
-                    
+
             elif fy_id:
-#                 duration_factor = self._get_fy_duration(
-#                     cr, uid, fy_id, option='years')
+                # duration_factor = self._get_fy_duration(
+                #    cr, uid, fy_id, option='years')
                 duration_factor = 1.0
         elif fy_id:
             fy_months = self._get_fy_duration(
                 cr, uid, fy_id, option='months')
             duration_factor = float(fy_months) / 12
-            
+
         return duration_factor
 
     def _get_depreciation_start_date(self, cr, uid, asset, fy, context=None):
@@ -378,7 +381,7 @@ class account_asset_asset(orm.Model):
         return depreciation_start_date
 
     def _get_depreciation_stop_date(self, cr, uid, asset,
-                                    depreciation_start_date, fy_duration_months, context=None):
+                depreciation_start_date, fy_duration_months, context=None):
         if asset.method_time == 'year':
             fy_duration_months = fy_duration_months * asset.method_number
             depreciation_stop_date = depreciation_start_date + \
@@ -1688,11 +1691,13 @@ class account_asset_depreciation_line(orm.Model):
             'tag': 'reload',
         }
 
-    def _setup_move_data(self, cr, uid, depreciation_line, depreciation_date,
+    def _setup_move_data(self, cr, uid, depreciation_line, 
+                         depreciation_date,
                          period_id, context):
         asset = depreciation_line.asset_id
         move_data = {
-            'name': self.pool.get('ir.sequence')._next(cr, uid, [asset.category_id.journal_id.sequence_id.id]),
+            'name': self.pool.get('ir.sequence')._next(
+                cr, uid, [asset.category_id.journal_id.sequence_id.id]),
             'date': depreciation_date,
             'ref': depreciation_line.name,
             'period_id': period_id,
@@ -1805,14 +1810,20 @@ class account_asset_depreciation_line(orm.Model):
             self.write(cr, uid, [line.id], {'move_id': False}, context=ctx)
             if line.type == 'revaluate':
                 revaluation_obj = self.pool.get('account.asset.revaluation')
-                revaluation_ids = revaluation_obj.search(cr, uid, [('depr_id', '=', line.id)])
-                revaluation_id = revaluation_obj.browse(cr, uid, revaluation_ids[0])
-                
+                revaluation_ids = revaluation_obj.search(
+                    cr, uid, [('depr_id', '=', line.id)])
+                revaluation_id = revaluation_obj.browse(
+                    cr, uid, revaluation_ids[0])
+
                 purchase_value = line.asset_id.purchase_value
-                line.asset_id.write({'date_revaluation': revaluation_id.previous_date_revaluation,
-                                     'value_residual': revaluation_id.previous_value_residual,
-                                     'profit_loss_disposal': False,
-                                     'purchase_value': purchase_value, #needed to trigeer fields recalculation 
+                line.asset_id.write({
+                    'date_revaluation': 
+                        revaluation_id.previous_date_revaluation,
+                    'value_residual': 
+                        revaluation_id.previous_value_residual,
+                    'profit_loss_disposal': False,
+                    'purchase_value': 
+                        purchase_value, #needed to trigeer fields recalculation
                                      })
                 self.unlink(cr, uid, [line.id])
                 if line.previous_id:
@@ -1849,9 +1860,9 @@ class account_asset_history(orm.Model):
         'asset_id': fields.many2one(
             'account.asset.asset', 'Asset', required=True, ondelete='cascade'),
         'method_time': fields.selection([
-            ('year', 'Number of Years'),
-            ('number','Number of Depreciations'),
-            ('end','Ending Date'),
+            ('year','Number of Years'), 
+            ('number','Number of Depreciations'), 
+            ('end','Ending Date'), 
             ('rate','Rate of Depreciation')
             ], 'Time Method', required=True),
         'method_number': fields.integer(

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -68,25 +68,26 @@ class account_asset_category(orm.Model):
         'name': fields.char('Name', size=64, required=True, select=1),
         'note': fields.text('Note'),
         'account_analytic_id': fields.many2one(
-            'account.analytic.account', 'Analytic account'),
+            'account.analytic.account', 'Analytic account',
+            domain=[('type', '<>', 'view')]),
         'account_asset_id': fields.many2one(
             'account.account', 'Asset Account', required=True,
-            domain=[('type', '=', 'other')]),
+            domain=[('type', '<>', 'view')]),
         'account_depreciation_id': fields.many2one(
             'account.account', 'Depreciation Account', required=True,
-            domain=[('type', '=', 'other')]),
+            domain=[('type', '<>', 'view')]),
         'account_expense_depreciation_id': fields.many2one(
             'account.account', 'Depr. Expense Account', required=True,
-            domain=[('type', '=', 'other')]),
+            domain=[('type', '<>', 'view')]),
         'account_plus_value_id': fields.many2one(
             'account.account', 'Plus-Value Account',
-            domain=[('type', '=', 'other')]),
+            domain=[('type', '<>', 'view')]),
         'account_min_value_id': fields.many2one(
             'account.account', 'Min-Value Account',
-            domain=[('type', '=', 'other')]),
+            domain=[('type', '<>', 'view')]),
         'account_residual_value_id': fields.many2one(
             'account.account', 'Residual Value Account',
-            domain=[('type', '=', 'other')]),
+            domain=[('type', '<>', 'view')]),
         'journal_id': fields.many2one(
             'account.journal', 'Journal', required=True),
         'company_id': fields.many2one(
@@ -1105,7 +1106,8 @@ class account_asset_asset(orm.Model):
             relation='res.currency',
             store=True, readonly=True,),
         'account_analytic_id': fields.many2one(
-            'account.analytic.account', 'Analytic account'),
+            'account.analytic.account', 'Analytic account',
+            domain=[('type', '<>', 'view')]),
     }
 
     _defaults = {

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -401,9 +401,14 @@ class account_asset_asset(orm.Model):
             depreciation_stop_date = datetime.strptime(
                 asset.method_end, '%Y-%m-%d')
         elif asset.method_time == 'rate':
-            months = int(fy_duration_months // asset.method_rate)
-            depreciation_stop_date = depreciation_start_date + \
-                relativedelta(months=months, days=-1)
+            try:
+                months = int(fy_duration_months // asset.method_rate)
+                depreciation_stop_date = depreciation_start_date + \
+                    relativedelta(months=months, days=-1)
+            except:
+                raise orm.except_orm(
+                    _('Asset Error!'),
+                    _("Illegal value %s in asset.method_rate for [%s] %s.") % (asset.method_rate, asset.code, asset.name))
         return depreciation_stop_date
 
     def _compute_year_amount(self, cr, uid, asset, amount_to_depr,
@@ -1312,6 +1317,7 @@ class account_asset_asset(orm.Model):
                 'parent_id': category_obj.parent_id.id,
                 'method': category_obj.method,
                 'method_number': category_obj.method_number,
+                'method_rate' : category_obj.method_rate,
                 'method_time': category_obj.method_time,
                 'method_period': category_obj.method_period,
                 'method_progress_factor': category_obj.method_progress_factor,

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -335,8 +335,8 @@ class account_asset_asset(orm.Model):
                 if fy_id:
                     fy_duration = self._get_fy_duration(
                         cr, uid, fy_id, option='months')
-                else: # the fiscal year was 'undefined' (dummy_fy is used)
-                    fy_duration = relativedelta(fy_date_stop, 
+                else:  # the fiscal year was 'undefined' (dummy_fy is used)
+                    fy_duration = relativedelta(fy_date_stop,
                                                 fy_date_start).months
                 delta = relativedelta(fy_date_stop, depreciation_date_start)
                 months_remaining = delta.months + 1

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -337,7 +337,7 @@ class account_asset_asset(orm.Model):
                         cr, uid, fy_id, option='months')
                 else:  # the fiscal year was 'undefined' (dummy_fy is used)
                     fy_duration = relativedelta(fy_date_stop,
-                                                fy_date_start).months
+                                                fy_date_start).months + 1
                 delta = relativedelta(fy_date_stop, depreciation_date_start)
                 months_remaining = delta.months + 1
                 duration_factor = float(months_remaining) / fy_duration

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -278,7 +278,7 @@ class account_asset_asset(orm.Model):
         cr.execute(
             "SELECT date_start, date_stop, "
             "date_stop-date_start+1 AS total_days "
-            "FROM account_fiscalyear WHERE id=%s" % fy_id)
+            "FROM account_fiscalyear WHERE id=%s", (fy_id,))
         fy_vals = cr.dictfetchall()[0]
         days = fy_vals['total_days']
         months = (int(fy_vals['date_stop'][:4]) -
@@ -1621,7 +1621,7 @@ class account_asset_depreciation_line(orm.Model):
             previous_id = dl.previous_id and dl.previous_id.id or False
             cr.execute(
                 "SELECT id FROM account_asset_depreciation_line "
-                "WHERE previous_id = %s" % dl.id)
+                "WHERE previous_id = %s", (dl.id,))
             next = cr.fetchone()
             if next:
                 next_id = next[0]

--- a/account_asset_management/account_asset.py
+++ b/account_asset_management/account_asset.py
@@ -1839,14 +1839,6 @@ class account_asset_depreciation_line(orm.Model):
         return True
 
 
-class account_move_line(orm.Model):
-    _inherit = 'account.move.line'
-    _columns = {
-        'asset_id': fields.many2one(
-            'account.asset.asset', 'Asset', ondelete="restrict"),
-    }
-
-
 class account_asset_history(orm.Model):
     _name = 'account.asset.history'
     _description = 'Asset history'

--- a/account_asset_management/account_asset_invoice.py
+++ b/account_asset_management/account_asset_invoice.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/account_asset_invoice.py
+++ b/account_asset_management/account_asset_invoice.py
@@ -118,5 +118,3 @@ class account_invoice_line(orm.Model):
         if line.asset_category_id:
             res['asset_category_id'] = line.asset_category_id.id
         return res
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -127,6 +127,7 @@
                 <separator string="Other Information" colspan="4"/>
                 <group colspan="4" col="4">
                   <field name="category_id" on_change="onchange_category_id(category_id)" attrs="{'required':[('type','=','normal')]}" colspan="4"/>
+                  <field name="account_analytic_id" colspan="4"/>
                   <field name="partner_id"/>
                 </group>
                 <group colspan="4">

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -127,7 +127,7 @@
                 <separator string="Other Information" colspan="4"/>
                 <group colspan="4" col="4">
                   <field name="category_id" on_change="onchange_category_id(category_id)" attrs="{'required':[('type','=','normal')]}" colspan="4"/>
-                  <field name="account_analytic_id" required="1" colspan="4"/>
+                  <field name="account_analytic_id" attrs="{'required':[('type','!=','view')]}" colspan="4"/>
                   <field name="partner_id"/>
                 </group>
                 <group colspan="4">

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -115,8 +115,8 @@
               <page string="General">
                 <group colspan="4" col="4">
                   <group>
-                  	<field name="date_purchase"
-                  		   attrs="{'readonly':[('state','!=','draft')]}" />
+                      <field name="date_purchase"
+                             attrs="{'readonly':[('state','!=','draft')]}" />
                     <field name="purchase_value" widget="monetary" options="{'currency_field': 'currency_id'}"
                            attrs="{'readonly':['|',('move_line_check','=',True),('state','!=','draft')]}"
                            on_change="onchange_purchase_salvage_value(purchase_value, salvage_value, date_start, date_purchase)"/>

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -114,17 +114,20 @@
               <page string="General">
                 <group colspan="4" col="4">
                   <group>
+                  	<field name="date_purchase"
+                  		   attrs="{'readonly':[('state','!=','draft')]}"
+                  		   on_change="onchange_purchase_salvage_value(purchase_value, salvage_value, date_start, date_purchase)"/>
                     <field name="purchase_value" widget="monetary" options="{'currency_field': 'currency_id'}"
                            attrs="{'readonly':['|',('move_line_check','=',True),('state','!=','draft')]}"
-                           on_change="onchange_purchase_salvage_value(purchase_value, salvage_value, date_start)"/>
+                           on_change="onchange_purchase_salvage_value(purchase_value, salvage_value, date_start, date_purchase)"/>
                     <field name="date_start"
                            attrs="{'readonly':[('state','!=','draft')],'required':[('type','=','normal')]}"
-                           on_change="onchange_purchase_salvage_value(purchase_value, salvage_value, date_start)"/>
+                           on_change="onchange_purchase_salvage_value(purchase_value, salvage_value, date_start, date_purchase)"/>
                   </group>
                   <group>
                     <field name="salvage_value" widget="monetary" options="{'currency_field': 'company_currency_id'}"
                            attrs="{'readonly':['|',('move_line_check','=',True),('state','!=','draft')]}"
-                           on_change="onchange_purchase_salvage_value(purchase_value, salvage_value, date_start)"/>
+                           on_change="onchange_purchase_salvage_value(purchase_value, salvage_value, date_start, date_purchase)"/>
                     <field name="date_remove"/>
                   </group>
                 </group>

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -27,7 +27,8 @@
             </group>
             <group string="Depreciation Dates">
               <field name="method_time" on_change="onchange_method_time(method_time)"/>
-              <field name="method_number" attrs="{'invisible':[('method_time','=','end')], 'required':[('method_time','in',['number','year'])]}"/>
+              <field name="method_number" attrs="{'invisible':[('method_time','in',['end','rate'])], 'required':[('method_time','in',['number','year'])]}"/>
+              <field name="method_rate" digits="(14, 4)" attrs="{'invisible':[('method_time','!=','rate')], 'required':[('method_time','=','rate')]}"/>
               <field name="method_period"/>
             </group>
             <group string="Depreciation Method">
@@ -83,9 +84,9 @@
             <button name="remove" string="Remove" type="object" groups="account.group_account_manager"
                     attrs="{'invisible':['|',('type','=','view'),'|',('method_time', '!=', 'year'),('state', 'not in', ['open', 'close'])]}"
                     help="Asset removal."/>
-            <button name="revaluate" string="Revaluate" type="object" groups="account.group_account_manager"
+            <button name="revaluate" string="Value Adjustement" type="object" groups="account.group_account_manager"
                     attrs="{'invisible':['|',('type','=','view'),'|',('method_time', '!=', 'year'),('state', '!=', 'open')]}"
-                    help="Asset revaluation"/>
+                    help="Increases or Decreases of value caused by revaluations, additions or others..."/>
             <field name="state" widget="statusbar" statusbar_visible="draft,open,close,removed"/>
           </header>
           <sheet>
@@ -115,8 +116,7 @@
                 <group colspan="4" col="4">
                   <group>
                   	<field name="date_purchase"
-                  		   attrs="{'readonly':[('state','!=','draft')]}"
-                  		   on_change="onchange_purchase_salvage_value(purchase_value, salvage_value, date_start, date_purchase)"/>
+                  		   attrs="{'readonly':[('state','!=','draft')]}" />
                     <field name="purchase_value" widget="monetary" options="{'currency_field': 'currency_id'}"
                            attrs="{'readonly':['|',('move_line_check','=',True),('state','!=','draft')]}"
                            on_change="onchange_purchase_salvage_value(purchase_value, salvage_value, date_start, date_purchase)"/>
@@ -145,9 +145,10 @@
                       <field name="method_time" on_change="onchange_method_time(method_time)" class="oe_inline"/>
                       <button name="%(action_asset_modify)d" states="open" string="Change Duration" type="action" icon="terp-stock_effects-object-colorize" class="oe_inline" colspan="1"/>
                     </div>
-                    <field name="method_number" attrs="{'invisible':[('method_time','=','end')], 'required':[('method_time','in',['number','year'])]}"/>
+                    <field name="method_number" attrs="{'invisible':[('method_time','in',['end','rate'])], 'required':[('method_time','in',['number','year'])]}"/>
+                    <field name="method_rate" digits="(14, 4)" attrs="{'invisible':[('method_time','!=','rate')], 'required':[('method_time','=','rate')]}"/>
                     <field name="method_period"/>
-                    <field name="method_end" attrs="{'required': [('method_time','=','end')], 'invisible':[('method_time','in',['number','year'])]}"/>
+                    <field name="method_end" attrs="{'required': [('method_time','=','end')], 'invisible':[('method_time','in',['number','year','rate'])]}"/>
                   </group>
                   <group>
                     <separator string="Depreciation Method" colspan="2"/>

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -23,6 +23,7 @@
               <field name="account_plus_value_id"/>
               <field name="account_min_value_id"/>
               <field name="account_residual_value_id"/>
+              <field name="account_revaluation_value_id"/>
             </group>
             <group string="Depreciation Dates">
               <field name="method_time" on_change="onchange_method_time(method_time)"/>
@@ -82,6 +83,9 @@
             <button name="remove" string="Remove" type="object" groups="account.group_account_manager"
                     attrs="{'invisible':['|', ('method_time', '!=', 'year'),('state', 'not in', ['open', 'close'])]}"
                     help="Asset removal."/>
+            <button name="revaluate" string="Revaluate" type="object" groups="account.group_account_manager"
+                    attrs="{'invisible':['|', ('method_time', '!=', 'year'),('state', 'not in', ['open', 'close'])]}"
+                    help="Asset revaluation"/>
             <field name="state" widget="statusbar" statusbar_visible="draft,open,close,removed"/>
           </header>
           <sheet>

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -95,7 +95,7 @@
               </h1>
             </div>
             <group colspan="4" col="4">
-              <field name="code"/>
+              <field name="code" required="1"/>
               <field name="parent_id" attrs="{'required':[('type','=','normal')]}"/>
               <field name="type" on_change="onchange_type(type)"/>
               <field name="company_id" widget="selection" groups="base.group_multi_company"/>

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -127,7 +127,7 @@
                 <separator string="Other Information" colspan="4"/>
                 <group colspan="4" col="4">
                   <field name="category_id" on_change="onchange_category_id(category_id)" attrs="{'required':[('type','=','normal')]}" colspan="4"/>
-                  <field name="account_analytic_id" colspan="4"/>
+                  <field name="account_analytic_id" required="1" colspan="4"/>
                   <field name="partner_id"/>
                 </group>
                 <group colspan="4">

--- a/account_asset_management/account_asset_view.xml
+++ b/account_asset_management/account_asset_view.xml
@@ -81,10 +81,10 @@
             <button name="validate" states="draft" string="Confirm Asset" type="object" class="oe_highlight"/>
             <button name="set_to_draft" states="open,close" string="Set to Draft" type="object" groups="account.group_account_manager"/>
             <button name="remove" string="Remove" type="object" groups="account.group_account_manager"
-                    attrs="{'invisible':['|', ('method_time', '!=', 'year'),('state', 'not in', ['open', 'close'])]}"
+                    attrs="{'invisible':['|',('type','=','view'),'|',('method_time', '!=', 'year'),('state', 'not in', ['open', 'close'])]}"
                     help="Asset removal."/>
             <button name="revaluate" string="Revaluate" type="object" groups="account.group_account_manager"
-                    attrs="{'invisible':['|', ('method_time', '!=', 'year'),('state', 'not in', ['open', 'close'])]}"
+                    attrs="{'invisible':['|',('type','=','view'),'|',('method_time', '!=', 'year'),('state', '!=', 'open')]}"
                     help="Asset revaluation"/>
             <field name="state" widget="statusbar" statusbar_visible="draft,open,close,removed"/>
           </header>

--- a/account_asset_management/account_move.py
+++ b/account_asset_management/account_move.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/account_move.py
+++ b/account_asset_management/account_move.py
@@ -71,6 +71,8 @@ class account_move_line(orm.Model):
     _inherit = 'account.move.line'
 
     _columns = {
+        'asset_id': fields.many2one(
+            'account.asset.asset', 'Asset', ondelete="restrict"),
         'asset_category_id': fields.many2one(
             'account.asset.category', 'Asset Category'),
     }

--- a/account_asset_management/account_move.py
+++ b/account_asset_management/account_move.py
@@ -166,5 +166,3 @@ class account_move_line(orm.Model):
 
         return super(account_move_line, self).write(
             cr, uid, ids, vals, context, check, update_check)
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/i18n/account_asset.pot
+++ b/account_asset_management/i18n/account_asset.pot
@@ -492,7 +492,7 @@ msgstr ""
 
 #. module: account_asset
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset

--- a/account_asset_management/i18n/account_asset.pot
+++ b/account_asset_management/i18n/account_asset.pot
@@ -233,7 +233,7 @@ msgstr ""
 #. module: account_asset
 #: model:ir.actions.act_window,name:account_asset.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset

--- a/account_asset_management/i18n/ar.po
+++ b/account_asset_management/i18n/ar.po
@@ -120,7 +120,7 @@ msgstr "قيد التنفيذ"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ar.po
+++ b/account_asset_management/i18n/ar.po
@@ -857,7 +857,7 @@ msgstr "المؤرخات"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "حساب الأصول"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ar.po
+++ b/account_asset_management/i18n/ar.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "حساب الأصول"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/bg.po
+++ b/account_asset_management/i18n/bg.po
@@ -119,7 +119,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/bg.po
+++ b/account_asset_management/i18n/bg.po
@@ -355,7 +355,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/bg.po
+++ b/account_asset_management/i18n/bg.po
@@ -856,7 +856,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ca.po
+++ b/account_asset_management/i18n/ca.po
@@ -857,7 +857,7 @@ msgstr "Història"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ca.po
+++ b/account_asset_management/i18n/ca.po
@@ -120,7 +120,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ca.po
+++ b/account_asset_management/i18n/ca.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ca_ES.po
+++ b/account_asset_management/i18n/ca_ES.po
@@ -119,7 +119,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ca_ES.po
+++ b/account_asset_management/i18n/ca_ES.po
@@ -355,7 +355,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ca_ES.po
+++ b/account_asset_management/i18n/ca_ES.po
@@ -856,7 +856,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/cs.po
+++ b/account_asset_management/i18n/cs.po
@@ -120,7 +120,7 @@ msgstr "Běžící"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/cs.po
+++ b/account_asset_management/i18n/cs.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Spočítat majetky"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/cs.po
+++ b/account_asset_management/i18n/cs.po
@@ -857,7 +857,7 @@ msgstr "Historie"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Spočítat majetek"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/da.po
+++ b/account_asset_management/i18n/da.po
@@ -120,7 +120,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/da.po
+++ b/account_asset_management/i18n/da.po
@@ -857,7 +857,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/da.po
+++ b/account_asset_management/i18n/da.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/de.po
+++ b/account_asset_management/i18n/de.po
@@ -858,7 +858,7 @@ msgstr "Verlauf"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Berechne Anlagen"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/de.po
+++ b/account_asset_management/i18n/de.po
@@ -357,7 +357,7 @@ msgstr "Anlagenposten"
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Berechne Anlagen"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/de.po
+++ b/account_asset_management/i18n/de.po
@@ -121,7 +121,7 @@ msgstr "In Betrieb"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr "Konto für Anlagen-Verkaufserlöse"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/en.po
+++ b/account_asset_management/i18n/en.po
@@ -355,8 +355,8 @@ msgstr "Asset Lines"
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
-msgstr "Compute Assets"
+msgid "Compute Depreciations"
+msgstr "Compute Depreciations"
 
 #. module: account_asset_management
 #: field:account.asset.asset,method_period:0

--- a/account_asset_management/i18n/en.po
+++ b/account_asset_management/i18n/en.po
@@ -119,8 +119,8 @@ msgstr "Running"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
-msgstr "Asset Sale Account"
+msgid "Payment Method"
+msgstr "Payment Method"
 
 #. module: account_asset_management
 #: view:account.asset.history:0

--- a/account_asset_management/i18n/en.po
+++ b/account_asset_management/i18n/en.po
@@ -856,8 +856,8 @@ msgstr "History"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
-msgstr "Compute Asset"
+msgid "Compute Depreciations"
+msgstr "Compute Depreciations"
 
 #. module: account_asset_management
 #: code:addons/account_asset_management/account_asset.py:796

--- a/account_asset_management/i18n/en_GB.po
+++ b/account_asset_management/i18n/en_GB.po
@@ -120,7 +120,7 @@ msgstr "Running"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/en_GB.po
+++ b/account_asset_management/i18n/en_GB.po
@@ -857,8 +857,8 @@ msgstr "History"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
-msgstr "Compute Asset"
+msgid "Compute Depreciations"
+msgstr "Compute Depreciations"
 
 #. module: account_asset_management
 #: code:addons/account_asset_management/account_asset.py:796

--- a/account_asset_management/i18n/en_GB.po
+++ b/account_asset_management/i18n/en_GB.po
@@ -356,8 +356,8 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
-msgstr "Compute Assets"
+msgid "Compute Depreciations"
+msgstr "Compute Depreciations"
 
 #. module: account_asset_management
 #: field:account.asset.asset,method_period:0

--- a/account_asset_management/i18n/en_GB.po
+++ b/account_asset_management/i18n/en_GB.po
@@ -867,6 +867,12 @@ msgid "Generate Asset Removal entries"
 msgstr ""
 
 #. module: account_asset_management
+#: code:addons/account_asset_management/account_asset.py:796
+#, python-format
+msgid "Generate Asset Revaluation entries"
+msgstr ""
+
+#. module: account_asset_management
 #: constraint:account.account:0
 msgid ""
 "The Asset Account defined in the Asset Category must be equal to the "
@@ -1150,6 +1156,12 @@ msgstr ""
 #: code:addons/account_asset_management/wizard/account_asset_remove.py:327
 #, python-format
 msgid "The removal date must be after the last depreciation date."
+msgstr ""
+
+#. module: account_asset_management
+#: code:addons/account_asset_management/wizard/account_asset_remove.py:327
+#, python-format
+msgid "The revaluation date must be after the last depreciation date."
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es.po
+++ b/account_asset_management/i18n/es.po
@@ -120,7 +120,7 @@ msgstr "En ejecución"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es.po
+++ b/account_asset_management/i18n/es.po
@@ -857,7 +857,7 @@ msgstr "Historia"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Calcular activo"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es.po
+++ b/account_asset_management/i18n/es.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Calcular amortizaciones"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_AR.po
+++ b/account_asset_management/i18n/es_AR.po
@@ -120,7 +120,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_AR.po
+++ b/account_asset_management/i18n/es_AR.po
@@ -857,7 +857,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_AR.po
+++ b/account_asset_management/i18n/es_AR.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_CR.po
+++ b/account_asset_management/i18n/es_CR.po
@@ -120,7 +120,7 @@ msgstr "En proceso"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_CR.po
+++ b/account_asset_management/i18n/es_CR.po
@@ -857,7 +857,7 @@ msgstr "Historia"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Calcular activo"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_CR.po
+++ b/account_asset_management/i18n/es_CR.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Calcular amortizaciones"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_EC.po
+++ b/account_asset_management/i18n/es_EC.po
@@ -857,7 +857,7 @@ msgstr "Histórico"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Calcular activo"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_EC.po
+++ b/account_asset_management/i18n/es_EC.po
@@ -120,7 +120,7 @@ msgstr "En proceso"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_EC.po
+++ b/account_asset_management/i18n/es_EC.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Calcular Depreciación de Activos Fijos"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_ES.po
+++ b/account_asset_management/i18n/es_ES.po
@@ -119,7 +119,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_ES.po
+++ b/account_asset_management/i18n/es_ES.po
@@ -355,7 +355,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_ES.po
+++ b/account_asset_management/i18n/es_ES.po
@@ -856,7 +856,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_MX.po
+++ b/account_asset_management/i18n/es_MX.po
@@ -857,7 +857,7 @@ msgstr "Histórico"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Calcular activo"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_MX.po
+++ b/account_asset_management/i18n/es_MX.po
@@ -120,7 +120,7 @@ msgstr "En ejecución"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_MX.po
+++ b/account_asset_management/i18n/es_MX.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Calcular amortizaciones"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_VE.po
+++ b/account_asset_management/i18n/es_VE.po
@@ -120,7 +120,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_VE.po
+++ b/account_asset_management/i18n/es_VE.po
@@ -857,7 +857,7 @@ msgstr "Historia"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/es_VE.po
+++ b/account_asset_management/i18n/es_VE.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/et.po
+++ b/account_asset_management/i18n/et.po
@@ -120,7 +120,7 @@ msgstr "Käigus"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/et.po
+++ b/account_asset_management/i18n/et.po
@@ -857,7 +857,7 @@ msgstr "Ajalugu"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Arvestus"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/et.po
+++ b/account_asset_management/i18n/et.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/fi.po
+++ b/account_asset_management/i18n/fi.po
@@ -120,7 +120,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/fi.po
+++ b/account_asset_management/i18n/fi.po
@@ -857,7 +857,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/fi.po
+++ b/account_asset_management/i18n/fi.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/fr.po
+++ b/account_asset_management/i18n/fr.po
@@ -121,7 +121,7 @@ msgstr "En cours"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr "Compte vente d'actifs"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/fr.po
+++ b/account_asset_management/i18n/fr.po
@@ -858,7 +858,7 @@ msgstr "Hstorique"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Calcul des amortissements"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/fr.po
+++ b/account_asset_management/i18n/fr.po
@@ -357,7 +357,7 @@ msgstr "Lignes d'actif"
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Calculer les amortissements"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/fr_BE.po
+++ b/account_asset_management/i18n/fr_BE.po
@@ -209,7 +209,7 @@ msgstr ""
 #: wizard_button:account.asset.compute,init,asset_compute:0
 #: model:ir.actions.wizard,name:account_asset.wizard_asset_compute
 #: model:ir.ui.menu,name:account_asset.menu_wizard_asset_compute
-msgid "Compute assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset

--- a/account_asset_management/i18n/fr_FR.po
+++ b/account_asset_management/i18n/fr_FR.po
@@ -119,7 +119,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/fr_FR.po
+++ b/account_asset_management/i18n/fr_FR.po
@@ -355,7 +355,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/fr_FR.po
+++ b/account_asset_management/i18n/fr_FR.po
@@ -856,7 +856,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/gl.po
+++ b/account_asset_management/i18n/gl.po
@@ -119,7 +119,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/gl.po
+++ b/account_asset_management/i18n/gl.po
@@ -355,7 +355,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/gl.po
+++ b/account_asset_management/i18n/gl.po
@@ -856,7 +856,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/gu.po
+++ b/account_asset_management/i18n/gu.po
@@ -120,7 +120,7 @@ msgstr "ચાલી રહ્યું છે"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/gu.po
+++ b/account_asset_management/i18n/gu.po
@@ -857,7 +857,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/gu.po
+++ b/account_asset_management/i18n/gu.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/hr.po
+++ b/account_asset_management/i18n/hr.po
@@ -857,7 +857,7 @@ msgstr "Povijest"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Izračunaj imovinu"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/hr.po
+++ b/account_asset_management/i18n/hr.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Izračunj imovinu"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/hr.po
+++ b/account_asset_management/i18n/hr.po
@@ -120,7 +120,7 @@ msgstr "Izvodi se"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/hu.po
+++ b/account_asset_management/i18n/hu.po
@@ -120,7 +120,7 @@ msgstr "Folyamatban lévő"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/hu.po
+++ b/account_asset_management/i18n/hu.po
@@ -857,7 +857,7 @@ msgstr "Előzmény"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/hu.po
+++ b/account_asset_management/i18n/hu.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/id.po
+++ b/account_asset_management/i18n/id.po
@@ -120,7 +120,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/id.po
+++ b/account_asset_management/i18n/id.po
@@ -857,7 +857,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/id.po
+++ b/account_asset_management/i18n/id.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/it.po
+++ b/account_asset_management/i18n/it.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Calcola Ammortamenti"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/it.po
+++ b/account_asset_management/i18n/it.po
@@ -857,7 +857,7 @@ msgstr "Storico"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Calcola Ammortamenti"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/it.po
+++ b/account_asset_management/i18n/it.po
@@ -120,7 +120,7 @@ msgstr "In esecuzione"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ja.po
+++ b/account_asset_management/i18n/ja.po
@@ -120,7 +120,7 @@ msgstr "動作中"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ja.po
+++ b/account_asset_management/i18n/ja.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "資産の計算"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ja.po
+++ b/account_asset_management/i18n/ja.po
@@ -857,7 +857,7 @@ msgstr "履歴"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "資産の計算"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ko.po
+++ b/account_asset_management/i18n/ko.po
@@ -237,7 +237,7 @@ msgstr ""
 #. module: account_asset
 #: model:ir.actions.act_window,name:account_asset.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset

--- a/account_asset_management/i18n/ko.po
+++ b/account_asset_management/i18n/ko.po
@@ -508,7 +508,7 @@ msgstr ""
 
 #. module: account_asset
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset

--- a/account_asset_management/i18n/lt.po
+++ b/account_asset_management/i18n/lt.po
@@ -120,7 +120,7 @@ msgstr "Veikiantis"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/lt.po
+++ b/account_asset_management/i18n/lt.po
@@ -857,7 +857,7 @@ msgstr "Istorija"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Skaičiuoti nusidėvėjimą"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/lt.po
+++ b/account_asset_management/i18n/lt.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Skaičiuoti nusidėvėjimą"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/mk.po
+++ b/account_asset_management/i18n/mk.po
@@ -858,7 +858,7 @@ msgstr "Историја"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Пресметај средство"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/mk.po
+++ b/account_asset_management/i18n/mk.po
@@ -357,7 +357,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Пресметај средства"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/mk.po
+++ b/account_asset_management/i18n/mk.po
@@ -121,7 +121,7 @@ msgstr "Работи"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/mn.po
+++ b/account_asset_management/i18n/mn.po
@@ -120,7 +120,7 @@ msgstr "Хэрэглэгдэж буй"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/mn.po
+++ b/account_asset_management/i18n/mn.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Тооцоолох хөрөнгө"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/mn.po
+++ b/account_asset_management/i18n/mn.po
@@ -857,7 +857,7 @@ msgstr "Түүх"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Хөрөнгө тооцоолох"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/nb.po
+++ b/account_asset_management/i18n/nb.po
@@ -120,7 +120,7 @@ msgstr "Løper"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/nb.po
+++ b/account_asset_management/i18n/nb.po
@@ -857,7 +857,7 @@ msgstr "Historie"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Beregn eiendel"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/nb.po
+++ b/account_asset_management/i18n/nb.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Beregn Eiendeler"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/nl.po
+++ b/account_asset_management/i18n/nl.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Bereken activa"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/nl.po
+++ b/account_asset_management/i18n/nl.po
@@ -857,7 +857,7 @@ msgstr "Historie"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Bereken activa"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/nl.po
+++ b/account_asset_management/i18n/nl.po
@@ -120,7 +120,7 @@ msgstr "Actief"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/nl_BE.po
+++ b/account_asset_management/i18n/nl_BE.po
@@ -120,7 +120,7 @@ msgstr "Lopend"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/nl_BE.po
+++ b/account_asset_management/i18n/nl_BE.po
@@ -857,7 +857,7 @@ msgstr "Historiek"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Afschrijving berekenen"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/nl_BE.po
+++ b/account_asset_management/i18n/nl_BE.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Afschrijvingen berekenen"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/pl.po
+++ b/account_asset_management/i18n/pl.po
@@ -120,7 +120,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/pl.po
+++ b/account_asset_management/i18n/pl.po
@@ -857,7 +857,7 @@ msgstr "Historia"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/pl.po
+++ b/account_asset_management/i18n/pl.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/pt.po
+++ b/account_asset_management/i18n/pt.po
@@ -857,7 +857,7 @@ msgstr "Histórico"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Calcula Ativos"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/pt.po
+++ b/account_asset_management/i18n/pt.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Calcula Ativos"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/pt.po
+++ b/account_asset_management/i18n/pt.po
@@ -120,7 +120,7 @@ msgstr "Em Funcionamento"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/pt_BR.po
+++ b/account_asset_management/i18n/pt_BR.po
@@ -858,7 +858,7 @@ msgstr "Histórico"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Calcular Patrimônio"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/pt_BR.po
+++ b/account_asset_management/i18n/pt_BR.po
@@ -357,7 +357,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Calcular Patrimônio"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/pt_BR.po
+++ b/account_asset_management/i18n/pt_BR.po
@@ -121,7 +121,7 @@ msgstr "Executando"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr "Conta de ativo de venda"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ro.po
+++ b/account_asset_management/i18n/ro.po
@@ -120,7 +120,7 @@ msgstr "In derulare"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ro.po
+++ b/account_asset_management/i18n/ro.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Calculeaza activele"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ro.po
+++ b/account_asset_management/i18n/ro.po
@@ -857,7 +857,7 @@ msgstr "Istoric"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Calculeaza Activele"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ru.po
+++ b/account_asset_management/i18n/ru.po
@@ -120,7 +120,7 @@ msgstr "Выполняется"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ru.po
+++ b/account_asset_management/i18n/ru.po
@@ -857,7 +857,7 @@ msgstr "История"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Вычислить актив"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/ru.po
+++ b/account_asset_management/i18n/ru.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Вычислить активы"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/sl.po
+++ b/account_asset_management/i18n/sl.po
@@ -121,7 +121,7 @@ msgstr "Se izvaja"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/sl.po
+++ b/account_asset_management/i18n/sl.po
@@ -357,7 +357,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Obračunaj"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/sl.po
+++ b/account_asset_management/i18n/sl.po
@@ -858,7 +858,7 @@ msgstr "Zgodovina"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Izračunaj amortizacijo"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/sr@latin.po
+++ b/account_asset_management/i18n/sr@latin.po
@@ -120,7 +120,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/sr@latin.po
+++ b/account_asset_management/i18n/sr@latin.po
@@ -857,7 +857,7 @@ msgstr "Istorijat"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/sr@latin.po
+++ b/account_asset_management/i18n/sr@latin.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/sv.po
+++ b/account_asset_management/i18n/sv.po
@@ -120,7 +120,7 @@ msgstr "Kör"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/sv.po
+++ b/account_asset_management/i18n/sv.po
@@ -857,7 +857,7 @@ msgstr "Historik"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Beräkna anskaffningar"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/sv.po
+++ b/account_asset_management/i18n/sv.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Beräkna tillgång"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/th.po
+++ b/account_asset_management/i18n/th.po
@@ -857,7 +857,7 @@ msgstr "ประวัติ"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "คำนวณสินทรัพย์"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/th.po
+++ b/account_asset_management/i18n/th.po
@@ -120,7 +120,7 @@ msgstr "กำลังทำงานอยู่"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/th.po
+++ b/account_asset_management/i18n/th.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/tr.po
+++ b/account_asset_management/i18n/tr.po
@@ -121,7 +121,7 @@ msgstr "Çalışan"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/tr.po
+++ b/account_asset_management/i18n/tr.po
@@ -357,7 +357,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "Demirbaşları Hesapla"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/tr.po
+++ b/account_asset_management/i18n/tr.po
@@ -858,7 +858,7 @@ msgstr "Geçmiş"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "Demirbaş Hesapla"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/vi.po
+++ b/account_asset_management/i18n/vi.po
@@ -120,7 +120,7 @@ msgstr ""
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/vi.po
+++ b/account_asset_management/i18n/vi.po
@@ -857,7 +857,7 @@ msgstr "Lịch sử"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/vi.po
+++ b/account_asset_management/i18n/vi.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/zh_CN.po
+++ b/account_asset_management/i18n/zh_CN.po
@@ -857,7 +857,7 @@ msgstr "历史"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "计算资产"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/zh_CN.po
+++ b/account_asset_management/i18n/zh_CN.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "计算资产"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/zh_CN.po
+++ b/account_asset_management/i18n/zh_CN.po
@@ -120,7 +120,7 @@ msgstr "运行中"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/zh_TW.po
+++ b/account_asset_management/i18n/zh_TW.po
@@ -120,7 +120,7 @@ msgstr "運行"
 
 #. module: account_asset_management
 #: field:account.asset.remove,account_sale_id:0
-msgid "Asset Sale Account"
+msgid "Payment Method"
 msgstr ""
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/zh_TW.po
+++ b/account_asset_management/i18n/zh_TW.po
@@ -857,7 +857,7 @@ msgstr "歷史記錄"
 
 #. module: account_asset_management
 #: view:asset.depreciation.confirmation.wizard:0
-msgid "Compute Asset"
+msgid "Compute Depreciations"
 msgstr "計算資產"
 
 #. module: account_asset_management

--- a/account_asset_management/i18n/zh_TW.po
+++ b/account_asset_management/i18n/zh_TW.po
@@ -356,7 +356,7 @@ msgstr ""
 #. module: account_asset_management
 #: model:ir.actions.act_window,name:account_asset_management.action_asset_depreciation_confirmation_wizard
 #: model:ir.ui.menu,name:account_asset_management.menu_asset_depreciation_confirmation_wizard
-msgid "Compute Assets"
+msgid "Compute Depreciations"
 msgstr "計算資產"
 
 #. module: account_asset_management

--- a/account_asset_management/report/__init__.py
+++ b/account_asset_management/report/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/report/__init__.py
+++ b/account_asset_management/report/__init__.py
@@ -22,5 +22,3 @@
 ##############################################################################
 
 from . import account_asset_report
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/report/account_asset_report.py
+++ b/account_asset_management/report/account_asset_report.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/report/account_asset_report.py
+++ b/account_asset_management/report/account_asset_report.py
@@ -89,5 +89,3 @@ class asset_asset_report(orm.Model):
                     a.category_id, a.partner_id, a.company_id, a.asset_value,
                     a.id, a.salvage_value
         )""")
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/res_config.py
+++ b/account_asset_management/res_config.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/res_config_view.xml
+++ b/account_asset_management/res_config_view.xml
@@ -5,7 +5,7 @@
         <record model="ir.ui.view" id="view_account_config_settings">
             <field name="name">account.config.settings.inherit</field>
             <field name="inherit_id" ref="account.view_account_config_settings"/>
-            <field name="priority" eval="1"/>
+            <field name="priority" eval="99"/>
             <field name="model">account.config.settings</field>
             <field name="arch" type="xml">
                 <field name="module_account_asset" position="replace">

--- a/account_asset_management/res_config_view.xml
+++ b/account_asset_management/res_config_view.xml
@@ -5,6 +5,7 @@
         <record model="ir.ui.view" id="view_account_config_settings">
             <field name="name">account.config.settings.inherit</field>
             <field name="inherit_id" ref="account.view_account_config_settings"/>
+            <field name="priority" eval="1"/>
             <field name="model">account.config.settings</field>
             <field name="arch" type="xml">
                 <field name="module_account_asset" position="replace">

--- a/account_asset_management/security/ir.model.access.csv
+++ b/account_asset_management/security/ir.model.access.csv
@@ -14,4 +14,5 @@ access_account_asset_recompute_trigger_user,account.asset.recompute.trigger,mode
 access_account_asset_recompute_trigger_manager,account.asset.recompute.trigger,model_account_asset_recompute_trigger,account.group_account_manager,1,1,1,1
 access_asset_asset_report_user,asset.asset.report,model_asset_asset_report,account.group_account_user,1,0,0,0
 access_asset_asset_report_manager,asset.asset.report,model_asset_asset_report,account.group_account_manager,1,1,1,1
+access_account_asset_revaluation,access_account_asset_revaluation,model_account_asset_revaluation,account.group_account_manager,1,1,1,1
 

--- a/account_asset_management/tests/__init__.py
+++ b/account_asset_management/tests/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/wizard/__init__.py
+++ b/account_asset_management/wizard/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/wizard/__init__.py
+++ b/account_asset_management/wizard/__init__.py
@@ -22,7 +22,9 @@
 ##############################################################################
 
 from . import account_asset_change_duration
+from . import account_asset_revaluation
 from . import wizard_asset_compute
 from . import account_asset_remove
+
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/wizard/__init__.py
+++ b/account_asset_management/wizard/__init__.py
@@ -25,6 +25,3 @@ from . import account_asset_change_duration
 from . import account_asset_revaluation
 from . import wizard_asset_compute
 from . import account_asset_remove
-
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/wizard/account_asset_change_duration.py
+++ b/account_asset_management/wizard/account_asset_change_duration.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/wizard/account_asset_change_duration.py
+++ b/account_asset_management/wizard/account_asset_change_duration.py
@@ -121,5 +121,3 @@ class asset_modify(orm.TransientModel):
         asset_obj.compute_depreciation_board(
             cr, uid, [asset_id], context=context)
         return {'type': 'ir.actions.act_window_close'}
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -123,7 +123,7 @@ class account_asset_remove(orm.TransientModel):
             help="Keep empty to use the period of the removal ate."),
         'sale_value': fields.float('Sale Value'),
         'account_sale_id': fields.many2one(
-            'account.account', 'Asset Sale Account',
+            'account.account', 'Payment Method',
             domain=[('type', '<>', 'view')]),
         'account_plus_value_id': fields.many2one(
             'account.account', 'Plus-Value Account',

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -223,6 +223,7 @@ class account_asset_remove(orm.TransientModel):
     def _get_removal_data(self, cr, uid, wiz_data, asset, residual_value,
                           context=None):
         move_lines = []
+        balance = 0.0
         partner_id = asset.partner_id and asset.partner_id.id or False
         categ = asset.category_id
 
@@ -337,7 +338,7 @@ class account_asset_remove(orm.TransientModel):
 
         # create move
         move_vals = {
-            'name': asset.name,
+            'name': self.pool.get('ir.sequence')._next(cr, uid, [asset.category_id.journal_id.sequence_id.id]),
             'date': wiz_data.date_remove,
             'ref': line_name,
             'period_id': period_id,

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -173,10 +173,10 @@ class account_asset_remove(orm.TransientModel):
             [('asset_id', '=', asset.id), ('type', '=', 'depreciate'),
              ('init_entry', '=', False), ('move_check', '=', False)],
             order='line_date asc')
-        
+
         if not dl_ids:
             return asset.value_residual, None
-        
+
         first_to_depreciate_dl = asset_line_obj.browse(cr, uid, dl_ids[0])
 
         first_date = first_to_depreciate_dl.line_date
@@ -338,7 +338,8 @@ class account_asset_remove(orm.TransientModel):
 
         # create move
         move_vals = {
-            'name': self.pool.get('ir.sequence')._next(cr, uid, [asset.category_id.journal_id.sequence_id.id]),
+            'name': self.pool.get('ir.sequence')._next(
+                cr, uid, [asset.category_id.journal_id.sequence_id.id]),
             'date': wiz_data.date_remove,
             'ref': line_name,
             'period_id': period_id,

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -124,16 +124,16 @@ class account_asset_remove(orm.TransientModel):
         'sale_value': fields.float('Sale Value'),
         'account_sale_id': fields.many2one(
             'account.account', 'Asset Sale Account',
-            domain=[('type', '=', 'other')]),
+            domain=[('type', '<>', 'view')]),
         'account_plus_value_id': fields.many2one(
             'account.account', 'Plus-Value Account',
-            domain=[('type', '=', 'other')]),
+            domain=[('type', '<>', 'view')]),
         'account_min_value_id': fields.many2one(
             'account.account', 'Min-Value Account',
-            domain=[('type', '=', 'other')]),
+            domain=[('type', '<>', 'view')]),
         'account_residual_value_id': fields.many2one(
             'account.account', 'Residual Value Account',
-            domain=[('type', '=', 'other')]),
+            domain=[('type', '<>', 'view')]),
         'posting_regime': fields.selection(
             _posting_regime, 'Removal Entry Policy',
             required=True,

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -120,7 +120,7 @@ class account_asset_remove(orm.TransientModel):
         'period_id': fields.many2one(
             'account.period', 'Force Period',
             domain=[('state', '<>', 'done')],
-            help="Keep empty to use the period of the removal ate."),
+            help="Keep empty to use the period of the removal date."),
         'sale_value': fields.float('Sale Value'),
         'account_sale_id': fields.many2one(
             'account.account', 'Payment Method',

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -361,6 +361,8 @@ class account_asset_remove(orm.TransientModel):
         move_obj.write(cr, uid, [move_id], {'line_id': move_lines},
                        context=dict(context, allow_asset=True))
         asset.write({'profit_loss_disposal': balance})
+        if wiz_data.posting_regime == 'gain_loss_on_sale':
+            asset.write({'sale_value': wiz_data.sale_value})
 
         return {
             'name': _("Asset '%s' Removal Journal Entry") % asset_ref,

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -173,6 +173,10 @@ class account_asset_remove(orm.TransientModel):
             [('asset_id', '=', asset.id), ('type', '=', 'depreciate'),
              ('init_entry', '=', False), ('move_check', '=', False)],
             order='line_date asc')
+        
+        if not dl_ids:
+            return asset.value_residual, None
+        
         first_to_depreciate_dl = asset_line_obj.browse(cr, uid, dl_ids[0])
 
         first_date = first_to_depreciate_dl.line_date

--- a/account_asset_management/wizard/account_asset_remove_view.xml
+++ b/account_asset_management/wizard/account_asset_remove_view.xml
@@ -10,11 +10,11 @@
             <group colspan="4" col="4">
               <field name="date_remove"/>
               <field name="period_id"/>
-              <field name="sale_value"/>
-              <field name="account_sale_id" attrs="{'invisible': [('sale_value', '=', 0.0)], 'required': [('sale_value', '>', 0.0)]}"/>
               <newline/>
               <field name="posting_regime"/>
               <newline/>
+              <field name="sale_value" attrs="{'invisible': [('posting_regime', '=', 'residual_value')]}"/>
+              <field name="account_sale_id" attrs="{'invisible': [('sale_value', '=', 0.0)], 'required': [('sale_value', '>', 0.0)]}"/>
               <field name="account_plus_value_id" attrs="{'invisible': [('posting_regime', '=', 'residual_value')], 'required': [('posting_regime', '!=', 'residual_value')]}"/>
               <field name="account_min_value_id" attrs="{'invisible': [('posting_regime', '=', 'residual_value')], 'required': [('posting_regime', '!=', 'residual_value')]}"/>
               <field name="account_residual_value_id" attrs="{'invisible': [('posting_regime', '!=', 'residual_value')], 'required': [('posting_regime', '=', 'residual_value')]}"/>

--- a/account_asset_management/wizard/account_asset_revaluation.py
+++ b/account_asset_management/wizard/account_asset_revaluation.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/wizard/account_asset_revaluation.py
+++ b/account_asset_management/wizard/account_asset_revaluation.py
@@ -39,11 +39,10 @@ class account_asset_revaluation(orm.Model):
         'previous_date_revaluation': fields.date('Previous Date Revaluation'),
         'date_revaluation': fields.date('Date', required=True),
         'depr_id': fields.many2one('account.asset.depreciation.line',
-            'Asset depreciation line',
-            required=True, ondelete='cascade'
-        ),
+                                   'Asset depreciation line',
+                                   required=True, ondelete='cascade'),
         'asset_id': fields.many2one('account.asset.asset', 'Asset',
-            required=True, ondelete='cascade'),
+                                    required=True, ondelete='cascade'),
         'previous_value': fields.float('Old Value', required=True),
         'previous_value_residual': fields.float(
             'Old Value Residual', required=True
@@ -76,7 +75,6 @@ class account_asset_revaluation(orm.TransientModel):
 #             asset_obj = self.pool.get('account.asset.asset')
 #             asset = asset_obj.browse(cr, uid, asset_id)
 #             previous_date_revaluation = asset.date_purchase
-        
         return previous_date_revaluation
 
     def _get_revaluation_account(self, cr, uid, context=None):

--- a/account_asset_management/wizard/account_asset_revaluation.py
+++ b/account_asset_management/wizard/account_asset_revaluation.py
@@ -1,0 +1,279 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#
+#    Copyright (C) 2010-2012 OpenERP s.a. (<http://openerp.com>).
+#    Copyright (c) 2014 Noviat nv/sa (www.noviat.com). All rights reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import time
+from lxml import etree
+from openerp.osv import fields, orm
+from openerp.tools.translate import _
+from dateutil.relativedelta import relativedelta
+from datetime import datetime
+
+class account_asset_revaluation(orm.Model):
+    _name = 'account.asset.revaluation'
+    _description = 'Revaluate Asset'
+    
+    def _get_revaluation_account(self, cr, uid, context=None):
+        if not context:
+            context = {}
+        acc = False
+        asset_obj = self.pool.get('account.asset.asset')
+        asset = asset_obj.browse(cr, uid, context.get('active_id'))
+        if asset:
+            acc = asset.category_id.account_revaluation_value_id
+        return acc and acc.id or False
+    
+    def _get_purchase_value(self, cr, uid, context=None):
+        if not context:
+            context = {}
+        acc = False
+        asset_obj = self.pool.get('account.asset.asset')
+        asset = asset_obj.browse(cr, uid, context.get('active_id'))
+        if asset:
+            acc = asset.purchase_value
+        return acc
+    
+    def _get_value_residual(self, cr, uid, context=None):
+        if not context:
+            context = {}
+        acc = False
+        asset_obj = self.pool.get('account.asset.asset')
+        asset = asset_obj.browse(cr, uid, context.get('active_id'))
+        if asset:
+            acc = asset.value_residual
+        return acc
+
+    _columns = {
+        'date_revaluation': fields.date('Date', required=True),
+        'depr_id': fields.many2one('account.asset.depreciation.line', 'Asset depreciation line',
+            required=True, ondelete='cascade'),
+        'previous_value': fields.float('Old Value', required=True),
+        'previous_value_residual': fields.float('Old Value Residual', required=True),
+        'revaluated_value': fields.float('New Value', required=True),
+        'account_revaluation_id': fields.many2one(
+            'account.account', 'Revaluation Value Account',
+            domain=[('type', '<>', 'view')], required=True, store=False),
+        'note': fields.text('Notes'),
+    }
+    
+    _defaults = {
+        'account_revaluation_id': _get_revaluation_account,
+        'previous_value': _get_purchase_value,
+        'previous_value_residual': _get_value_residual,
+    }
+
+    def revaluate(self, cr, uid, ids, context=None):
+        asset_obj = self.pool.get('account.asset.asset')
+        asset_line_obj = self.pool.get('account.asset.depreciation.line')
+        move_obj = self.pool.get('account.move')
+        period_obj = self.pool.get('account.period')
+        revaluation_obj = self.pool.get('account.asset.revaluation')
+
+        asset_id = context['active_id']
+        asset = asset_obj.browse(cr, uid, asset_id, context=context)
+        asset_ref = asset.code and '%s (ref: %s)' \
+            % (asset.name, asset.code) or asset.name
+        wiz_data = self.browse(cr, uid, ids[0], context=context)
+        new_value = wiz_data.revaluated_value
+
+        if context.get('early_removal'):
+            residual_value, previous_id = self._prepare_last_depreciacion(
+                cr, uid, asset, wiz_data.date_revaluation, context=context)
+        else:
+            residual_value = asset.value_residual
+            
+        ctx = dict(context, company_id=asset.company_id.id)
+        ctx.update(account_period_prefer_normal=True)
+        period_ids = period_obj.find(
+            cr, uid, wiz_data.date_revaluation, context=ctx)
+        period_id = period_ids[0]
+        dl_ids = asset_line_obj.search(
+            cr, uid,
+            [('asset_id', '=', asset.id), ('type', '=', 'depreciate')],
+            order='line_date desc')
+        if dl_ids:
+            last_date = asset_line_obj.browse(
+                cr, uid, dl_ids[0], context=context).line_date
+        else:
+            create_dl_id = asset_line_obj.search(
+                cr, uid,
+                [('asset_id', '=', asset.id), ('type', '=', 'create')],
+                context=context)[0]
+            last_date = asset_line_obj.browse(cr, uid, create_dl_id).line_date
+        if wiz_data.date_revaluation < last_date:
+            raise orm.except_orm(
+                _('Error!'),
+                _("The revaluation date must be after "
+                  "the last depreciation date."))
+
+        line_name = asset_obj._get_revaluation_entry_name(
+            cr, uid, asset, len(dl_ids) + 1, context=context)
+        journal_id = asset.category_id.journal_id.id
+
+        # create move
+        move_vals = {
+            'name': asset.name,
+            'date': wiz_data.date_revaluation,
+            'ref': line_name,
+            'period_id': period_id,
+            'journal_id': journal_id,
+            'narration': wiz_data.note,
+            }
+        move_id = move_obj.create(cr, uid, move_vals, context=context)
+
+        # create depreciation line
+        asset_line_vals = {
+            'amount': new_value,
+            'previous_id': previous_id,
+            'asset_id': asset_id,
+            'name': line_name,
+            'line_date': wiz_data.date_revaluation,
+            'move_id': move_id,
+            'type': 'revaluate',
+        }
+        depr_id = asset_line_obj.create(cr, uid, asset_line_vals, context=context)
+        asset.write({'date_revaluation': wiz_data.date_revaluation, 
+                     'purchase_value' : new_value})
+
+        # create move lines
+        move_lines = self._get_revaluation_data(
+            cr, uid, wiz_data, asset, wiz_data.revaluated_value, context=context)
+        move_obj.write(cr, uid, [move_id], {'line_id': move_lines},
+                       context=dict(context, allow_asset=True))
+        
+        # create revaluation line (for history)
+        revaluation_line_vals = {
+            'date_revaluation': wiz_data.date_revaluation,
+            'depr_id': depr_id,
+            'previous_value': wiz_data.previous_value,
+            'previous_value_residual': wiz_data.previous_value_residual,
+            'revaluated_value': wiz_data.revaluated_value,
+            'note':  wiz_data.note,
+        }
+#         obj_data = self.read(cr, uid, ids[0], context=context)
+#         for k,v in obj_data.items(): 
+#             if type( v ) in (list, tuple) and len( v ) == 2: 
+#                 obj_data[k] = v[0]
+#         revaluation_obj.create(cr, uid, obj_data, context=context)
+        revaluation_obj.create(cr, uid, revaluation_line_vals, context=context)
+        
+        return {
+            'name': _("Asset '%s' Revaluation Journal Entry") % asset_ref,
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'account.move',
+            'view_id': False,
+            'type': 'ir.actions.act_window',
+            'context': context,
+            'nodestroy': True,
+            'domain': [('id', '=', move_id)],
+        }
+        
+    def _prepare_last_depreciacion(self, cr, uid,
+                               asset, date_revaluation, context=None):
+        """
+        Generate last depreciation entry on the day before the revaluation date.
+        """
+        asset_line_obj = self.pool.get('account.asset.depreciation.line')
+
+        digits = self.pool.get('decimal.precision').precision_get(
+            cr, uid, 'Account')
+
+        dl_ids = asset_line_obj.search(
+            cr, uid,
+            [('asset_id', '=', asset.id), ('type', '=', 'depreciate'),
+             ('init_entry', '=', False), ('move_check', '=', False)],
+            order='line_date asc')
+        first_to_depreciate_dl = asset_line_obj.browse(cr, uid, dl_ids[0])
+
+        first_date = first_to_depreciate_dl.line_date
+        if date_revaluation > first_date:
+            raise orm.except_orm(
+                _('Error!'),
+                _("You can't make a revaluation if all the depreciation "
+                  "lines for previous periods are not posted."))
+
+        if first_to_depreciate_dl.previous_id:
+            last_depr_date = first_to_depreciate_dl.previous_id.line_date
+        else:
+            create_dl_id = asset_line_obj.search(
+                cr, uid,
+                [('asset_id', '=', asset.id), ('type', '=', 'create')],
+                context=context)[0]
+            create_dl = asset_line_obj.browse(
+                cr, uid, create_dl_id, context=context)
+            last_depr_date = create_dl.line_date
+        period_number_days = (
+            datetime.strptime(first_date, '%Y-%m-%d') -
+            datetime.strptime(last_depr_date, '%Y-%m-%d')).days
+        date_revaluation = datetime.strptime(date_revaluation, '%Y-%m-%d')
+        new_line_date = date_revaluation + relativedelta(days=-1)
+        to_depreciate_days = (
+            new_line_date -
+            datetime.strptime(last_depr_date, '%Y-%m-%d')).days
+        to_depreciate_amount = round(
+            float(to_depreciate_days) / float(period_number_days) *
+            first_to_depreciate_dl.amount, digits)
+        residual_value = asset.value_residual - to_depreciate_amount
+        if to_depreciate_amount:
+            update_vals = {
+                'amount': to_depreciate_amount,
+                'line_date': new_line_date
+            }
+            first_to_depreciate_dl.write(update_vals)
+            asset_line_obj.create_move(
+                cr, uid, [dl_ids[0]], context=context)
+            dl_ids.pop(0)
+        asset_line_obj.unlink(cr, uid, dl_ids, context=context)
+        return residual_value, first_to_depreciate_dl.id
+    
+    def _get_revaluation_data(self, cr, uid, wiz_data, asset, new_value,
+                          context=None):
+        move_lines = []
+        partner_id = asset.partner_id and asset.partner_id.id or False
+        categ = asset.category_id
+
+        # asset and asset revaluation account reversal
+        move_amount = new_value - asset.asset_value
+        if move_amount:
+            move_line_vals = {
+                'name': asset.name,
+                'account_id': wiz_data.account_revaluation_id.id,
+                'debit': move_amount < 0 and -move_amount or 0.0,
+                'credit': move_amount > 0 and move_amount or 0.0,
+                'partner_id': partner_id,
+                'asset_id': asset.id
+            }
+            move_lines.append((0, 0, move_line_vals))
+            move_line_vals = {
+                'name': asset.name,
+                'account_id': categ.account_asset_id.id,
+                'debit': move_amount > 0 and move_amount or 0.0,
+                'credit': move_amount < 0 and -move_amount or 0.0,
+                'partner_id': partner_id,
+                'asset_id': asset.id
+            }
+            move_lines.append((0, 0, move_line_vals))
+
+        return move_lines
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/wizard/account_asset_revaluation.py
+++ b/account_asset_management/wizard/account_asset_revaluation.py
@@ -28,12 +28,16 @@ from openerp.tools.translate import _
 from dateutil.relativedelta import relativedelta
 from datetime import datetime
 
+import logging
+_logger = logging.getLogger(__name__)
+_debug = False
+
 class account_asset_revaluation(orm.Model):
     _name = 'account.asset.revaluation'
     _description = 'Revaluate Asset'
     
     _columns = {
-        'previous_date_revaluation': fields.date('Date', required=True),
+        'previous_date_revaluation': fields.date('Previous Date Revaluation'),
         'date_revaluation': fields.date('Date', required=True),
         'depr_id': fields.many2one('account.asset.depreciation.line', 'Asset depreciation line',
             required=True, ondelete='cascade'),
@@ -47,7 +51,6 @@ class account_asset_revaluation(orm.Model):
             domain=[('type', '<>', 'view')], required=True, store=False),
         'note': fields.text('Notes'),
     }
-    
     
 
 class account_asset_revaluation(orm.TransientModel):
@@ -64,6 +67,11 @@ class account_asset_revaluation(orm.TransientModel):
         if revaluation_ids:
             revaluation = revaluation_obj.browse(cr, uid, revaluation_ids[0])
             previous_date_revaluation = revaluation.date_revaluation
+            
+#         if not previous_date_revaluation:
+#             asset_obj = self.pool.get('account.asset.asset')
+#             asset = asset_obj.browse(cr, uid, asset_id)
+#             previous_date_revaluation = asset.date_purchase
         
         return previous_date_revaluation
     
@@ -106,7 +114,7 @@ class account_asset_revaluation(orm.TransientModel):
         return acc
 
     _columns = {
-        'previous_date_revaluation': fields.date('Date', required=True),
+        'previous_date_revaluation': fields.date('Previous Date Revaluation'),
         'date_revaluation': fields.date('Date', required=True),
         'previous_value': fields.float('Old Value', required=True),
         'previous_value_residual': fields.float('Old Value Residual', required=True),
@@ -123,7 +131,7 @@ class account_asset_revaluation(orm.TransientModel):
         'previous_value': _get_previous_value,
         'previous_value_residual': _get_value_residual,
     }
-
+    
     def _check_revaluated_value(self, cr, uid, ids, context=None):
         for revaluation in self.browse(cr, uid, ids, context=context):
             if revaluation.revaluated_value < 0:

--- a/account_asset_management/wizard/account_asset_revaluation.py
+++ b/account_asset_management/wizard/account_asset_revaluation.py
@@ -391,5 +391,3 @@ class account_asset_revaluation(orm.TransientModel):
             move_lines.append((0, 0, move_line_vals))
 
         return move_lines, depr_amount
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/wizard/account_asset_revaluation.py
+++ b/account_asset_management/wizard/account_asset_revaluation.py
@@ -32,6 +32,27 @@ class account_asset_revaluation(orm.Model):
     _name = 'account.asset.revaluation'
     _description = 'Revaluate Asset'
     
+    _columns = {
+        'date_revaluation': fields.date('Date', required=True),
+        'depr_id': fields.many2one('account.asset.depreciation.line', 'Asset depreciation line',
+            required=True, ondelete='cascade'),
+        'asset_id': fields.many2one('account.asset.asset', 'Asset',
+            required=True, ondelete='cascade'),
+        'previous_value': fields.float('Old Value', required=True),
+        'previous_value_residual': fields.float('Old Value Residual', required=True),
+        'revaluated_value': fields.float('New Value', required=True),
+        'account_revaluation_id': fields.many2one(
+            'account.account', 'Revaluation Value Account',
+            domain=[('type', '<>', 'view')], required=True, store=False),
+        'note': fields.text('Notes'),
+    }
+    
+    
+
+class account_asset_revaluation(orm.TransientModel):
+    _name = 'account.asset.revaluation.wizard'
+    _description = 'Revaluate Asset Wizard'
+    
     def _get_revaluation_account(self, cr, uid, context=None):
         if not context:
             context = {}
@@ -64,8 +85,6 @@ class account_asset_revaluation(orm.Model):
 
     _columns = {
         'date_revaluation': fields.date('Date', required=True),
-        'depr_id': fields.many2one('account.asset.depreciation.line', 'Asset depreciation line',
-            required=True, ondelete='cascade'),
         'previous_value': fields.float('Old Value', required=True),
         'previous_value_residual': fields.float('Old Value Residual', required=True),
         'revaluated_value': fields.float('New Value', required=True),
@@ -164,12 +183,14 @@ class account_asset_revaluation(orm.Model):
         revaluation_line_vals = {
             'date_revaluation': wiz_data.date_revaluation,
             'depr_id': depr_id,
+            'asset_id': asset.id,
             'previous_value': wiz_data.previous_value,
             'previous_value_residual': wiz_data.previous_value_residual,
             'revaluated_value': wiz_data.revaluated_value,
+            'account_revaluation_id': wiz_data.account_revaluation_id.id,
             'note':  wiz_data.note,
-        }
-#         obj_data = self.read(cr, uid, ids[0], context=context)
+        }#         obj_data = self.read(cr, uid, ids[0], context=context)
+
 #         for k,v in obj_data.items(): 
 #             if type( v ) in (list, tuple) and len( v ) == 2: 
 #                 obj_data[k] = v[0]

--- a/account_asset_management/wizard/account_asset_revaluation_view.xml
+++ b/account_asset_management/wizard/account_asset_revaluation_view.xml
@@ -4,7 +4,7 @@
 
     <record model="ir.ui.view" id="asset_revaluation_form">
       <field name="name">account.asset.revaluation.form</field>
-      <field name="model">account.asset.revaluation</field>
+      <field name="model">account.asset.revaluation.wizard</field>
       <field name="arch" type="xml">
         <form string="Revaluate Asset" version="7.0">
           <group colspan="2" col="2">
@@ -26,7 +26,7 @@
 
     <record id="action_asset_revaluate" model="ir.actions.act_window">
       <field name="name">Revaluate Asset</field>
-      <field name="res_model">account.asset.revaluation</field>
+      <field name="res_model">account.asset.revaluation.wizard</field>
       <field name="type">ir.actions.act_window</field>
       <field name="view_type">form</field>
       <field name="view_mode">tree,form</field>

--- a/account_asset_management/wizard/account_asset_revaluation_view.xml
+++ b/account_asset_management/wizard/account_asset_revaluation_view.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record model="ir.ui.view" id="asset_revaluation_form">
+      <field name="name">account.asset.revaluation.form</field>
+      <field name="model">account.asset.revaluation</field>
+      <field name="arch" type="xml">
+        <form string="Revaluate Asset" version="7.0">
+          <group colspan="2" col="2">
+            <field name="date_revaluation"/>
+            <field name="previous_value" readonly="1"/>
+            <field name="revaluated_value"/>
+            <field name="account_revaluation_id"/>
+          </group>
+          <separator string="Notes"/>
+          <field name="note"/>
+          <footer>
+            <button name="revaluate" string="Revaluate" type="object" class="oe_highlight"/>
+            or
+            <button string="Cancel" class="oe_link" special="cancel"/>
+          </footer>
+        </form>
+      </field>
+    </record>
+
+    <record id="action_asset_revaluate" model="ir.actions.act_window">
+      <field name="name">Revaluate Asset</field>
+      <field name="res_model">account.asset.revaluation</field>
+      <field name="type">ir.actions.act_window</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">tree,form</field>
+      <field name="view_id" ref="asset_revaluation_form"/>
+      <field name="target">new</field>
+    </record>
+
+  </data>
+</openerp>

--- a/account_asset_management/wizard/wizard_asset_compute.py
+++ b/account_asset_management/wizard/wizard_asset_compute.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/account_asset_management/wizard/wizard_asset_compute.py
+++ b/account_asset_management/wizard/wizard_asset_compute.py
@@ -69,5 +69,3 @@ class asset_depreciation_confirmation_wizard(orm.TransientModel):
             'domain': domain,
             'type': 'ir.actions.act_window',
         }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/account_asset_management/wizard/wizard_asset_compute_view.xml
+++ b/account_asset_management/wizard/wizard_asset_compute_view.xml
@@ -19,7 +19,7 @@
         </record>
 
         <record id="action_asset_depreciation_confirmation_wizard" model="ir.actions.act_window">
-            <field name="name">Compute Assets</field>
+            <field name="name">Compute Asset</field>
             <field name="res_model">asset.depreciation.confirmation.wizard</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>

--- a/account_check_deposit/__openerp__.py
+++ b/account_check_deposit/__openerp__.py
@@ -24,7 +24,7 @@
 
 {
     'name': 'Account Check Deposit',
-    'version': '0.1',
+    'version': '7.0.0.1.0',
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'Manage deposit of checks to the bank',

--- a/account_check_deposit/report/report_webkit_html.py
+++ b/account_check_deposit/report/report_webkit_html.py
@@ -36,6 +36,7 @@ class report_webkit_html(report_sxw.rml_parse):
             'uid': uid,
         })
 
+
 report_sxw.report_sxw('report.account.check.deposit',
                       'account.check.deposit',
                       'addons/account_check_deposit/report/check_deposit.mako',

--- a/account_credit_control/__openerp__.py
+++ b/account_credit_control/__openerp__.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 {'name': 'Account Credit Control',
- 'version': '0.2.0',
+ 'version': '7.0.0.2.0',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'maintainer': 'Camptocamp',
  'category': 'Finance',

--- a/account_credit_control/report/credit_control_summary.py
+++ b/account_credit_control/report/credit_control_summary.py
@@ -33,6 +33,7 @@ class CreditSummaryReport(report_sxw.rml_parse):
             'uid': uid,
         })
 
+
 report_sxw.report_sxw(
     'report.credit_control_summary',
     'credit.control.communication',

--- a/account_renumber/__openerp__.py
+++ b/account_renumber/__openerp__.py
@@ -26,7 +26,7 @@
 
 {
     'name': "Account renumber wizard",
-    'version': "1.0",
+    'version': "7.0.1.0.0",
     'author': "Pexego,Odoo Community Association (OCA)",
     'website': "http://www.pexego.es",
     'category': "Enterprise Specific Modules",

--- a/account_renumber/test/create_moves.py
+++ b/account_renumber/test/create_moves.py
@@ -103,12 +103,8 @@ def create_lots_of_account_moves(dbname, user, passwd, howmany):
                               u'account.move', 'button_validate',
                               [move_id], {})
 
-# ------------------------------------------------------------------------
-# ------------------------------------------------------------------------
-# ------------------------------------------------------------------------
 
 if __name__ == "__main__":
-
 
     if len(sys.argv) < 5:
         logger.info(u"Usage: %s <dbname> <user> <password> <howmany>" %

--- a/account_renumber/test/create_moves.py
+++ b/account_renumber/test/create_moves.py
@@ -108,6 +108,8 @@ def create_lots_of_account_moves(dbname, user, passwd, howmany):
 # ------------------------------------------------------------------------
 
 if __name__ == "__main__":
+
+
     if len(sys.argv) < 5:
         logger.info(u"Usage: %s <dbname> <user> <password> <howmany>" %
                     sys.argv[0])


### PR DESCRIPTION
**Revaluation feature (version 1.0)**:
- Used remove logic template
- Added new button and new view for the revaluation date, revaluation value and revaluation account (equity) input 
- Revaluation account (equity) set on the Asset Category
- Check on revaluation date not before last posted depreciation and not in a not defined year/period
- New 'type' = 'revaluate' in depreciation table showed along with other 'create' and 'depreciate' entries on depreciation board
- More revaluations allowed in the history
- Revaluation deletion handled with unposting last depreciation
- Handled revaluation to zero value that implies the asset is closed and its value is set to zero as well as its residual value, but the purchase_value is kept as historical value and the new value is taken
  from the last revaluation one; accumulated depreciation write off is also performed
- Handled revaluation in case of 0% depreciation (no depreciation lines)
- Removal buttons is hidden for 'view' assets.
- _**TODO**: Revaluation of a 'view' asset (and its children) by percentage_

**Moreover**:
Fixed Asset Register (depreciation book):
- [https://github.com/mwithi/openerp_addons/tree/7.0](url)

Asset Category & Asset:
- added domain to Analytic Account field and extended domains to all types except views on other accounts fields

Asset:
- Added Purchase Date with onchange event to set the Depreciation Start Date accordingly (only in draf state)
- Set Analytic Account required
- Set "Reference" field as required (in view)
- Added Analytic Account field
- On change Asset Category the related Analytic Account is selected
- The Analytic Account can then be changed as desired
- On Expense move the asset Analytic Account will be used only
- first version of 'rate' depreciation method
- enabled method 'number' and 'end'

Asset Remove:
- Changed domain for Sales, Plus, Min and Residual in order to allow all accounts types except views
- Renamed "Asset Sale Account" to "Payment Method" (like in the rest of the system)
- Fixed the "Force Period" field tooltip
- Changed the layout
- Sale Value visible only for Sale
- Added field for "Profit / (Loss) from Disposal" for fast retrieve
- Added "Sale Value" field for fast retrieve
- Improved deletion of a removal (re-open the asset and unlink last depreciation)
- Removal button is hidden for 'view' assets.
- Handled removal in case of 0% depreciation (no depreciation lines)
- _**TODO**: Removal of a 'view' asset (and its children)_
