### PR TITLE
[10.0][FIX] account_credit_control report

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2017 Okia SPRL (https://okia.be)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Account Credit Control',
- 'version': '10.0.1.2.0',
+ 'version': '10.0.1.2.1',
  'author': "Camptocamp,Odoo Community Association (OCA),Okia",
  'maintainer': 'Camptocamp',
  'category': 'Finance',

--- a/account_credit_control/i18n/fr.po
+++ b/account_credit_control/i18n/fr.po
@@ -1175,7 +1175,7 @@ msgstr "État"
 #. module: account_credit_control
 #: model:ir.ui.view,arch_db:account_credit_control.report_credit_control_summary_document
 msgid "Summary"
-msgstr "Listes des factures en attente de règlement"
+msgstr "Liste des factures en attente de règlement"
 
 #. module: account_credit_control
 #: model:ir.model.fields,help:account_credit_control.field_account_invoice_credit_policy_id

--- a/account_credit_control/report/report_credit_control_summary.xml
+++ b/account_credit_control/report/report_credit_control_summary.xml
@@ -7,8 +7,8 @@
                     <div class="col-xs-5 col-xs-offset-7">
                         <address t-field="doc.contact_address"
                                  t-field-options='{"widget": "contact",
-                "fields": ["address", "name"],
-                "no_marker": true}'/>
+                                                   "fields": ["address", "name"],
+                                                   "no_marker": true}'/>
                     </div>
                     <div class="col-xs-5 col-xs-offset-7">
                         <span t-field="doc.report_date"/>
@@ -19,8 +19,10 @@
                     <span t-field="doc.current_policy_level.name"/>
                 </h2>
 
-                <div class="col-xs-12">
-                   <span t-field="doc.current_policy_level.custom_text" />
+                <div class="row mt32 mb32">
+                    <div class="col-xs-12">
+                       <span t-field="doc.current_policy_level.custom_text"/>
+                    </div>
                 </div>
 
                 <h3>Summary</h3>
@@ -91,7 +93,11 @@
                 </div>
 
                 <t t-if="doc.current_policy_level.custom_text_after_details">
-                    <p class="mt32 mb32" t-field="doc.current_policy_level.custom_text_after_details"/>
+                    <div class="row mt32 mb32">
+                        <div class="col-xs-12">
+                            <p t-field="doc.current_policy_level.custom_text_after_details"/>
+                        </div>
+                    </div>
                 </t>
 
             </div>


### PR DESCRIPTION
* Credit control policy level custom text wasn't aligned with other blocks.
* Also added space between summary and Credit control policy level custom text