### PR TITLE
[FIX] account_credit_control_dunning_fees: Change currency by SQL

### DIFF
--- a/account_credit_control_dunning_fees/tests/test_fees_generation.py
+++ b/account_credit_control_dunning_fees/tests/test_fees_generation.py
@@ -15,7 +15,10 @@ class FixedFeesTester(common.TransactionCase):
         self.assertTrue(self.usd)
 
         self.company = self.browse_ref('base.main_company')
-        self.company.currency_id = self.euro
+        self.env.cr.execute(
+            """UPDATE res_company SET currency_id = %s
+            WHERE id = %s""", (self.company.id, self.euro.id),
+        )
 
         level_obj = self.env['credit.control.policy.level']
         self.euro_level = level_obj.new({


### PR DESCRIPTION
To avoid constraint.

Fix incompatibility introduced in https://github.com/OCA/OCB/commit/0e881fcd3a5671c4fe84b2a47c9d3611e4b823a1

Port of https://github.com/OCA/account-financial-tools/commit/ae3143b6ae18c49145b5cec5569382986b8a6590

Closes #654 