### PR TITLE
[10.0] account_fiscal_year + account_fiscal_month: prevent to declare fiscal month and/or year for all companies in a multi-company context

### DIFF
--- a/account_fiscal_month/models/res_company.py
+++ b/account_fiscal_month/models/res_company.py
@@ -17,5 +17,7 @@ class ResCompany(models.Model):
             ('type_id', '=', fm_id.id),
             ('date_start', '<=', date_str),
             ('date_end', '>=', date_str),
+            '|',
             ('company_id', '=', self.id),
-        ])
+            ('company_id', '=', False),
+        ], limit=1, order='company_id asc')

--- a/account_fiscal_year/models/res_company.py
+++ b/account_fiscal_year/models/res_company.py
@@ -19,9 +19,13 @@ class ResCompany(models.Model):
             ('type_id', '=', fy_id.id),
             ('date_start', '<=', date_str),
             ('date_end', '>=', date_str),
+            '|',
             ('company_id', '=', self.id),
+            ('company_id', '=', False),
         ]
-        date_range = self.env['date.range'].search(s_args)
+        date_range = self.env['date.range'].search(s_args,
+                                                   limit=1,
+                                                   order='company_id asc')
         return date_range
 
     @api.multi


### PR DESCRIPTION
This PR allow to share fiscal months and years between companies