### PR TITLE
[11.0][account_loan] Change logger level on import dependency

### DIFF
--- a/account_loan/model/account_loan.py
+++ b/account_loan/model/account_loan.py
@@ -13,7 +13,7 @@ _logger = logging.getLogger(__name__)
 try:
     import numpy
 except (ImportError, IOError) as err:
-    _logger.error(err)
+    _logger.debug(err)
 
 
 class AccountLoan(models.Model):


### PR DESCRIPTION
According to the guidelines:
https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md#importerror

Change the logger level from `error` to `debug`.