### PR TITLE
[10.0][Fix] account_credit_control : Do not ignore lines with company currency defined

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2017 Okia SPRL (https://okia.be)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Account Credit Control',
- 'version': '10.0.1.3.2',
+ 'version': '10.0.1.3.3',
  'author': "Camptocamp,Odoo Community Association (OCA),Okia",
  'maintainer': 'Camptocamp',
  'category': 'Finance',

--- a/account_credit_control/models/credit_control_line.py
+++ b/account_credit_control/models/credit_control_line.py
@@ -181,7 +181,8 @@ class CreditControlLine(models.Model):
 
         new_lines = self.browse()
         for move_line in lines:
-            if move_line.currency_id:
+            ml_currency = move_line.currency_id
+            if ml_currency and ml_currency != user_currency:
                 open_amount = move_line.amount_residual_currency
             else:
                 open_amount = move_line.amount_residual


### PR DESCRIPTION
If account.move.line records have currency_id defined and this currency_id is the same than company_id.currency_id, these records should generate credit.control.line.