### PR TITLE
[9.0][ADD] backport of account_journal_lock_date to 9.0

### DIFF
--- a/account_journal_lock_date/README.rst
+++ b/account_journal_lock_date/README.rst
@@ -1,0 +1,79 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+.. _account_journal_lock_date: https://github.com/OCA/account-financial-tools/tree/10.0/account_journal_lock_date
+
+=========================
+Account Journal Lock Date
+=========================
+
+Lock each accounting journal independently.
+
+In addition to the lock dates provided by standard Odoo and
+account_permanent_lock_move, provide a per journal lock date.
+
+Note: this module depends on account_permanent_lock_move because it
+implements stricter checks than standard Odoo, such as verifying that
+one cannot create draft moves before the lock date.
+
+Note: the journal lock date is ignored for users that are part of
+the Adviser group. This rule can be adapted by overriding method
+`_can_bypass_journal_lock_date` of `account.journal`.
+
+This is a backport of version 10.0 module account_journal_lock_date_ by @sbidoul
+
+Usage
+=====
+
+To use this module, you need to set
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/{repo_id}/{branch}
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+Known issues / Roadmap
+======================
+
+* the module does not check that all moves prior the lock date are posted, this could be
+  made as part of the wizard
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Stéphane Bidoul <stephane.bidoul@acsone.eu>
+* Robin Keunen <robin@keunen.net>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_journal_lock_date/__init__.py
+++ b/account_journal_lock_date/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/account_journal_lock_date/__openerp__.py
+++ b/account_journal_lock_date/__openerp__.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Account Journal Lock Date",
+
+    'summary': """
+        Lock account journals independently""",
+
+    'description': """
+        Lock account journals independently.
+        This is a backport of version 10.0 module of the same name by Stéphane Bidoul.
+
+        https://github.com/OCA/account-financial-tools/tree/10.0/account_journal_lock_date
+    """,
+
+    'author': "Coop IT Easy SCRL",
+    'website': "http://www.coopiteasy.be",
+
+    'category': 'Accounting & Finance',
+    'version': '9.0.1.0.0',
+
+    'depends': [
+        'base',
+        'account',
+        'account_permanent_lock_move',
+    ],
+
+    'data': [
+        'views/journal_lock_views.xml',
+    ],
+}

--- a/account_journal_lock_date/models/__init__.py
+++ b/account_journal_lock_date/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import account_journal
+from . import account_move

--- a/account_journal_lock_date/models/account_journal.py
+++ b/account_journal_lock_date/models/account_journal.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, fields, api
+from openerp.exceptions import ValidationError, UserError
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    journal_lock_date = fields.Date(
+        name='Lock Date',
+        help="Moves cannot be entered nor modified in this "
+             "journal prior to the lock date, unless the user "
+             "has the Adviser role.",
+    )
+
+    @api.model
+    def _can_bypass_journal_lock_date(self):
+        """ This method is meant to be overridden to provide
+        finer control on who can bypass the lock date """
+        return self.env.user.has_group('account.group_account_manager')

--- a/account_journal_lock_date/models/account_move.py
+++ b/account_journal_lock_date/models/account_move.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, fields, api
+from openerp.exceptions import ValidationError, UserError
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.multi
+    def _check_lock_date(self):
+        res = super(AccountMove, self)._check_lock_date()
+
+        if self.env['account.journal']._can_bypass_journal_lock_date():
+            return res
+
+        for move in self:
+            lock_date = move.journal_id.journal_lock_date
+            if lock_date and move.date <= lock_date:
+                raise JournalLockDateError("You cannot add/modify entries "
+                                               "prior to and inclusive of the "
+                                               "journal lock date "
+                                               " %s" % lock_date)
+        return res
+
+
+class JournalLockDateError(ValidationError):
+    pass

--- a/account_journal_lock_date/tests/__init__.py
+++ b/account_journal_lock_date/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Robin Keunen, Coop IT Easy SCRL fs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_journal_lock_date

