### PR TITLE
[10.0][FIX] account_asset_management: domain in multicompany

### DIFF
--- a/account_asset_management/README.rst
+++ b/account_asset_management/README.rst
@@ -60,6 +60,7 @@ Contributors
 - Florian Dacosta (Akretion)
 - Stéphane Bidoul (Acsone)
 - Adrien Peiffer (Acsone)
+- Andrea Stirpe (Onestein)
 
 Maintainer
 ----------

--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -18,31 +18,31 @@ class AccountAssetProfile(models.Model):
         string='Analytic account')
     account_asset_id = fields.Many2one(
         comodel_name='account.account',
-        domain=[('deprecated', '=', False)],
+        domain="[('company_id', '=', company_id),('deprecated', '=', False)]",
         string='Asset Account', required=True)
     account_depreciation_id = fields.Many2one(
         comodel_name='account.account',
-        domain=[('deprecated', '=', False)],
+        domain="[('company_id', '=', company_id),('deprecated', '=', False)]",
         string='Depreciation Account', required=True)
     account_expense_depreciation_id = fields.Many2one(
         comodel_name='account.account',
-        domain=[('deprecated', '=', False)],
+        domain="[('company_id', '=', company_id),('deprecated', '=', False)]",
         string='Depr. Expense Account', required=True)
     account_plus_value_id = fields.Many2one(
         comodel_name='account.account',
-        domain=[('deprecated', '=', False)],
+        domain="[('company_id', '=', company_id),('deprecated', '=', False)]",
         string='Plus-Value Account')
     account_min_value_id = fields.Many2one(
         comodel_name='account.account',
-        domain=[('deprecated', '=', False)],
+        domain="[('company_id', '=', company_id),('deprecated', '=', False)]",
         string='Min-Value Account')
     account_residual_value_id = fields.Many2one(
         comodel_name='account.account',
-        domain=[('deprecated', '=', False)],
+        domain="[('company_id', '=', company_id),('deprecated', '=', False)]",
         string='Residual Value Account')
     journal_id = fields.Many2one(
         comodel_name='account.journal',
-        domain=[('type', '=', 'general')],
+        domain="[('company_id', '=', company_id),('type', '=', 'general')]",
         string='Journal', required=True)
     company_id = fields.Many2one(
         comodel_name='res.company',


### PR DESCRIPTION
In a multicompany environment, an user who has access to multiple companies is able to select accounts and journals of multiple companies in the assets profile form. This can easily lead to mistakes in the definition of an asset profile.

With this PR the user can only read/select accounts and journals belonging to the company already set in the asset profile.

This PR is similar to the one I opened for the standard _account_asset_ module: see https://github.com/odoo/odoo/pull/26578.