### PR TITLE
[FIX] account_invoice_tax_required: Pass integration tests

### DIFF
--- a/account_invoice_tax_required/tests/test_account_invoice_tax_required.py
+++ b/account_invoice_tax_required/tests/test_account_invoice_tax_required.py
@@ -2,10 +2,12 @@
 # Copyright 2016 - Tecnativa - Angel Moya <odoo@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import at_install, post_install, TransactionCase
 from odoo import exceptions
 
 
+@at_install(False)
+@post_install(True)
 class TestAccountInvoiceTaxRequired(TransactionCase):
 
     def setUp(self):


### PR DESCRIPTION
Tests fail if `sale` is preinstalled, with:

    ERROR: test_exception (odoo.addons.account_invoice_tax_required.tests.test_account_invoice_tax_required.TestAccountInvoiceTaxRequired)
    ` Validate invoice without tax must raise exception
    Traceback (most recent call last):
    `   File "/opt/odoo/auto/addons/account_invoice_tax_required/tests/test_account_invoice_tax_required.py", line 42, in setUp
    `     'description': 'Test',
    `   File "/opt/odoo/auto/addons/product/models/product.py", line 320, in create
    `     product = super(ProductProduct, self.with_context(create_product_product=True)).create(vals)
    `   File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 228, in create
    `     thread = super(MailThread, self).create(values)
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3847, in create
    `     record = self.browse(self._create(old_vals))
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3908, in _create
    `     parent_id = self.env[parent_model].create(parent_vals).id
    `   File "/opt/odoo/auto/addons/product/models/product_template.py", line 267, in create
    `     template = super(ProductTemplate, self).create(vals)
    `   File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 228, in create
    `     thread = super(MailThread, self).create(values)
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3847, in create
    `     record = self.browse(self._create(old_vals))
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3942, in _create
    `     cr.execute(query, tuple(u[2] for u in updates if len(u) > 2))
    `   File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 154, in wrapper
    `     return f(self, *args, **kwargs)
    `   File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 231, in execute
    `     res = self._obj.execute(query, params)
    ` IntegrityError: null value in column "sale_line_warn" violates not-null constraint
    ` DETAIL:  Failing row contains (42, null, 100.00, null, 1, null, 1, 1, null, null, 2018-05-15 08:03:45.708787, 1, t, t, null, 1, 1, null, Test, null, 2018-05-15 08:03:45.708787, t, 1, Test, f, service, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null).

@Tecnativa