### PR TITLE
[FIX] account_asset_management, error when remove asset not yet run depreciation

### DIFF
--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -182,7 +182,8 @@ class account_asset_remove(orm.TransientModel):
                 _("You can't make an early removal if all the depreciation "
                   "lines for previous periods are not posted."))
 
-        last_depr_date = first_to_depreciate_dl.previous_id.line_date
+        last_depr_date = first_to_depreciate_dl.previous_id.line_date or \
+            first_to_depreciate_dl.asset_id.date_start
         period_number_days = (
             datetime.strptime(first_date, '%Y-%m-%d') -
             datetime.strptime(last_depr_date, '%Y-%m-%d')).days


### PR DESCRIPTION
If the asst has lines in depreciation board, but non of the line (even first line) being posted yet.
System will return error,
```
account_asset_management/wizard/account_asset_remove.py", line 189, in _prepare_early_removal
    datetime.strptime(last_depr_date, '%Y-%m-%d')).days
TypeError: strptime() argument 1 must be string, not bool
```
This is because, the first depreciation line will not have previous_id yet, first_to_depreciate_dl.previous_id, and so the last_depr_date = False.
And if non of line ever posted, the calculation will start from the first line, and so, no last date.

The fix make sure that even it is the first depreciation line, it get the asset.date_start for calculatoin.