### PR TITLE
[9.0][MIG] account_reset_chart

### DIFF
--- a/account_reset_chart/README.rst
+++ b/account_reset_chart/README.rst
@@ -1,6 +1,8 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :alt: License
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
+===================
 Account chart reset
 ===================
 
@@ -39,14 +41,19 @@ modifications or extensions of the current implementation.
 
 Sequences are not reset during the process.
 
+* Error is generated if there are no default sales/vendor taxes defined for company:
+
+          File "/opt/odoo/addons/account/models/account.py", line 540, in unlink
+            supplier_taxes_id = set(ir_values.get_default('product.template', 'supplier_taxes_id', company_id=company_id))
+    ValueError: "'NoneType' object is not iterable" while evaluating
+
 
 Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/account-financial-tools/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/account-financial-tools/issues/new?body=module:%20account_reset_chart%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback.
 
 
 Credits
@@ -56,6 +63,7 @@ Contributors
 ------------
 
 * Stefan Rijnhart <stefan@therp.nl>
+* Dave Lasley <dave@laslabs.com>
 
 Icon courtesy of Alan Klim (CC-BY-20) -
 https://www.flickr.com/photos/igraph/6469812927/

--- a/account_reset_chart/__openerp__.py
+++ b/account_reset_chart/__openerp__.py
@@ -1,33 +1,17 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Odoo, an open source suite of business apps
-#    This module copyright (C) 2014-2015 Therp BV (<http://therp.nl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2014-2015 Therp BV (<http://therp.nl>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 {
     "name": "Reset a chart of accounts",
-    "summary": ("Delete the accounting setup from an otherwise reusable "
-                "database"),
-    "version": "8.0.1.0.0",
-    "author": "Therp BV,Odoo Community Association (OCA)",
+    "summary": "Delete the accounting setup from an otherwise reusable "
+               "database",
+    "version": "9.0.1.0.0",
+    "author": "Therp BV, LasLabs, Odoo Community Association (OCA)",
     "category": 'Accounting & Finance',
     "depends": [
         'account',
     ],
     'license': 'AGPL-3',
-    'installable': False,
+    'installable': True,
 }

