### PR TITLE
[10.0][FIX] Fix error when updating account templates with a currency defined

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -596,8 +596,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
     def _create_account_from_template(self, account_template):
         return self.env["account.account"].create({
             'name': account_template.name,
-            'currency_id': account_template.currency_id and
-                           account_template.currency_id.id,
+            'currency_id': account_template.currency_id.id,
             'code': self.padded_code(account_template.code),
             'user_type_id': account_template.user_type_id.id,
             'reconcile': account_template.reconcile,

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -596,7 +596,8 @@ class WizardUpdateChartsAccounts(models.TransientModel):
     def _create_account_from_template(self, account_template):
         return self.env["account.account"].create({
             'name': account_template.name,
-            'currency_id': account_template.currency_id,
+            'currency_id': account_template.currency_id and
+                           account_template.currency_id.id,
             'code': self.padded_code(account_template.code),
             'user_type_id': account_template.user_type_id.id,
             'reconcile': account_template.reconcile,


### PR DESCRIPTION
Hello,

This is a minor fix to allow updating account.account templates with currency defined.
I think the error is pretty clear (cannot adapt type res.currency).

This error can also be reproduced in versions 8 and 9.

Regards.