### PR TITLE
[FIX] account_credit_control: missing permission

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2017 Okia SPRL (https://okia.be)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Account Credit Control',
- 'version': '10.0.1.1.0',
+ 'version': '10.0.1.2.0',
  'author': "Camptocamp,Odoo Community Association (OCA),Okia",
  'maintainer': 'Camptocamp',
  'category': 'Finance',

--- a/account_credit_control/views/account_invoice.xml
+++ b/account_credit_control/views/account_invoice.xml
@@ -12,20 +12,17 @@
         <field name="name">invoice.followup.form.view</field>
         <field name="model">account.invoice</field>
         <field name="inherit_id" ref="account.invoice_form"/>
+        <field name="groups_id" eval="[(4, ref('account_credit_control.group_account_credit_control_manager')), (4, ref('account_credit_control.group_account_credit_control_user')), (4, ref('account_credit_control.group_account_credit_control_info'))]"/>
         <field name="arch" type="xml">
             <notebook position="inside">
-                <page string="Credit Control"
-                      groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_user,account_credit_control.group_account_credit_control_info">
+                <page string="Credit Control">
                     <group>
                         <field name="credit_policy_id"
                                string="Manual Credit Control Policy"
-                               attrs="{'invisible': [('credit_policy_id', '=', False)]}"
-                               groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_user,account_credit_control.group_account_credit_control_info"/>
+                               attrs="{'invisible': [('credit_policy_id', '=', False)]}"/>
                     </group>
                     <separator string="Issued Lines" colspan="4"/>
-                    <field name="credit_control_line_ids" colspan="4"
-                           nolabel="1"
-                           groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_user,account_credit_control.group_account_credit_control_info">
+                    <field name="credit_control_line_ids" colspan="4" nolabel="1">
                         <tree string="Credit Control Lines">
                             <field name="date"/>
                             <field name="level"/>

--- a/account_credit_control/views/res_partner.xml
+++ b/account_credit_control/views/res_partner.xml
@@ -4,10 +4,10 @@
         <field name="name">partner.credit_control.form.view</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="account.view_partner_property_form"/>
+        <field name="groups_id" eval="[(4, ref('account_credit_control.group_account_credit_control_manager')), (4, ref('account_credit_control.group_account_credit_control_user'))]"/>
         <field name="arch" type="xml">
             <field name="credit" position="after">
-                <field name="credit_policy_id" widget="selection"
-                       groups="account_credit_control.group_account_credit_control_manager,account_credit_control.group_account_credit_control_user"/>
+                <field name="credit_policy_id" widget="selection"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
User with Accounting & Finance permissions got an error if he doesn't belongs to a Credit Control group on viewing partner form.

cc @Tecnativa