### PR TITLE
[10.0][FIX] account_credit_control: more accurate usage of sudo() to avoid multi-company issues

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2017 Okia SPRL (https://okia.be)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Account Credit Control',
- 'version': '10.0.1.3.3',
+ 'version': '10.0.1.3.4',
  'author': "Camptocamp,Odoo Community Association (OCA),Okia",
  'maintainer': 'Camptocamp',
  'category': 'Finance',

--- a/account_credit_control/models/res_partner.py
+++ b/account_credit_control/models/res_partner.py
@@ -56,12 +56,12 @@ class ResPartner(models.Model):
     def _check_credit_policy(self):
         """ Ensure that policy on partner are limited to the account policy """
         # sudo needed for those w/o permission that duplicate records
-        for partner in self.sudo():
+        for partner in self:
             if (not partner.property_account_receivable_id or
-                    not partner.credit_policy_id):
+                    not partner.sudo().credit_policy_id):
                 continue
             account = partner.property_account_receivable_id
-            policy = partner.credit_policy_id
+            policy = partner.sudo().credit_policy_id
             try:
                 policy.check_policy_against_account(account)
             except UserError as err:


### PR DESCRIPTION
Step to reproduce:

- Define 2 companies A and B.
- Configure Policies only for company A (set the list of accounts)
- Set Admin user on company B

Try to change the policy on a partner on campany A. An error message will appear explaining that the account is not allowed on the policy.
The reason is that `partner.property_account_receivable_id` is evaluate in sudo() the contains the value of company B.