### PR TITLE
[10.0][FIX] account_move_line_tax_editable: Remove duplicate field in…

### DIFF
--- a/account_move_line_tax_editable/views/account_move_line.xml
+++ b/account_move_line_tax_editable/views/account_move_line.xml
@@ -8,7 +8,6 @@
         <field name="inherit_id" ref="account.view_move_line_form"/>
         <field name="arch" type="xml">
             <field name="tax_line_id" position="before">
-                <field name="move_id" invisible="1" required="0"/>
                 <field name="is_tax_editable" invisible="1"/>
             </field>
             <field name="tax_line_id" position="attributes">


### PR DESCRIPTION
… view

The move_id field already exists in view. The duplicated one disable the first one