### PR TITLE
8.0 account_credit_control: enable communication under invoice

### DIFF
--- a/account_credit_control/README.rst
+++ b/account_credit_control/README.rst
@@ -27,3 +27,6 @@ On each generated line, you have many choices:
  * Send a email
  * Print a letter
  * Change the state (so you can ignore or reopen lines)
+
+To change manually overdue level of invoice you can use the wizard ``More >
+Change current credit policy`` in the invoice form or list.

--- a/account_credit_control/wizard/credit_control_communication.py
+++ b/account_credit_control/wizard/credit_control_communication.py
@@ -195,10 +195,19 @@ class CreditCommunication(models.TransientModel):
                                                              comm.id,
                                                              context=context)
             email_values['type'] = 'email'
-            # model is Transient record (self) removed periodically so no point
-            # of storing res_id
-            email_values.pop('model', None)
-            email_values.pop('res_id', None)
+            # Gives possibility to continue communication under related invoice
+            invoices = comm.credit_control_line_ids.filtered(
+                'invoice_id').mapped('invoice_id')
+            if invoices:
+                invoice = invoices[0]
+                email_values.update({
+                    'model': invoice._name,
+                    'res_id': invoice.id,
+                })
+            else:
+                email_values.pop('model', None)
+                email_values.pop('res_id', None)
+
             email = email_message_obj.create(email_values)
 
             state = 'sent'


### PR DESCRIPTION
This feature gives possibility to route replied email and continue communication with recipient via chatter under related invoice.

Added and small description of feature that should be mentioned, otherwise hard to notice that such exist.