### PR TITLE
[10.0][FIX] account_move_fiscal_month/year: Wrong search result

### DIFF
--- a/account_move_fiscal_month/models/account_move.py
+++ b/account_move_fiscal_month/models/account_move.py
@@ -30,6 +30,8 @@ class AccountMove(models.Model):
             date_range_domain = [('name', operator, value)]
 
         date_ranges = self.env['date.range'].search(date_range_domain)
+        if not date_ranges:
+            return [('id', '=', False)]
         domain = []
         for date_range in date_ranges:
             domain = expression.OR([domain, [

--- a/account_move_fiscal_month/tests/test_account_move_fiscal_month.py
+++ b/account_move_fiscal_month/tests/test_account_move_fiscal_month.py
@@ -154,3 +154,10 @@ class TestAccountMoveFiscalMonth(TransactionCase):
             move_march_2017 not in moves,
             move_jan_2018 not in moves,
         ]))
+        # Search non existing month
+        moves = self.AccountMoveObj.search([
+            ('date_range_fm_id', 'ilike', '2016'),
+        ])
+        self.assertFalse(
+            moves
+        )

--- a/account_move_fiscal_year/models/account_move.py
+++ b/account_move_fiscal_year/models/account_move.py
@@ -40,6 +40,9 @@ class AccountMove(models.Model):
         date_range_domain.append(('type_id', '=', fiscal_year_type.id))
         date_ranges = self.env['date.range'].search(date_range_domain)
 
+        if not date_ranges:
+            return [('id', '=', False)]
+
         domain = []
         for date_range in date_ranges:
             domain = expression.OR([domain, [

--- a/account_move_fiscal_year/tests/test_account_move_fiscal_year.py
+++ b/account_move_fiscal_year/tests/test_account_move_fiscal_year.py
@@ -131,3 +131,10 @@ class TestAccountMoveFiscalYear(TransactionCase):
             move_2018 in moves,
             move_2019 not in moves,
         ]))
+        # Search non existing year
+        moves = self.AccountMoveObj.search([
+            ('date_range_fy_id', 'ilike', '2016'),
+        ])
+        self.assertFalse(
+            moves
+        )


### PR DESCRIPTION
In case of non existing fiscal year/month, the search method returns void domain which returns all records.