### PR TITLE
[9.0][Fix] fix reconciliation when reversing an account move

### DIFF
--- a/account_reversal/models/account_move.py
+++ b/account_reversal/models/account_move.py
@@ -112,5 +112,5 @@ class AccountMove(models.Model):
         if moves and post:
             moves.post()
             if reconcile:
-                moves.move_reverse_reconcile()
+                self.move_reverse_reconcile()
         return moves

--- a/account_reversal/tests/test_account_reversal.py
+++ b/account_reversal/tests/test_account_reversal.py
@@ -63,11 +63,16 @@ class TestAccountReversal(TransactionCase):
             ':SALE_' or ':CUSTOMER_')
             for x in move.line_ids.sorted(key=lambda r: r.account_id.id)])
 
-    def test_reverse(self):
+    def test_reverse_posted_reconcile(self):
         move = self._create_move()
         self.assertEqual(
             self._move_str(move), '0.00100.00:SALE_100.000.00:CUSTOMER_')
-        rev = move.create_reversals()
+        rev = move.create_reversals(post=True, reconcile=True)
         self.assertEqual(len(rev), 1)
         self.assertEqual(
             self._move_str(rev), '100.000.00:SALE_0.00100.00:CUSTOMER_')
+        reconciled_line = move.line_ids.filtered(
+            lambda l: l.account_id.reconcile)
+        self.assertEqual(
+            'posted', rev.state)
+        self.assertTrue(reconciled_line.full_reconcile_id)


### PR DESCRIPTION
I have just tested the module account_reversal and reconciliation did not work.
Unless I did something wrong during my tests, it seems there is a small bug.

https://github.com/OCA/account-financial-tools/blob/9.0/account_reversal/models/account_move.py#L69
Here, it is always an empty loop since we call the method on the new created moves, for which reversal_id field is empty.