### PR TITLE
[7.0][FIX] Prevent problems when closing fiscal year.

### DIFF
--- a/account_constraints/__init__.py
+++ b/account_constraints/__init__.py
@@ -18,3 +18,4 @@
 #
 ##############################################################################
 from . import account_constraints
+from . import wizards

--- a/account_constraints/wizards/__init__.py
+++ b/account_constraints/wizards/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import account_fiscalyear_close

--- a/account_constraints/wizards/account_fiscalyear_close.py
+++ b/account_constraints/wizards/account_fiscalyear_close.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp.osv import orm
+
+
+class AccountFiscalyearCloseWizard(orm.TransientModel):
+    _inherit = 'account.fiscalyear.close'
+
+    def data_save(self, cr, uid, ids, context=None):
+        context = context and context.copy() or {}
+        context['from_parent_object'] = True
+        super(AccountFiscalyearCloseWizard, self).data_save(
+            cr, uid, ids, context=context
+        )


### PR DESCRIPTION
Generating an opening balance gives an error when account_constraints is installed:

2017-06-06 08:05:54,011 17956 ERROR openerpbisdombreda openerp.netsvc: Fout
You cannot do this on an entry generated by a bank statement. You must change the relatedbank statement directly.
Bank statement name (id): RAB778-2128 (89).
Traceback (most recent call last):
  File "/home/openerp1/odoo/parts/odoo/openerp/netsvc.py", line 307, in dispatch_rpc
    result = ExportService.getService(service_name).dispatch(method, params)
  File "/home/openerp1/odoo/parts/odoo/openerp/service/web_services.py", line 632, in dispatch
    res = fn(db, uid, *params)
  File "/home/openerp1/odoo/parts/odoo/openerp/osv/osv.py", line 193, in execute_kw
    return self.execute(db, uid, obj, method, *args, **kw or {})
  File "/home/openerp1/odoo/parts/odoo/openerp/osv/osv.py", line 133, in wrapper
    return f(self, dbname, *args, **kwargs)
  File "/home/openerp1/odoo/parts/odoo/openerp/osv/osv.py", line 202, in execute
    res = self.execute_cr(cr, uid, obj, method, *args, **kw)
  File "/home/openerp1/odoo/parts/odoo/addons/audittrail/audittrail.py", line 553, in execute_cr
    return fct_src(cr, uid, model, method, *args, **kw)
  File "/home/openerp1/odoo/parts/odoo/openerp/osv/osv.py", line 190, in execute_cr
    return getattr(object, method)(cr, uid, *args, **kw)
  File "/home/openerp1/odoo/parts/odoo/addons/account/wizard/account_fiscalyear_close.py", line 248, in data_save
    obj_acc_move.validate(cr, uid, [move_id], context=context)
  File "/home/openerp1/odoo/parts/odoo/addons/account/account.py", line 1660, in validate
    self._centralise(cr, uid, move, 'debit', context=context)
  File "/home/openerp1/odoo/parts/odoo/addons/account/account.py", line 1540, in _centralise
    }, context)
  File "/home/openerp1/odoo/parts/odoo/addons/account/account_move_line.py", line 1326, in create
    tmp = move_obj.validate(cr, uid, [vals['move_id']], context)
  File "/home/openerp1/odoo/parts/odoo/addons/account/account.py", line 1661, in validate
    self._centralise(cr, uid, move, 'credit', context=context)
  File "/home/openerp1/odoo/parts/odoo/addons/account/account.py", line 1540, in _centralise
    }, context)
  File "/home/openerp1/odoo/parts/odoo/addons/account/account_move_line.py", line 1326, in create
    tmp = move_obj.validate(cr, uid, [vals['move_id']], context)
  File "/home/openerp1/odoo/parts/odoo/addons/account/account.py", line 1664, in validate
    }, context, check=False)
  File "/home/openerp1/odoo/parts/account-financial-tools/account_constraints/account_constraints.py", line 152, in write
    context=context)
  File "/home/openerp1/odoo/parts/account-financial-tools/account_constraints/account_constraints.py", line 106, in _check_statement_related_move
    'bank statement directly.\n%s.') % err_msg
except_osv: (u'Fout', u'You cannot do this on an entry generated by a bank statement. You must change the relatedbank statement directly.\nBank statement name (id): RAB778-2128 (89).')