### PR TITLE
[10.0] Fix import report_xlsx_helper without try-except

### DIFF
--- a/account_asset_management_xls/models/account_asset.py
+++ b/account_asset_management_xls/models/account_asset.py
@@ -3,9 +3,16 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
-from odoo.addons.report_xlsx_helper.report.abstract_report_xlsx \
-    import AbstractReportXlsx
-_render = AbstractReportXlsx._render
+import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from odoo.addons.report_xlsx_helper.report.abstract_report_xlsx \
+        import AbstractReportXlsx
+    _render = AbstractReportXlsx._render
+except (ImportError, IOError) as err:
+    _logger.debug(err)
 
 
 class AccountAsset(models.Model):


### PR DESCRIPTION
I add a try-except to break nothing if some dependences need `_render = AbstractReportXlsx._render`
In my case I don't need _account_asset_management_xls_ so I don't use (and need add _report_xlsx_helper_)