### PR TITLE
[9.0][FIX] account_chart_update: Check fiscal positions with same name

### DIFF
--- a/account_chart_update/README.rst
+++ b/account_chart_update/README.rst
@@ -57,6 +57,7 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Jairo Llopis <jairo.llopis@tecnativa.com>
 * Jacques-Etienne Baudoux <je@bcim.be>
+* Nacho Muñoz <nacmuro@gmail.com>
 
 Maintainer
 ----------

--- a/account_chart_update/__openerp__.py
+++ b/account_chart_update/__openerp__.py
@@ -7,7 +7,7 @@
 {
     'name': "Detect changes and update the Account Chart from a template",
     "summary": "Wizard to update a company's account chart from a template",
-    'version': "9.0.1.0.0",
+    'version': "9.0.1.0.1",
     'author': "Tecnativa, "
               "BCIM,"
               "Odoo Community Association (OCA)",
@@ -18,6 +18,7 @@
         'Pedro M. Baeza',
         'Jairo Llopis',
         'Jacques-Etienne Baudoux',
+        'Nacho Muñoz',
     ],
     'license': "AGPL-3",
     "data": [

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -442,8 +442,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             try:
                 if not relation:
                     if len(real) > 1:
-                        raise exceptions.Warning(
-                            _("Fiscal position duplicated:\n\n%s") % real[0].name)
+                        real = real[0]
                     if expected is not None and expected != real[key]:
                         result[key] = expected
                     elif template[key] != real[key]:

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -303,7 +303,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         """Find a real fiscal position from a template."""
         return self.env['account.fiscal.position'].search(
             [('name', 'in', templates.mapped("name")),
-             ('company_id', '=', self.company_id.id)])
+             ('company_id', '=', self.company_id.id)], limit=1)
 
     @api.multi
     @tools.ormcache("templates", "current_fp_accounts")
@@ -441,8 +441,6 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             # Register detected differences
             try:
                 if not relation:
-                    if len(real) > 1:
-                        real = real[0]
                     if expected is not None and expected != real[key]:
                         result[key] = expected
                     elif template[key] != real[key]:

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -441,6 +441,9 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             # Register detected differences
             try:
                 if not relation:
+                    if len(real) > 1:
+                        raise exceptions.Warning(
+                            _("Fiscal position duplicated:\n\n%s") % real[0].name)
                     if expected is not None and expected != real[key]:
                         result[key] = expected
                     elif template[key] != real[key]:


### PR DESCRIPTION
This PR checks if there is more than one fiscal position with same name and handles the exception, preventing Odoo crash.

@pedrobaeza 