--- a/account_reset_chart/i18n/el_GR.po
+++ b/account_reset_chart/i18n/el_GR.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_reset_chart
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: account-financial-tools (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-05 01:25+0000\n"
+"PO-Revision-Date: 2015-12-09 16:40+0000\n"
+"Last-Translator: Goutoudis Kostas <goutoudis@gmail.com>\n"
+"Language-Team: Greek (Greece) (http://www.transifex.com/oca/OCA-account-financial-tools-8-0/language/el_GR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: el_GR\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_reset_chart
+#: model:ir.model,name:account_reset_chart.model_res_company
+msgid "Companies"
+msgstr "Εταιρείες"

--- a/account_reset_chart/i18n/es.po
+++ b/account_reset_chart/i18n/es.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_reset_chart
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: account-financial-tools (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-01-16 01:25+0000\n"
+"PO-Revision-Date: 2015-06-03 15:55+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Spanish (http://www.transifex.com/oca/OCA-account-financial-tools-8-0/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_reset_chart
+#: model:ir.model,name:account_reset_chart.model_res_company
+msgid "Companies"
+msgstr "Compañías"

--- a/account_reset_chart/i18n/fi.po
+++ b/account_reset_chart/i18n/fi.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_reset_chart
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: account-financial-tools (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-03 09:18+0000\n"
+"PO-Revision-Date: 2015-06-03 15:55+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Finnish (http://www.transifex.com/oca/OCA-account-financial-tools-8-0/language/fi/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fi\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_reset_chart
+#: model:ir.model,name:account_reset_chart.model_res_company
+msgid "Companies"
+msgstr "Yritykset"

--- a/account_reset_chart/i18n/hr_HR.po
+++ b/account_reset_chart/i18n/hr_HR.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_reset_chart
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: account-financial-tools (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-05-28 00:59+0000\n"
+"PO-Revision-Date: 2015-06-03 15:55+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Croatian (Croatia) (http://www.transifex.com/oca/OCA-account-financial-tools-8-0/language/hr_HR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hr_HR\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: account_reset_chart
+#: model:ir.model,name:account_reset_chart.model_res_company
+msgid "Companies"
+msgstr "Poduzeća"

--- a/account_reset_chart/i18n/it.po
+++ b/account_reset_chart/i18n/it.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_reset_chart
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: account-financial-tools (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-23 00:52+0000\n"
+"PO-Revision-Date: 2015-06-03 15:55+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Italian (http://www.transifex.com/oca/OCA-account-financial-tools-8-0/language/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_reset_chart
+#: model:ir.model,name:account_reset_chart.model_res_company
+msgid "Companies"
+msgstr "Azienda"

--- a/account_reset_chart/i18n/sk.po
+++ b/account_reset_chart/i18n/sk.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_reset_chart
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: account-financial-tools (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-14 02:46+0000\n"
+"PO-Revision-Date: 2015-06-03 15:55+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Slovak (http://www.transifex.com/oca/OCA-account-financial-tools-8-0/language/sk/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sk\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#. module: account_reset_chart
+#: model:ir.model,name:account_reset_chart.model_res_company
+msgid "Companies"
+msgstr "Spoločnosti"

--- a/account_reset_chart/models/res_company.py
+++ b/account_reset_chart/models/res_company.py
@@ -161,9 +161,7 @@ class ResCompany(models.Model):
             pass
 
         try:
-            self.env['account.full.reconcile'].search(
-                [('company_id', '=', self.id)]
-            ).unlink()
+            self.env['account.full.reconcile'].search([]).unlink()
         except KeyError:
             pass
 
@@ -172,6 +170,12 @@ class ResCompany(models.Model):
         )
         settings_id.write({
             'has_chart_of_accounts': False,
-            'expects_chart_of_accounts': False,
+            'expects_chart_of_accounts': True,
+            'chart_template_id': False,
         })
+        self.chart_template_id = False
+
+        if settings_id:
+            settings_id.execute()
+
         return True

--- a/account_reset_chart/models/res_company.py
+++ b/account_reset_chart/models/res_company.py
@@ -153,17 +153,9 @@ class ResCompany(models.Model):
         unlink_from_company('account.journal')
         unlink_from_company('account.account')
 
-        try:
-            self.env['account.partial.reconcile'].search(
-                [('company_id', '=', self.id)]
-            ).unlink()
-        except KeyError:
-            pass
-
-        try:
-            self.env['account.full.reconcile'].search([]).unlink()
-        except KeyError:
-            pass
+        self.env['account.partial.reconcile'].search(
+            [('company_id', '=', self.id)]
+        ).unlink()
 
         settings_id = self.env['account.config.settings'].search(
             [('company_id', '=', self.id)]

--- a/account_reset_chart/models/res_company.py
+++ b/account_reset_chart/models/res_company.py
@@ -1,46 +1,38 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Odoo, an open source suite of business apps
-#    This module copyright (C) 2014-2015 Therp BV (<http://therp.nl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2014-2015 Therp BV (<http://therp.nl>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import api, models
 import logging
 
 
-class Company(models.Model):
+_logger = logging.getLogger(__name__)
+
+
+class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    @api.one
+    @api.multi
     def reset_chart(self):
+        """ It loops selected company records and calls _reset_chart """
+        return all(r._reset_chart() for r in self)
+
+    @api.multi
+    def _reset_chart(self):
         """
         This method removes the chart of account on the company record,
         including all the related financial transactions.
         """
-        logger = logging.getLogger('openerp.addons.account_reset_chart')
+
+        self.ensure_one()
 
         def unlink_from_company(model):
-            logger.info('Unlinking all records of model %s for company %s',
-                        model, self.name)
+            _logger.info('Unlinking all records of model %s for company %s',
+                         model, self.name)
             try:
                 obj = self.env[model].with_context(active_test=False)
             except KeyError:
-                logger.info('Model %s not found', model)
+                _logger.info('Model %s not found', model)
                 return
             self._cr.execute(
                 """
@@ -51,7 +43,7 @@ class Company(models.Model):
                 """.format(model=model, table=obj._table),
                 (self.id,))
             if self._cr.rowcount:
-                logger.info(
+                _logger.info(
                     "Unlinked %s properties that refer to records of type %s "
                     "that are linked to company %s",
                     self._cr.rowcount, model, self.name)
@@ -63,12 +55,14 @@ class Company(models.Model):
             [('company_id', '=', self.id)]).write({'update_posted': True})
         statements = self.env['account.bank.statement'].search(
             [('company_id', '=', self.id)])
-        statements.button_cancel()
-        statements.unlink()
+
+        for statement in statements:
+            statement.button_cancel()
+            statement.unlink()
 
         try:
             voucher_obj = self.env['account.voucher']
-            logger.info('Unlinking vouchers.')
+            _logger.info('Unlinking vouchers.')
             vouchers = voucher_obj.search(
                 [('company_id', '=', self.id),
                  ('state', 'in', ('proforma', 'posted'))])
@@ -80,7 +74,7 @@ class Company(models.Model):
 
         try:
             if self.env['payment.order']:
-                logger.info('Unlinking payment orders.')
+                _logger.info('Unlinking payment orders.')
                 self._cr.execute(
                     """
                     DELETE FROM payment_line
@@ -99,12 +93,7 @@ class Company(models.Model):
         unlink_from_company('account.banking.account.settings')
         unlink_from_company('res.partner.bank')
 
-        logger.info('Unlinking reconciliations')
-        rec_obj = self.env['account.move.reconcile']
-        rec_obj.search(
-            [('line_id.company_id', '=', self.id)]).unlink()
-
-        logger.info('Reset paid invoices\'s workflows')
+        _logger.info('Reset paid invoices\'s workflows')
         paid_invoices = self.env['account.invoice'].search(
             [('company_id', '=', self.id), ('state', '=', 'paid')])
         if paid_invoices:
@@ -131,7 +120,7 @@ class Company(models.Model):
         inv_ids = self.env['account.invoice'].search(
             [('company_id', '=', self.id)]).ids
         if inv_ids:
-            logger.info('Unlinking invoices')
+            _logger.info('Unlinking invoices')
             self.env['account.invoice.line'].search(
                 [('invoice_id', 'in', inv_ids)]).unlink()
             self.env['account.invoice.tax'].search(
@@ -141,7 +130,7 @@ class Company(models.Model):
                 DELETE FROM account_invoice
                 WHERE id IN %s""", (tuple(inv_ids),))
 
-        logger.info('Unlinking moves')
+        _logger.info('Unlinking moves')
         moves = self.env['account.move'].search([('company_id', '=', self.id)])
         if moves:
             self._cr.execute(
@@ -163,4 +152,11 @@ class Company(models.Model):
         unlink_from_company('account.tax.code')
         unlink_from_company('account.journal')
         unlink_from_company('account.account')
+        settings_id = self.env['account.config.settings'].search(
+            [('company_id', '=', self.id)]
+        )
+        settings_id.write({
+            'has_chart_of_accounts': False,
+            'expects_chart_of_accounts': False,
+        })
         return True

--- a/account_reset_chart/models/res_company.py
+++ b/account_reset_chart/models/res_company.py
@@ -157,6 +157,8 @@ class ResCompany(models.Model):
             [('company_id', '=', self.id)]
         ).unlink()
 
+        self.env['account.full.reconcile'].search([]).unlink()
+
         settings_id = self.env['account.config.settings'].search(
             [('company_id', '=', self.id)]
         )

--- a/account_reset_chart/models/res_company.py
+++ b/account_reset_chart/models/res_company.py
@@ -152,6 +152,21 @@ class ResCompany(models.Model):
         unlink_from_company('account.tax.code')
         unlink_from_company('account.journal')
         unlink_from_company('account.account')
+
+        try:
+            self.env['account.partial.reconcile'].search(
+                [('company_id', '=', self.id)]
+            ).unlink()
+        except KeyError:
+            pass
+
+        try:
+            self.env['account.full.reconcile'].search(
+                [('company_id', '=', self.id)]
+            ).unlink()
+        except KeyError:
+            pass
+
         settings_id = self.env['account.config.settings'].search(
             [('company_id', '=', self.id)]
         )


### PR DESCRIPTION
Upgrade to v9; main changes other than new standards:
- Circumvent new account bank statement singleton validations
- Remove reconciliation model (now Transient)
- Switched api.one for multi, but I didn't want the nesting so I just used recursion instead
- Reset account settings for company
- Add note about no sales/vendor tax ValueError in Known Issues

I squashed a bunch of the Transifex commits as I brought them in too. Let me know if I was out of line there & I will redo
