### PR TITLE
[FIX] account_asset_management, list index out of range when remove asset w/o depre line

### DIFF
--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -173,6 +173,8 @@ class account_asset_remove(orm.TransientModel):
             [('asset_id', '=', asset.id), ('type', '=', 'depreciate'),
              ('init_entry', '=', False), ('move_check', '=', False)],
             order='line_date asc')
+        if not dl_ids:
+            return asset.value_residual
         first_to_depreciate_dl = asset_line_obj.browse(cr, uid, dl_ids[0])
 
         first_date = first_to_depreciate_dl.line_date
@@ -305,7 +307,9 @@ class account_asset_remove(orm.TransientModel):
             cr, uid,
             [('asset_id', '=', asset.id), ('type', '=', 'depreciate')],
             order='line_date desc')
-        last_date = asset_line_obj.browse(cr, uid, dl_ids[0]).line_date
+        last_date = asset.date_start
+        if dl_ids:
+            last_date = asset_line_obj.browse(cr, uid, dl_ids[0]).line_date
         if wiz_data.date_remove < last_date:
             raise orm.except_orm(
                 _('Error!'),


### PR DESCRIPTION
For asset without any depreciation lines, removing it will cause index out of range error.