### PR TITLE
[FIX] Also reverse tax amount

### DIFF
--- a/account_reversal/__openerp__.py
+++ b/account_reversal/__openerp__.py
@@ -25,7 +25,7 @@
 
 {
     'name': 'Account Reversal',
-    'version': '8.0.1.1.1',
+    'version': '8.0.1.1.2',
     'category': 'Generic Modules/Accounting',
     'license': 'AGPL-3',
     'author': "Akretion,Camptocamp,Odoo Community Association (OCA)",

--- a/account_reversal/account_reversal.py
+++ b/account_reversal/account_reversal.py
@@ -114,6 +114,7 @@ class account_move(models.Model):
                 {'debit': rev_move_line.credit,
                  'credit': rev_move_line.debit,
                  'amount_currency': rev_move_line.amount_currency * -1,
+                 'tax_amount': rev_move_line.tax_amount * -1,
                  'name': rev_ml_name},
                 check=True,
                 update_check=True)

--- a/account_reversal/tests/test_account_reversal.py
+++ b/account_reversal/tests/test_account_reversal.py
@@ -75,7 +75,8 @@ class test_account_reversal(common.TransactionCase):
                 'account_id': account2.id,
                 'company_id': company_id,
                 'partner_id': self.ref('base.res_partner_1')
-                if with_partner else False
+                if with_partner else False,
+                'tax_amount': -amount,
             }
         )
         return move_line_id.move_id
@@ -110,6 +111,8 @@ class test_account_reversal(common.TransactionCase):
                              x.account_id == account1 and 'aaaa' or 'bbbb')
              for x in reversed_moves.line_id])
         self.assertEqual(movestr_reversed, '0.00100.00bbbb100.000.00aaaa')
+        self.assertEqual(
+            reversed_moves.line_id.filtered('credit').tax_amount, 100)
 
     def test_reverse_closed_period(self):
         move_period = self.env.ref('account.period_0')


### PR DESCRIPTION
When reversing a move with tax on its lines, reverse the sign on the tax amount to prevent paying double the amount as tax instead of negating the tax to pay.