### PR TITLE
[10.0][FIX] account_credit_control: add currency on summary report

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2017 Okia SPRL (https://okia.be)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Account Credit Control',
- 'version': '10.0.1.3.2',
+ 'version': '10.0.1.3.3',
  'author': "Camptocamp,Odoo Community Association (OCA),Okia",
  'maintainer': 'Camptocamp',
  'category': 'Finance',

--- a/account_credit_control/report/report_credit_control_summary.xml
+++ b/account_credit_control/report/report_credit_control_summary.xml
@@ -61,10 +61,10 @@
                             </td>
 
                             <td class="text-right">
-                                <span t-field="l.amount_due"/>
+                                <span t-field="l.amount_due" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
                             </td>
                             <td class="text-right">
-                                <span t-field="l.balance_due"/>
+                                <span t-field="l.balance_due" t-options='{"widget": "monetary", "display_currency": l.currency_id or l.company_id.currency_id}'/>
                             </td>
                         </tr>
                     </tbody>
@@ -78,7 +78,7 @@
                                     <strong>Total Invoiced</strong>
                                 </td>
                                 <td class="text-right">
-                                    <span t-field="doc.total_invoiced" />
+                                    <span t-field="doc.total_invoiced" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
                                 </td>
                             </tr>
                             <tr>
@@ -86,7 +86,7 @@
                                     <strong>Total Due</strong>
                                 </td>
                                 <td class="text-right">
-                                    <span t-field="doc.total_due"/>
+                                    <span t-field="doc.total_due" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
                                 </td>
                             </tr>
                         </table>


### PR DESCRIPTION
On v8.0 the currency was displayed on the report but during the migrations, this information was lost.
This PR re-introduce it.
