### PR TITLE
[REF] .travis.yml: Disable UNIT_TEST environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 
 env:
   global:
-  - VERSION="9.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0" UNIT_TEST="1"
+  - VERSION="9.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
   - TRANSIFEX_USER='transbot@odoo-community.org'
   - secure: "XzZzWhiVWXHI+tmcdYH0rPjietxvr1nUXuCRiqnDY3fM0lq6RmtwOlpDDwYEiX+9fHAE8mDttlJ7H4J/YZ+0ugwZxeM10yuT7FwkJY9kPvBe6T59P9aD9R6mSC/da4JGVd+Th5QXDBuBGRBVdY/qBT2lagHuSzBZdKwvMMsaBtA="
 


### PR DESCRIPTION
The new runbot based on travis2docker use the same .travis.yml configuration
`UNIT_TEST="1"` test all modules but delete the previous database, then we will have the database with the latest module tested in runbot.
Disabling this option we will have all modules tested installed in runbot