### PR TITLE
Account reconcile switchon

### DIFF
--- a/account_reconcile_switchon/README.rst
+++ b/account_reconcile_switchon/README.rst
@@ -1,0 +1,53 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===========================
+Account Switch On Reconcile
+===========================
+
+This module .
+
+
+Configuration
+=============
+
+No configuration
+
+Usage
+=====
+
+Just set reconcile flag to True
+
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-closing/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Willem Hulshof <w.hulshof@magnus.nl>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_reconcile_switchon/__init__.py
+++ b/account_reconcile_switchon/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/account_reconcile_switchon/__manifest__.py
+++ b/account_reconcile_switchon/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# © 2013-2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# © 2018 Magnus (Willem Hulshof <w.hulshof@magnus.nl>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Account Switch On Reconcile',
+    'version': '10.0.1.0.0',
+    'category': 'Accounting & Finance',
+    'license': 'AGPL-3',
+    'summary': 'Make switching on reconcile for account with lines possible',
+    'author': 'Magnus',
+    'website': 'http://www.magnus.nl',
+    'depends': [
+        'account',
+        ],
+    'data': [
+    ],
+    'images': [
+        ],
+    'installable': True,
+}

--- a/account_reconcile_switchon/models/__init__.py
+++ b/account_reconcile_switchon/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import account

--- a/account_reconcile_switchon/models/account.py
+++ b/account_reconcile_switchon/models/account.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+
+from odoo.exceptions import UserError, ValidationError
+from odoo import api, fields, models, _
+
+
+#----------------------------------------------------------
+# Accounts
+#----------------------------------------------------------
+
+
+class AccountAccount(models.Model):
+    _inherit = "account.account"
+
+
+
+    @api.multi
+    def write(self, vals):
+        accounts = []
+        aml = self.env['account.move.line']
+        for account in self:
+            if vals.get('reconcile') \
+                     and not account.reconcile \
+                     and not len(aml.search([('account_id','=', account.id),('reconciled','=', True)])) > 0\
+                     and len(aml.search([('account_id','=', account.id)])) > 0:
+                accounts.append(account.id)
+                vals.pop('reconcile')
+            elif vals.get('reconcile') == False:
+                move_lines = self.env['account.move.line'].search([('account_id', 'in', self.ids)], limit=1)
+                if len(move_lines):
+                    raise UserError(_('You cannot switch reconciliation off on this account as it already has some moves'))
+        if accounts != []:
+            self.set_reconcile_true(accounts)
+        return super(AccountAccount, self).write(vals)
+
+    @api.multi
+    def set_reconcile_true(self, ids):
+        for account in self.env['account.account'].search([('id','in',ids)]):
+            if account.reconcile:
+                raise UserError(_('You are trying to switch on reconciliation on %s %s %s, that already has reconcile True') %
+                                (account.code, account.name, account.company_id.name))
+        str_lst = ','.join([str(item) for item in ids])
+
+        # UPDATE query to compute residual amounts
+        sql_aml = ("""UPDATE account_move_line
+                    SET 
+                    reconciled = false,
+                    amount_residual = debit - credit,
+                    amount_residual_currency = CASE 
+                                                WHEN amount_currency > 0 
+                                                AND currency_id IS NOT NULL 
+                                                THEN amount_currency 
+                                                ELSE 0 
+                                               END
+                    {0};""".format(
+                    "WHERE account_id in (%s)" % str_lst
+                    ))
+        self.env.cr.execute(sql_aml)
+
+        # UPDATE query to set reconcile = true in account_account
+        sql_account = ("""UPDATE account_account
+                    SET 
+                    reconcile = true
+                    {0};""".format(
+                    "WHERE id in (%s)" % str_lst
+                    ))
+        self.env.cr.execute(sql_account)


### PR DESCRIPTION
This mod allows to set the allow reconcile flag in the account, even if there are move lines with the account. Switching it off again is prohibited, because than it would be much more difficult to switch it on again.