### PR TITLE
[10.0] account_check_deposit: no auto-post move

### DIFF
--- a/account_check_deposit/models/account_deposit.py
+++ b/account_check_deposit/models/account_deposit.py
@@ -232,9 +232,7 @@ class AccountCheckDeposit(models.Model):
             counter_vals['move_id'] = move.id
             move_line_obj.create(counter_vals)
 
-            move.post()
             deposit.write({'state': 'done', 'move_id': move.id})
-            # We have to reconcile after post()
             for reconcile_lines in to_reconcile_lines:
                 reconcile_lines.reconcile()
         return True

--- a/account_check_deposit/tests/test_check_deposit.py
+++ b/account_check_deposit/tests/test_check_deposit.py
@@ -189,5 +189,5 @@ class TestPayment(AccountingTestCase):
 
         self.assertEqual(check_deposit.total_amount, 300)
         self.assertEqual(liquidity_aml.debit, 300)
-        self.assertEqual(check_deposit.move_id.state, 'posted')
+        self.assertEqual(check_deposit.move_id.state, 'draft')
         self.assertEqual(check_deposit.state, 'done')


### PR DESCRIPTION
If you use account_cancel, it's not a problem to auto-post account moves generated upon validation of the check deposit, but for those who don't/can't use account_cancel, it's not a good idea to auto-post account moves.