### PR TITLE
[IMP] account_credit_control: avoid mark as sent mistakenly

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2017 Okia SPRL (https://okia.be)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Account Credit Control',
- 'version': '10.0.1.3.2',
+ 'version': '10.0.1.3.3',
  'author': "Camptocamp,Odoo Community Association (OCA),Okia",
  'maintainer': 'Camptocamp',
  'category': 'Finance',

--- a/account_credit_control/wizard/credit_control_printer.py
+++ b/account_credit_control/wizard/credit_control_printer.py
@@ -22,7 +22,6 @@ class CreditControlPrinter(models.TransientModel):
         return context.get('active_ids', False)
 
     mark_as_sent = fields.Boolean(string='Mark letter lines as sent',
-                                  default=True,
                                   help="Only letter lines will be marked.")
     line_ids = fields.Many2many('credit.control.line',
                                 string='Credit Control Lines',


### PR DESCRIPTION
User can print summary and accidentally mark as done all records selected.

cc @Tecnativa