### PR TITLE
[FIX] account_invoice_tax_required: missing permission

### DIFF
--- a/account_invoice_tax_required/__manifest__.py
+++ b/account_invoice_tax_required/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': "Tax required in invoice",
-    'version': "10.0.1.0.0",
+    'version': "10.0.1.0.1",
     "author": "Camptocamp,Tecnativa,Odoo Community Association (OCA)",
     'website': "http://www.camptocamp.com",
     'category': "Localisation / Accounting",

--- a/account_invoice_tax_required/models/account_invoice.py
+++ b/account_invoice_tax_required/models/account_invoice.py
@@ -31,7 +31,7 @@ class AccountInvoice(models.Model):
         force_test = self.env.context.get('test_tax_required')
         skip_test = any((
             # It usually fails when installing other addons with demo data
-            self.env["ir.module.module"].search([
+            self.sudo().env["ir.module.module"].search([
                 ("state", "in", ["to install", "to upgrade"]),
                 ("demo", "=", True),
             ]),


### PR DESCRIPTION
If user is not a settings user, he can't validate invoices.

cc @Tecnativa