### PR TITLE
Add account_full_reconcile to dependencies

### DIFF
--- a/account_check_deposit/__openerp__.py
+++ b/account_check_deposit/__openerp__.py
@@ -21,6 +21,7 @@
     'website': 'http://www.akretion.com/',
     'depends': [
         'account_accountant',
+        'account_full_reconcile',
     ],
     'data': [
         'views/account_deposit_view.xml',


### PR DESCRIPTION
Needed as the view calls full_reconcile_id filed, which is not in the standard installation.