### PR TITLE
[FIX] account_credit_control: add data migration script

### DIFF
--- a/account_credit_control/migrations/9.0.1.0.0/post-migration.py
+++ b/account_credit_control/migrations/9.0.1.0.0/post-migration.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openupgradelib import openupgrade
+from openerp import fields
 
 
 def migrate_followup_data(env):
@@ -40,7 +41,37 @@ def migrate_followup_data(env):
             })
 
 
+def set_followup_data(env):
+    today = fields.Date.context_today
+    policy = env['credit.control.policy.level'].search([])[:-1]
+    if policy:
+        env.cr.execute("""
+            SELECT aml.* FROM account_move_line aml, account_account aa
+            WHERE aml.account_id = aa.id
+            AND invoice_id IS NOT NULL
+            AND aa.internal_type = 'receivable'
+            AND aml.reconciled IS NULL
+            AND aml.date_maturity < %s
+        """, today)
+        data = env.cr.dictfetchall()
+        for line in data:
+            env['credit.control.line'].create({
+                'date': today,
+                'date_due': line['date_maturity'],
+                'state': 'draft',
+                'channel': 'letter',
+                'invoice_id': line['invoice_id'],
+                'partner_id': line['partner_id'],
+                'amount_due': line['debit'],
+                'balance_due': line['debit'],
+                'move_line_id': line['id'],
+                'account_id': line['account_id'],
+                'policy_level_id': policy.id,
+            })
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     if openupgrade.table_exists(env.cr, 'account_followup_followup'):
         migrate_followup_data(env)
+        set_followup_data(env)


### PR DESCRIPTION
It is necessary create account_credit_lines from account move lines because account_credit_control is now based in model invoice instead of account_move_line. 