### PR TITLE
[FIX] account_invoice_tax_required: No conflict with l10n_generic_coa

### DIFF
--- a/account_invoice_tax_required/models/account_invoice.py
+++ b/account_invoice_tax_required/models/account_invoice.py
@@ -27,8 +27,14 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def invoice_validate(self):
-        if self.env.context.get('test_tax_required') or not (
-                config['test_enable'] or
-                config["init"].get("l10n_generic_coa")):
+        # Always test if it is required by context
+        force_test = self.env.context.get('test_tax_required')
+        skip_test = any((
+            # This addon fails when installing any l10n_* addon
+            any(key.startswith("l10n_") for key in config["init"]),
+            # Avoid breaking unaware addons' tests by default
+            config["test_enable"],
+        ))
+        if force_test or not skip_test:
             self._test_invoice_line_tax()
         return super(AccountInvoice, self).invoice_validate()

--- a/account_invoice_tax_required/models/account_invoice.py
+++ b/account_invoice_tax_required/models/account_invoice.py
@@ -27,8 +27,8 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def invoice_validate(self):
-        if not (config['test_enable'] and
-                not self.env.context.get('test_tax_required')):
+        if self.env.context.get('test_tax_required') or not (
+                config['test_enable'] or
+                config["init"].get("l10n_generic_coa")):
             self._test_invoice_line_tax()
-        res = super(AccountInvoice, self).invoice_validate()
-        return res
+        return super(AccountInvoice, self).invoice_validate()

--- a/account_invoice_tax_required/models/account_invoice.py
+++ b/account_invoice_tax_required/models/account_invoice.py
@@ -30,8 +30,11 @@ class AccountInvoice(models.Model):
         # Always test if it is required by context
         force_test = self.env.context.get('test_tax_required')
         skip_test = any((
-            # This addon fails when installing any l10n_* addon
-            any(key.startswith("l10n_") for key in config["init"]),
+            # It usually fails when installing other addons with demo data
+            self.env["ir.module.module"].search([
+                ("state", "in", ["to install", "to upgrade"]),
+                ("demo", "=", True),
+            ]),
             # Avoid breaking unaware addons' tests by default
             config["test_enable"],
         ))


### PR DESCRIPTION
Integration tests reveal that this addon is installed and you install l10n_generic_coa with demo data, it crashes. Now it doesn't.

@Tecnativa