### PR TITLE
[8.0] account_check_deposit: no auto-post move

### DIFF
--- a/account_check_deposit/models/account_deposit.py
+++ b/account_check_deposit/models/account_deposit.py
@@ -237,9 +237,8 @@ class AccountCheckDeposit(models.Model):
             counter_vals['move_id'] = move.id
             aml_obj.create(counter_vals)
 
-            move.post()
+            move.validate()
             deposit.write({'state': 'done', 'move_id': move.id})
-            # We have to reconcile after post()
             for reconcile_lines in to_reconcile_lines:
                 reconcile_lines.reconcile()
         return True


### PR DESCRIPTION
If you use account_cancel, it's not a problem to auto-post account moves generated upon validation of the check deposit, but for those who don't/can't use account_cancel, it's not a good idea to auto-post account moves.

Similar PR for v10 #485 