### PR TITLE
[IMP] account_chart_update: Include field selection

### DIFF
--- a/account_chart_update/__manifest__.py
+++ b/account_chart_update/__manifest__.py
@@ -8,7 +8,7 @@
 {
     'name': "Detect changes and update the Account Chart from a template",
     "summary": "Wizard to update a company's account chart from a template",
-    'version': "10.0.2.0.1",
+    'version': "10.0.2.1.0",
     'author': "Tecnativa, "
               "BCIM, "
               "Okia, "

--- a/account_chart_update/models/__init__.py
+++ b/account_chart_update/models/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import models
-from . import wizard
+from . import ir_model_fields

--- a/account_chart_update/models/ir_model_fields.py
+++ b/account_chart_update/models/ir_model_fields.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class IrModelFields(models.Model):
+    _inherit = 'ir.model.fields'
+
+    def name_get(self):
+        """Return special label when showing fields in chart update wizard."""
+        if self.env.context.get('account_chart_update'):
+            res = []
+            for record in self:
+                res.append((record.id, "%s (%s)" % (
+                    record.field_description, record.name,
+                )))
+            return res
+        return super(IrModelFields, self).name_get()

--- a/account_chart_update/tests/test_account_chart_update.py
+++ b/account_chart_update/tests/test_account_chart_update.py
@@ -133,9 +133,21 @@ class TestAccountChartUpdate(common.HttpCase):
         }
 
     def test_chart_update(self):
-        # Test no changes
         wizard = self.wizard_obj.create(self.wizard_vals)
         wizard.action_find_records()
+        # Test ir.model.fields name_get
+        field = wizard.fp_field_ids[:1]
+        name = field.with_context(account_chart_update=True).name_get()[0]
+        self.assertEqual(name[0], field.id)
+        self.assertEqual(
+            name[1], "%s (%s)" % (field.field_description, field.name),
+        )
+        name = field.name_get()[0]
+        self.assertEqual(name[0], field.id)
+        self.assertEqual(
+            name[1], "%s (%s)" % (field.field_description, field.model),
+        )
+        # Test no changes
         self.assertEqual(wizard.state, 'ready')
         self.assertFalse(wizard.tax_ids)
         self.assertFalse(wizard.account_ids)
@@ -251,6 +263,32 @@ class TestAccountChartUpdate(common.HttpCase):
         self.assertEqual(self.fp.note, self.fp_template.note)
         self.assertEqual(self.fp.account_ids.account_dest_id, new_account)
         self.assertEqual(self.fp.tax_ids.tax_dest_id, self.tax)
+        wizard.unlink()
+        # Exclude fields from check
+        self.tax_template.description = "Test description 2"
+        self.account_template.name = "Other name 2"
+        self.fp_template.note = "Test note 2"
+        wizard = self.wizard_obj.create(self.wizard_vals)
+        wizard.action_find_records()
+        wizard.tax_field_ids -= self.env['ir.model.fields'].search([
+            ('model', '=', 'account.tax.template'),
+            ('name', '=', 'description'),
+        ])
+        wizard.account_field_ids -= self.env['ir.model.fields'].search([
+            ('model', '=', 'account.account.template'),
+            ('name', '=', 'name'),
+        ])
+        wizard.fp_field_ids -= self.env['ir.model.fields'].search([
+            ('model', '=', 'account.fiscal.position.template'),
+            ('name', '=', 'note'),
+        ])
+        wizard.action_find_records()
+        self.assertFalse(wizard.tax_ids)
+        self.assertFalse(wizard.account_ids)
+        self.assertFalse(wizard.fiscal_position_ids)
+        self.tax_template.description = "Test description"
+        self.account_template.name = "Other name"
+        self.fp_template.note = "Test note"
         wizard.unlink()
         # Remove objects
         new_tax_tmpl.unlink()

--- a/account_chart_update/wizard/wizard_chart_update_view.xml
+++ b/account_chart_update/wizard/wizard_chart_update_view.xml
@@ -32,23 +32,62 @@
                         />
                 <field name="lang" attrs="{'invisible':[('state','!=','init')]}" />
             </group>
-            <group attrs="{'invisible':[('state','!=','init')]}">
-                <group string="Update records?">
-                    <field name="update_tax" />
-                    <field name="update_account" />
-                    <field name="update_fiscal_position" />
-                </group>
-                <group string="Other options" attrs="{'invisible':[('state','!=','init')]}">
-                    <field name="continue_on_errors" />
-                </group>
-            </group>
-
-            <group attrs="{'invisible':[('state','!=','init')]}">
-                <h5>
-                    <p>If you leave these options set, the wizard will not just create new records, but also update records with changes (i.e. different tax amount)</p>
-                    <p>Note: Only the changed fields are updated.</p>
-                </h5>
-            </group>
+            <notebook attrs="{'invisible':[('state','!=','init')]}">
+                <page string="General options" name="page_general_options">
+                    <group>
+                        <group string="Update records?">
+                            <field name="update_tax" />
+                            <field name="update_account" />
+                            <field name="update_fiscal_position" />
+                        </group>
+                        <group string="Other options" attrs="{'invisible':[('state','!=','init')]}">
+                            <field name="continue_on_errors" />
+                        </group>
+                    </group>
+                    <group>
+                        <h5>
+                            <p>If you leave these options set, the wizard will not just create new records, but also update records with changes (i.e. different tax amount)</p>
+                            <p>Note: Only the changed fields are updated.</p>
+                        </h5>
+                    </group>
+                </page>
+                <page string="Field options"
+                      attrs="{'invisible': [('update_tax', '=', False), ('update_account', '=', False), ('update_fiscal_position', '=', False)]}"
+                >
+                    <h3>
+                        <p>Here you can select the fields you want to check if they have been updated in the templates.</p>
+                    </h3>
+                    <notebook>
+                        <page string="Taxes"
+                              name="page_fields_taxes"
+                              attrs="{'invisible': [('update_tax', '=', False)]}"
+                        >
+                            <field name="tax_field_ids"
+                                   widget="many2many_checkboxes"
+                                   context="{'account_chart_update': True}"
+                            />
+                        </page>
+                        <page string="Accounts"
+                              name="page_fields_accounts"
+                              attrs="{'invisible': [('update_account', '=', False)]}"
+                        >
+                            <field name="account_field_ids"
+                                   widget="many2many_checkboxes"
+                                   context="{'account_chart_update': True}"
+                            />
+                        </page>
+                        <page string="Fiscal positions"
+                              name="page_fields_fps"
+                              attrs="{'invisible': [('update_fiscal_position', '=', False)]}"
+                        >
+                            <field name="fp_field_ids"
+                                   widget="many2many_checkboxes"
+                                   context="{'account_chart_update': True}"
+                            />
+                        </page>
+                    </notebook>
+                </page>
+            </notebook>
             <group attrs="{'invisible':[('state','!=','ready'),]}"
                 string="Records to create/update">
                 <notebook colspan="4">


### PR DESCRIPTION
With this option, you can select which fields do you want to compare for updating.

Use case: you have specific accounts in taxes, and you don't want to lose them, but you want to update their groups through the wizard. Before this, the update was all or nothing. Now, you have total control!