### PR TITLE
[10.0][FIX] account_move_line_tax_editable: fix invisible required field on views

### DIFF
--- a/account_move_line_tax_editable/views/account_move.xml
+++ b/account_move_line_tax_editable/views/account_move.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='line_ids']/tree/field[@name='name']" position="after">
-                <field name="move_id" invisible="1"/>
+                <field name="move_id" invisible="1" required="0"/>
                 <field name="is_tax_editable" invisible="1"/>
                 <field name="tax_line_id" attrs="{'readonly': [('is_tax_editable', '=', False)]}"/>
                 <field name="tax_ids" attrs="{'readonly': [('is_tax_editable', '=', False)]}"

--- a/account_move_line_tax_editable/views/account_move_line.xml
+++ b/account_move_line_tax_editable/views/account_move_line.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="account.view_move_line_form"/>
         <field name="arch" type="xml">
             <field name="tax_line_id" position="before">
-                <field name="move_id" invisible="1"/>
+                <field name="move_id" invisible="1" required="0"/>
                 <field name="is_tax_editable" invisible="1"/>
             </field>
             <field name="tax_line_id" position="attributes">


### PR DESCRIPTION
Since the merge of #656 it is no more possible to create a journal entry manually.
The reason comes from adding move_id on views but set invisible. As it is a required field, the user is blocked without knowing why.

THis PR solve this problem by setting required="0" in views.