### PR TITLE
[11.0] Fix colliding account codes in DEMO data to run tests

### DIFF
--- a/account_group_menu/demo/account_group.xml
+++ b/account_group_menu/demo/account_group.xml
@@ -6,47 +6,47 @@
     </record>
     <record id="demo_account_group_1" model="account.group">
         <field name="name">Class 1</field>
-        <field name="code_prefix">1</field>
+        <field name="code_prefix">T1</field>
         <field name="parent_id" ref="demo_account_group_root"/>
     </record>
     <record id="demo_account_group_11" model="account.group">
         <field name="name">Class 11</field>
-        <field name="code_prefix">11</field>
+        <field name="code_prefix">T11</field>
         <field name="parent_id" ref="demo_account_group_1"/>
     </record>
     <record id="demo_account_group_2" model="account.group">
         <field name="name">Class 2</field>
-        <field name="code_prefix">1</field>
+        <field name="code_prefix">T2</field>
         <field name="parent_id" ref="demo_account_group_root"/>
     </record>
     <!-- Accounts -->
     <record id="demo_account_105" model="account.account">
         <field name="name">Account 105</field>
-        <field name="code">105</field>
+        <field name="code">T105</field>
         <field name="group_id" ref="demo_account_group_1"/>
         <field name="user_type_id" ref="account.data_account_type_non_current_liabilities"/>
     </record>
     <record id="demo_account_110" model="account.account">
         <field name="name">Account 110</field>
-        <field name="code">110</field>
+        <field name="code">T110</field>
         <field name="group_id" ref="demo_account_group_1"/>
         <field name="user_type_id" ref="account.data_account_type_non_current_liabilities"/>
     </record>
     <record id="demo_account_111" model="account.account">
         <field name="name">Account 111</field>
-        <field name="code">111</field>
+        <field name="code">T111</field>
         <field name="group_id" ref="demo_account_group_1"/>
         <field name="user_type_id" ref="account.data_account_type_non_current_liabilities"/>
     </record>
     <record id="demo_account_112" model="account.account">
         <field name="name">Account 112</field>
-        <field name="code">112</field>
+        <field name="code">T112</field>
         <field name="group_id" ref="demo_account_group_1"/>
         <field name="user_type_id" ref="account.data_account_type_non_current_liabilities"/>
     </record>
     <record id="demo_account_130" model="account.account">
         <field name="name">Account 130</field>
-        <field name="code">130</field>
+        <field name="code">T130</field>
         <field name="user_type_id" ref="account.data_account_type_non_current_liabilities"/>
     </record>
 </odoo>


### PR DESCRIPTION
Account codes defined as DEMO data in `account_group_menu` are colliding with the codes defined by odoo in `account_minimal_test.xml`. 
cf : 
https://github.com/OCA/account-financial-tools/pull/698/files#diff-8a93f0f5e06a65cf4a9a23055e8c2c00R25
https://travis-ci.org/OCA/account-financial-tools/jobs/435721365#L1380