--- a/account_journal_lock_date/tests/test_journal_lock_date.py
+++ b/account_journal_lock_date/tests/test_journal_lock_date.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import date, timedelta
+
+from openerp import fields, tools
+from openerp.modules import get_module_resource
+from openerp.tests import common
+
+from ..models.account_move import JournalLockDateError
+
+
+class TestJournalLockDate(common.TransactionCase):
+
+    def setUp(self):
+        super(TestJournalLockDate, self).setUp()
+        tools.convert_file(self.cr, 'account',
+                           get_module_resource('account', 'test',
+                                               'account_minimal_test.xml'),
+                           {}, 'init', False, 'test')
+        self.account_move_obj = self.env["account.move"]
+        self.account_move_line_obj = \
+            self.env["account.move.line"]
+
+        self.company_id = self.ref('base.main_company')
+        self.partner = self.browse_ref("base.res_partner_2")
+        self.account = self.browse_ref("account.a_recv")
+        self.account2 = self.browse_ref("account.a_expense")
+        self.journal = self.browse_ref("account.bank_journal")
+
+    def set_group_account_manager(self):
+        self.env.user.write({
+            'groups_id': [(4, self.ref('account.group_account_manager'))],
+        })
+        self.assertTrue(self.env.user.has_group(
+            'account.group_account_manager'))
+
+    def unset_group_account_manager(self):
+        self.env.user.write({
+            'groups_id': [(3, self.ref('account.group_account_manager'))],
+        })
+        self.assertFalse(self.env.user.has_group(
+            'account.group_account_manager'))
+
+    def create_move(self):
+        """create a move and post it"""
+        move = self.account_move_obj.create({
+            'date': fields.Date.today(),
+            'journal_id': self.journal.id,
+            'line_ids': [
+                (0, 0, {
+                    'account_id': self.account.id,
+                    'credit': 1000.0,
+                    'name': 'Credit line'}),
+                (0, 0, {
+                    'account_id': self.account2.id,
+                    'debit': 1000.0,
+                    'name': 'Debit line',
+            })]
+        })
+        move.post()
+        return move
+
+    def test_create_account_move(self):
+        self.unset_group_account_manager()
+        self.create_move()
+
+    def test_create_account_move_on_locked_journal(self):
+        """Test that the move cannot be created."""
+        self.unset_group_account_manager()
+        self.journal.journal_lock_date = fields.Date.today()
+
+        with self.assertRaises(JournalLockDateError):
+            self.account_move_obj.create({
+                'date': fields.Date.today(),
+                'journal_id': self.journal.id,
+                'line_ids': [(0, 0, {
+                    'account_id': self.account.id,
+                    'credit': 1000.0,
+                    'name': 'Credit line',
+                }), (0, 0, {
+                    'account_id': self.account2.id,
+                    'debit': 1000.0,
+                    'name': 'Debit line',
+                })]
+            })
+
+    def test_update_account_move_on_locked_journal(self):
+        """Test that the move cannot be written"""
+        self.unset_group_account_manager()
+        move = self.create_move()
+        self.journal.journal_lock_date = fields.Date.today()
+
+        with self.assertRaises(JournalLockDateError):
+            move.write({'name': 'TEST'})
+
+    def test_cancel_account_move_on_locked_journal(self):
+        """Test that the move cannot be cancelled"""
+        self.unset_group_account_manager()
+        move = self.create_move()
+        self.journal.journal_lock_date = fields.Date.today()
+        with self.assertRaises(JournalLockDateError):
+            move.button_cancel()
+
+    def test_update_account_move_on_unlocked_journal(self):
+        """Create a move after their lock date and post it"""
+        self.unset_group_account_manager()
+        self.journal.journal_lock_date = fields.Date.today()
+        tomorrow = date.today() + timedelta(days=1)
+        move = self.account_move_obj.create({
+            'date': tomorrow,
+            'journal_id': self.journal.id,
+            'line_ids': [(0, 0, {
+                'account_id': self.account.id,
+                'credit': 1000.0,
+                'name': 'Credit line',
+            }), (0, 0, {
+                'account_id': self.account2.id,
+                'debit': 1000.0,
+                'name': 'Debit line',
+            })]
+        })
+        move.post()
+
+    def test_journal_lock_date_adviser(self):
+        """The journal lock date is ignored for Advisers """
+        self.set_group_account_manager()
+        self.journal.journal_lock_date = fields.Date.today()
+
+        # advisers can create moves before or on the lock date
+        self.account_move_obj.create({
+            'date': fields.Date.today(),
+            'journal_id': self.journal.id,
+            'line_ids': [(0, 0, {
+                'account_id': self.account.id,
+                'credit': 1000.0,
+                'name': 'Credit line',
+            }), (0, 0, {
+                'account_id': self.account2.id,
+                'debit': 1000.0,
+                'name': 'Debit line',
+            })]
+        })
+

--- a/account_journal_lock_date/views/journal_lock_views.xml
+++ b/account_journal_lock_date/views/journal_lock_views.xml
@@ -1,5 +1,4 @@
 <openerp>
-  <data>
 
     <record model="ir.ui.view" id="account_journal_form_view">
         <field name="name">account.journal.form (in account_journal_lock_date)</field>
@@ -24,5 +23,4 @@
         </field>
     </record>
 
-  </data>
 </openerp>

--- a/account_journal_lock_date/views/journal_lock_views.xml
+++ b/account_journal_lock_date/views/journal_lock_views.xml
@@ -1,0 +1,28 @@
+<openerp>
+  <data>
+
+    <record model="ir.ui.view" id="account_journal_form_view">
+        <field name="name">account.journal.form (in account_journal_lock_date)</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <field name="type" position="after">
+                <field name="journal_lock_date"/>
+            </field>
+        </field>
+    </record>
+
+
+    <record model="ir.ui.view" id="account_journal_tree_view">
+        <field name="name">account.journal.tree (in account_journal_lock_date)</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_tree"/>
+        <field name="arch" type="xml">
+            <field name="type" position="after">
+                <field name="journal_lock_date"/>
+            </field>
+        </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
Allow locking each account journals independently. 

This is a backport of version 10.0 module [account_journal_lock_date](https://github.com/OCA/account-financial-tools/tree/10.0/account_journal_lock_date) by @sbidoul  .

1st pull request for the OCA, best practice or style comments welcome :-)