### PR TITLE
8.0 Usability improvements in account_reversal

### DIFF
--- a/account_reversal/wizard/account_move_reverse.py
+++ b/account_reversal/wizard/account_move_reverse.py
@@ -37,7 +37,7 @@ class account_move_reversal(orm.TransientModel):
             required=True,
             help="Enter the date of the reversal account entries. "
                  "By default, OpenERP proposes the first day of "
-                 "the next period."),
+                 "the period following the period of the move to reverse."),
         'period_id': fields.many2one(
             'account.period',
             'Reversal Period',
@@ -57,6 +57,7 @@ class account_move_reversal(orm.TransientModel):
             help="Prefix that will be added to the name of the journal "
                  "item to be reversed to create the name of the reversal "
                  "journal item (a space is added after the prefix)."),
+        'reconcile': fields.boolean('Reconcile'),
     }
 
     def _next_period_first_date(self, cr, uid, context=None):
@@ -66,21 +67,21 @@ class account_move_reversal(orm.TransientModel):
         period_ctx = context.copy()
         period_ctx['account_period_prefer_normal'] = True
         period_obj = self.pool.get('account.period')
-        today_period_id = period_obj.find(cr, uid, context=period_ctx)
-        if today_period_id:
-            today_period = period_obj.browse(
-                cr, uid, today_period_id[0], context=context)
-            next_period_id = period_obj.next(
-                cr, uid, today_period, 1, context=context)
-            if next_period_id:
-                next_period = period_obj.browse(
-                    cr, uid, next_period_id, context=context)
-                res = next_period.date_start
+        assert context['active_model'] == 'account.move'
+        to_reverse_move = self.pool['account.move'].browse(
+            cr, uid, context['active_id'], context=context)
+        next_period_id = period_obj.next(
+            cr, uid, to_reverse_move.period_id, 1, context=context)
+        if next_period_id:
+            next_period = period_obj.browse(
+                cr, uid, next_period_id, context=context)
+            res = next_period.date_start
         return res
 
     _defaults = {
         'date': _next_period_first_date,
         'move_line_prefix': 'REV -',
+        'reconcile': True,
     }
 
     def action_reverse(self, cr, uid, ids, context=None):
@@ -90,13 +91,12 @@ class account_move_reversal(orm.TransientModel):
 
         form = self.read(cr, uid, ids, context=context)[0]
 
-        mod_obj = self.pool.get('ir.model.data')
-        act_obj = self.pool.get('ir.actions.act_window')
         move_obj = self.pool.get('account.move')
         move_ids = context['active_ids']
 
         period_id = form['period_id'][0] if form.get('period_id') else False
         journal_id = form['journal_id'][0] if form.get('journal_id') else False
+        reconcile = form['reconcile'] if form.get('reconcile') else False
         reversed_move_ids = move_obj.create_reversals(
             cr, uid,
             move_ids,
@@ -105,12 +105,18 @@ class account_move_reversal(orm.TransientModel):
             reversal_journal_id=journal_id,
             move_prefix=form['move_prefix'],
             move_line_prefix=form['move_line_prefix'],
+            reconcile=reconcile,
             context=context)
 
-        __, action_id = mod_obj.get_object_reference(
+        action = self.pool['ir.actions.act_window'].for_xml_id(
             cr, uid, 'account', 'action_move_journal_line')
-        action = act_obj.read(cr, uid, [action_id], context=context)[0]
-        action['domain'] = unicode([('id', 'in', reversed_move_ids)])
         action['name'] = _('Reversal Entries')
         action['context'] = unicode({'search_default_to_be_reversed': 0})
+        if len(reversed_move_ids) == 1:
+            action['res_id'] = reversed_move_ids[0]
+            action['view_mode'] = 'form,tree'
+            action['views'] = False
+            action['view_id'] = False
+        else:
+            action['domain'] = unicode([('id', 'in', reversed_move_ids)])
         return action

--- a/account_reversal/wizard/account_move_reverse_view.xml
+++ b/account_reversal/wizard/account_move_reverse_view.xml
@@ -6,7 +6,7 @@
             <field name="name">account.move.reverse.form</field>
             <field name="model">account.move.reverse</field>
             <field name="arch" type="xml">
-                <form string="Create reversal journal entries" version="7.0">
+                <form string="Create reversal journal entries">
                     <label string="This will create reversal for all selected entries whether checked 'to be reversed' or not."/>
                     <group>
                         <field name="date"/>
@@ -15,6 +15,7 @@
                         <newline/>
                         <field name="move_prefix" />
                         <field name="move_line_prefix" />
+                        <field name="reconcile"/>
                     </group>
 
                     <footer>
@@ -30,7 +31,6 @@
         <record id="act_account_move_reverse" model="ir.actions.act_window">
             <field name="name">Reverse Entries</field>
             <field name="res_model">account.move.reverse</field>
-            <field name="view_type">form</field>
             <field name="view_mode">form</field>
             <field name="view_id" ref="view_account_move_reverse"/>
             <field name="target">new</field>


### PR DESCRIPTION
I made these 3 usability improvements (I got the idea for those improvements by watching accountants use the account_reversal module and when I use it myself for my own accounting):
- Add option to reconcile the reversal move with the original move (option enabled by default)
- Default date for reverse move is now start_date of the period following the period of the original move (and not the period following today's period)
- Return form view of account.move if only 1 move is reversed
