### PR TITLE
[FIX] account_credit_control: permission error on duplicate

### DIFF
--- a/account_credit_control/__openerp__.py
+++ b/account_credit_control/__openerp__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Account Credit Control',
-    'version': '9.0.1.0.2',
+    'version': '9.0.1.0.3',
     'author': "Camptocamp, "
               "Tecnativa, "
               "Odoo Community Association (OCA)",

--- a/account_credit_control/models/res_partner.py
+++ b/account_credit_control/models/res_partner.py
@@ -34,7 +34,8 @@ class ResPartner(models.Model):
     @api.constrains('credit_policy_id', 'property_account_receivable_id')
     def _check_credit_policy(self):
         """ Ensure that policy on partner are limited to the account policy """
-        for partner in self:
+        # sudo needed for those w/o permission that duplicate records
+        for partner in self.sudo():
             if (not partner.property_account_receivable_id or
                     not partner.credit_policy_id):
                 continue


### PR DESCRIPTION
A user without credit control permission run constraint on duplicate partner.

These change avoid this problem.

cc @Tecnativa