### PR TITLE
[10.0] Fix test on account_move_locking

### DIFF
--- a/account_move_locking/tests/test_move_locking.py
+++ b/account_move_locking/tests/test_move_locking.py
@@ -21,8 +21,8 @@ class MoveLocking(common.TransactionCase):
     def test_locking(self):
         vals = {
             'journal_ids': [(4, self.cust_invoices_journal.id, 0)],
-            'date_start': Date.to_string(datetime.now() - timedelta(days=365)),
-            'date_end': Date.today(),
+            'date_start': Date.to_string(datetime.now() - timedelta(days=335)),
+            'date_end': Date.to_string(datetime.now() + timedelta(days=30)),
         }
         lock_wiz = self.env['lock.account.move'].create(vals)
         lock_wiz.lock_move({})


### PR DESCRIPTION
Fixes error in test :
```
> /opt/odoo/external-src/account-financial-tools/account_move_locking/tests/test_move_locking.py(30)test_locking()
-> for move in self.entries:
(Pdb) self.entries
account.move(3, 2, 1)
(Pdb) [ent.date for ent in self.entries]
['2018-10-08', '2018-10-08', '2018-10-01']
(Pdb) [(ent.date, ent.locked) for ent in self.entries]
[('2018-10-08', False), ('2018-10-08', False), ('2018-10-01', True)]
```