### PR TITLE
[8.0] account_credit_control sentwizard

### DIFF
--- a/account_credit_control/README.rst
+++ b/account_credit_control/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
 Credit Control
 ==============
 
@@ -23,7 +26,47 @@ Create a new "run" in the ``Credit Control Run`` menu with the controlling date.
 Then, use the ``Compute credit lines`` button. All the credit control lines will
 be generated. You can find them in the ``Credit Control Lines`` menu.
 
-On each generated line, you have many choices:
- * Send a email
+On each generated line, use wizard to set lines:
+ * ready to be sent
+ * ignored
+
+On each line ready to be sent:
+ * Send an email
  * Print a letter
- * Change the state (so you can ignore or reopen lines)
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/account-financial-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/account-financial-tools/issues/new?body=module:%20account_credit_control%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+- Guewen Baconnier, Joël Grand-Guillaume, Alexandre Fayolle, Matthieu Dietrich,
+  Vincent Renaville, Nicolas Bessi, Yannick Vaucher (Camptocamp)
+- Stefan Rijnhart (Therp)
+- Adrien Peiffer, Laurent Mignon (Acsone)
+- Andrius Preimantas
+- Alexis de Lattre, Sebastien Beau (Akretion)
+- Thomas Fossoul (Noviat)
+- Jacques-Etienne Baudoux (BCIM)
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+      :target: https://odoo-community.org
+
+      This module is maintained by the OCA.
+
+      OCA, or the Odoo Community Association, is a nonprofit organization whose
+      mission is to support the collaborative development of Odoo features and
+      promote its widespread use.
+
+      To contribute to this module, please visit http://odoo-community.org.

--- a/account_credit_control/__openerp__.py
+++ b/account_credit_control/__openerp__.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 {'name': 'Account Credit Control',
- 'version': '8.0.0.3.0',
+ 'version': '8.0.0.3.1',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'maintainer': 'Camptocamp',
  'category': 'Finance',

--- a/account_credit_control/i18n/account_credit_control.pot
+++ b/account_credit_control/i18n/account_credit_control.pot
@@ -362,6 +362,11 @@ msgid "Custom Mail Message"
 msgstr ""
 
 #. module: account_credit_control
+#: field:credit.control.policy.level,email_copy:0
+msgid "Send copy by email"
+msgstr ""
+
+#. module: account_credit_control
 #: field:credit.control.policy.level,custom_text:0
 msgid "Custom Message"
 msgstr ""

--- a/account_credit_control/i18n/fr.po
+++ b/account_credit_control/i18n/fr.po
@@ -445,6 +445,11 @@ msgid "Custom Mail Message"
 msgstr "Email personnalisé"
 
 #. module: account_credit_control
+#: field:credit.control.policy.level,email_copy:0
+msgid "Send copy by email"
+msgstr "Envoyer une copie par email"
+
+#. module: account_credit_control
 #: field:credit.control.policy.level,custom_text:0
 msgid "Custom Message"
 msgstr "Message personnalisable"

--- a/account_credit_control/policy.py
+++ b/account_credit_control/policy.py
@@ -237,6 +237,7 @@ class CreditControlPolicyLevel(models.Model):
                                 ('email', 'Email')],
                                string='Channel',
                                required=True)
+    email_copy = fields.Boolean('Send copy by email')
     custom_text = fields.Text(string='Custom Message',
                               required=True,
                               translate=True)

--- a/account_credit_control/policy_view.xml
+++ b/account_credit_control/policy_view.xml
@@ -37,6 +37,7 @@
                     <page string="Mail and reporting">
                       <group>
                         <field name="email_template_id"/>
+                        <field name="email_copy" attrs="{'invisible':[('channel','=','email')]}"/>
                         <newline/>
                         <field name="custom_text" colspan="4"/>
                         <newline/>

--- a/account_credit_control/run.py
+++ b/account_credit_control/run.py
@@ -124,9 +124,10 @@ class CreditControlRun(models.Model):
                 create = cr_line_obj.create_or_update_from_mv_lines
                 for level in reversed(policy.level_ids):
                     level_lines = level.get_level_lines(self.date, lines)
-                    policy_lines_generated += create(level_lines,
-                                                     level,
-                                                     self.date)
+                    if level_lines:
+                        policy_lines_generated += create(level_lines,
+                                                         level,
+                                                         self.date)
             generated |= policy_lines_generated
             if policy_lines_generated:
                 report += (_("Policy \"<b>%s</b>\" has generated <b>%d Credit "

--- a/account_credit_control/wizard/credit_control_printer.py
+++ b/account_credit_control/wizard/credit_control_printer.py
@@ -67,6 +67,9 @@ class CreditControlPrinter(models.TransientModel):
         comms = comm_obj._generate_comm_from_credit_lines(filtered_lines)
 
         if self.mark_as_sent:
+            comms_email = comms.filtered("current_policy_level.email_copy")
+            if comms_email:
+                comms_email._generate_emails()
             comms._mark_credit_line_as_sent()
 
         report_name = 'account_credit_control.report_credit_control_summary'

--- a/account_credit_control/wizard/credit_control_printer_view.xml
+++ b/account_credit_control/wizard/credit_control_printer_view.xml
@@ -9,8 +9,7 @@
           <separator string="Print the selected lines" colspan="4"/>
           <newline/>
           <group>
-            <field name="mark_as_sent"
-              colspan="4"/>
+            <field name="mark_as_sent" />
           </group>
           <newline/>
           <notebook>


### PR DESCRIPTION
* Do not generate erroneous email in mail queue. I think it's better to not generate emails without email_to. Email must be fixed on client. Then lin must be put back in state to_be_sent
* Set checkbox on same line as label. In print wizard, the checkbox was not in front of the label.
* Align email and print wizard: like for email, printed lines must be in state to_be_sent and right channel. Email and letter process were not the same. For emails, you had to put lines in to_be_sent state and you are restricted to lines in channel email. For letters, that domain wasn't existing. Now it's the same principle.
* Allow to send a copy of the letter by email