### PR TITLE
[FIX] account_invoice_currency: Integration tests

### DIFF
--- a/account_invoice_currency/__manifest__.py
+++ b/account_invoice_currency/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': "Company currency in invoices",
-    'version': "10.0.1.1.0",
+    'version': "10.0.1.1.1",
     'author': "Zikzakmedia SL, "
               "Joaquín Gutierrez, "
               "Tecnativa, "

--- a/account_invoice_currency/tests/test_account_invoice_currency.py
+++ b/account_invoice_currency/tests/test_account_invoice_currency.py
@@ -2,9 +2,11 @@
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import at_install, post_install, TransactionCase
 
 
+@at_install(False)
+@post_install(True)
 class TestAccountInvoiceCurrency(TransactionCase):
     def setUp(self):
         super(TestAccountInvoiceCurrency, self).setUp()


### PR DESCRIPTION
Creating a partner in at install mode raises this in integration environment:

    IntegrityError: null value in column "sale_warn" violates not-null constraint

Moving to post install mode.

@Tecnativa