### PR TITLE
[10.0][FIX] account_check_deposit: Don't force 'name' on account.move !

### DIFF
--- a/account_check_deposit/models/account_config_settings.py
+++ b/account_check_deposit/models/account_config_settings.py
@@ -12,3 +12,5 @@ class AccountConfigSettings(models.TransientModel):
         related='company_id.check_deposit_offsetting_account')
     check_deposit_transfer_account_id = fields.Many2one(
         related='company_id.check_deposit_transfer_account_id')
+    check_deposit_post_move = fields.Boolean(
+        related='company_id.check_deposit_post_move')

--- a/account_check_deposit/models/account_deposit.py
+++ b/account_check_deposit/models/account_deposit.py
@@ -164,8 +164,7 @@ class AccountCheckDeposit(models.Model):
         move_vals = {
             'journal_id': journal_id,
             'date': deposit.deposit_date,
-            'name': _('Check Deposit %s') % deposit.name,
-            'ref': deposit.name,
+            'ref': _('Check Deposit %s') % deposit.name,
         }
         return move_vals
 
@@ -236,6 +235,8 @@ class AccountCheckDeposit(models.Model):
                 deposit, total_debit, total_amount_currency)
             counter_vals['move_id'] = move.id
             move_line_obj.create(counter_vals)
+            if deposit.company_id.check_deposit_post_move:
+                move.post()
 
             deposit.write({'state': 'done', 'move_id': move.id})
             for reconcile_lines in to_reconcile_lines:

--- a/account_check_deposit/models/company.py
+++ b/account_check_deposit/models/company.py
@@ -20,4 +20,5 @@ class ResCompany(models.Model):
         'account.account', string='Transfer Account for Check Deposits',
         ondelete='restrict', copy=False,
         domain=[('reconcile', '=', True), ('deprecated', '=', False)])
-    check_deposit_post_move = fields.Boolean(string='Post Move for Check Deposits')
+    check_deposit_post_move = fields.Boolean(
+        string='Post Move for Check Deposits')

--- a/account_check_deposit/models/company.py
+++ b/account_check_deposit/models/company.py
@@ -20,3 +20,4 @@ class ResCompany(models.Model):
         'account.account', string='Transfer Account for Check Deposits',
         ondelete='restrict', copy=False,
         domain=[('reconcile', '=', True), ('deprecated', '=', False)])
+    check_deposit_post_move = fields.Boolean(string='Post Move for Check Deposits')

--- a/account_check_deposit/views/account_config_settings.xml
+++ b/account_check_deposit/views/account_config_settings.xml
@@ -10,16 +10,23 @@
     <field name="model">account.config.settings</field>
     <field name="inherit_id" ref="account.view_account_config_settings"/>
     <field name="arch" type="xml">
-        <div name="bank_options" position="inside">
-            <div name="check_deposit_option">
-                <label for="check_deposit_offsetting_account"/>
-                <field name="check_deposit_offsetting_account" class="oe_inline"/>
-            </div>
-            <div name="check_deposit_transfer"
-                    attrs="{'invisible': ['|', ('has_chart_of_accounts', '=', False), ('check_deposit_offsetting_account', '!=', 'transfer_account')]}">
-                <label for="check_deposit_transfer_account_id"/>
-                <field name="check_deposit_transfer_account_id" class="oe_inline"
-                    context="{'default_reconcile': True}"/>
+        <div name="bank_options" position="after">
+            <label string="Check Deposit" name="check_deposit"/>
+            <div name="check_deposit">
+                <div name="check_deposit_option">
+                    <label for="check_deposit_offsetting_account"/>
+                    <field name="check_deposit_offsetting_account" class="oe_inline"/>
+                </div>
+                <div name="check_deposit_transfer"
+                        attrs="{'invisible': ['|', ('has_chart_of_accounts', '=', False), ('check_deposit_offsetting_account', '!=', 'transfer_account')]}">
+                    <label for="check_deposit_transfer_account_id"/>
+                    <field name="check_deposit_transfer_account_id" class="oe_inline"
+                        context="{'default_reconcile': True}"/>
+                </div>
+                <div name="check_deposit_post_move">
+                    <field name="check_deposit_post_move" class="oe_inline"/>
+                    <label for="check_deposit_post_move"/>
+                </div>
             </div>
         </div>
     </field>


### PR DESCRIPTION
Add configuration option to post move or not
Improve check deposit section of accounting configuration page