### PR TITLE
[FIX+REF] account_move_line_tax_editable: fixes not being able to def…

### DIFF
--- a/account_move_line_tax_editable/__manifest__.py
+++ b/account_move_line_tax_editable/__manifest__.py
@@ -6,7 +6,7 @@
     'name': 'Account Move Line Tax Editable',
     'summary': """
         Allows to edit taxes on non-posted account move lines""",
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'license': 'AGPL-3',
     'author': 'ACSONE SA/NV,Odoo Community Association (OCA)',
     'website': 'https://www.acsone.eu',

--- a/account_move_line_tax_editable/models/account_move_line.py
+++ b/account_move_line_tax_editable/models/account_move_line.py
@@ -6,14 +6,14 @@ from odoo import api, fields, models
 
 
 class AccountMoveLine(models.Model):
-
     _inherit = 'account.move.line'
 
     is_tax_editable = fields.Boolean(
         string="Is tax data editable?", compute='_compute_is_tax_editable')
+    move_state = fields.Selection(related="move_id.state", readonly=True)
 
     @api.multi
-    @api.depends('move_id.state')
+    @api.depends('move_state')
     def _compute_is_tax_editable(self):
         for rec in self:
             rec.is_tax_editable = rec._get_is_tax_editable()
@@ -21,4 +21,4 @@ class AccountMoveLine(models.Model):
     @api.multi
     def _get_is_tax_editable(self):
         self.ensure_one()
-        return self.move_id.state == 'draft'
+        return self.move_state in (False, 'draft')

--- a/account_move_line_tax_editable/models/account_move_line.py
+++ b/account_move_line_tax_editable/models/account_move_line.py
@@ -21,4 +21,4 @@ class AccountMoveLine(models.Model):
     @api.multi
     def _get_is_tax_editable(self):
         self.ensure_one()
-        return self.move_state in (False, 'draft')
+        return not self.move_id or self.move_id.state == 'draft'

--- a/account_move_line_tax_editable/models/account_move_line.py
+++ b/account_move_line_tax_editable/models/account_move_line.py
@@ -10,10 +10,9 @@ class AccountMoveLine(models.Model):
 
     is_tax_editable = fields.Boolean(
         string="Is tax data editable?", compute='_compute_is_tax_editable')
-    move_state = fields.Selection(related="move_id.state", readonly=True)
 
     @api.multi
-    @api.depends('move_state')
+    @api.depends('move_id.state')
     def _compute_is_tax_editable(self):
         for rec in self:
             rec.is_tax_editable = rec._get_is_tax_editable()

--- a/account_move_line_tax_editable/views/account_move.xml
+++ b/account_move_line_tax_editable/views/account_move.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2017 ACSONE SA/NV
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
-
 <odoo>
-<data>
-
     <record model="ir.ui.view" id="account_move_form_view">
         <field name="name">account.move.form (in account_move_line_tax_editable)</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='line_ids']/tree/field[@name='name']" position="after">
+                <field name="move_state" invisible="1"/>
                 <field name="is_tax_editable" invisible="1"/>
                 <field name="tax_line_id" attrs="{'readonly': [('is_tax_editable', '=', False)]}"/>
                 <field name="tax_ids" attrs="{'readonly': [('is_tax_editable', '=', False)]}"
@@ -18,6 +16,4 @@
             </xpath>
         </field>
     </record>
-
-</data>
 </odoo>

--- a/account_move_line_tax_editable/views/account_move.xml
+++ b/account_move_line_tax_editable/views/account_move.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='line_ids']/tree/field[@name='name']" position="after">
-                <field name="move_state" invisible="1"/>
+                <field name="move_id" invisible="1"/>
                 <field name="is_tax_editable" invisible="1"/>
                 <field name="tax_line_id" attrs="{'readonly': [('is_tax_editable', '=', False)]}"/>
                 <field name="tax_ids" attrs="{'readonly': [('is_tax_editable', '=', False)]}"

--- a/account_move_line_tax_editable/views/account_move_line.xml
+++ b/account_move_line_tax_editable/views/account_move_line.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2017 ACSONE SA/NV
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
-
 <odoo>
-<data>
-
     <record model="ir.ui.view" id="account_move_line_form_view">
         <field name="name">account.move.line.form (in account_move_line_tax_editable)</field>
         <field name="model">account.move.line</field>
         <field name="inherit_id" ref="account.view_move_line_form"/>
         <field name="arch" type="xml">
             <field name="tax_line_id" position="before">
+                <field name="move_state" invisible="1"/>
                 <field name="is_tax_editable" invisible="1"/>
             </field>
             <field name="tax_line_id" position="attributes">
@@ -23,6 +21,4 @@
             </field>
         </field>
     </record>
-
-</data>
 </odoo>

--- a/account_move_line_tax_editable/views/account_move_line.xml
+++ b/account_move_line_tax_editable/views/account_move_line.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="account.view_move_line_form"/>
         <field name="arch" type="xml">
             <field name="tax_line_id" position="before">
-                <field name="move_state" invisible="1"/>
+                <field name="move_id" invisible="1"/>
                 <field name="is_tax_editable" invisible="1"/>
             </field>
             <field name="tax_line_id" position="attributes">


### PR DESCRIPTION
…ine the tax when creating a new journal entry

Before this fix, when a new journal entry was created, the taxes fields were readonly. They were only editable after saving the entry for the first time and editing it again.

Additionally, there's some refactoring too.