### PR TITLE
[ADD][11.0] Provide wizard to perform accounting operations on multiple move lines at once

### DIFF
--- a/account_move_line_reclassify/README.rst
+++ b/account_move_line_reclassify/README.rst
@@ -1,0 +1,58 @@
+.. image:: https://img.shields.io/badge/license-AGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl.html
+   :alt: License: AGPL-3
+
+===============================
+Account Move Line Reclassify
+===============================
+
+This module introduces a wizard which facilitates the reclassification of accounting lines.
+
+Based on the options chosen, the process can go through a transitory account.
+
+
+Usage
+=====
+
+Move lines can be manually marked as To Reclassify, then selected using the special filter added.
+
+Alternatively, lines can be selected on the fly.
+
+Once lines have been selected, the wizard can be launched from the Actions central menu.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-financial-tools/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Stéphane Valaeys <svalaeys@fiefmanage.ch>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_move_line_reclassify/__init__.py
+++ b/account_move_line_reclassify/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from . import models
+from . import wizards
+

--- a/account_move_line_reclassify/__manifest__.py
+++ b/account_move_line_reclassify/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2018 FIEF Management SA (www.fief.ch)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Account Move Line Reclassify",
+    "summary": "Wizard that can help reclassify multiple move lines at once",
+    "version": "11.0.1.0.0",
+    "author": "FIEF Management SA, "
+              "Odoo Community Association (OCA)",
+    "website": "http://www.github.com/OCA/account-financial-tools",
+    "category": "Generic",
+    "depends": ["account"],
+    "license": "AGPL-3",
+    "data": [
+        'views/account_move_line_view.xml',
+        'wizards/reclassify_account_move_line_view.xml',
+    ],
+    'installable': True,
+}

--- a/account_move_line_reclassify/i18n/fr_CH.po
+++ b/account_move_line_reclassify/i18n/fr_CH.po
@@ -1,0 +1,227 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_move_line_reclassify
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-10-21 15:20+0000\n"
+"PO-Revision-Date: 2018-10-21 17:34+0200\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: fr_CH\n"
+"X-Generator: Poedit 2.2\n"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_analytic_account_id
+msgid "Analytic Account"
+msgstr "Compte analytique"
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "Analytic Accounting Information"
+msgstr "Information analytique"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_analytic_tag_ids
+msgid "Analytic Tags"
+msgstr "Étiquettes analytiques"
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: account_move_line_reclassify
+#: code:addons/account_move_line_reclassify/wizards/reclassify_account_move_line.py:118
+#, python-format
+msgid "Created Lines"
+msgstr "Écritures créées"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_destination_date
+msgid "Date On The Move To The Destination Account"
+msgstr "Date de la pièce vers le compte de destination"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_transitory_date
+msgid "Date On The Move To The Transitory Account"
+msgstr "Date de la pièce vers le compte transitoire"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_destination_account_id
+msgid "Destination Account"
+msgstr "Compte de destination"
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "Destination Move"
+msgstr "Pièce de destination"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_display_name
+msgid "Display Name"
+msgstr "Nom à afficher"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_line_prefix
+msgid "Entry prefix"
+msgstr "Préfixe au nom des écritures"
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "General Accounting Information"
+msgstr "Information de comptabilité générale"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "If necessary, you can specify a transitory account."
+msgstr "Si nécessaire, un compte transitoire peut être exigé"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_journal_id
+msgid "Journal"
+msgstr "Journal"
+
+#. module: account_move_line_reclassify
+#: model:ir.model,name:account_move_line_reclassify.model_account_move_line
+msgid "Journal Item"
+msgstr "Écriture comptable"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line___last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_write_uid
+msgid "Last Updated by"
+msgstr "Dernière mise à jour par"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_write_date
+msgid "Last Updated on"
+msgstr "Dernière mise à jour le"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,help:account_move_line_reclassify.field_reclassify_account_move_line_transitory_date
+msgid "Leave blank to use original line date"
+msgstr "Laisser vide pour utiliser la date originale"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,help:account_move_line_reclassify.field_reclassify_account_move_line_destination_account_id
+msgid "Leave blank to use the original line account"
+msgstr "Laisser vide pour utiliser le compte original"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,help:account_move_line_reclassify.field_reclassify_account_move_line_destination_date
+msgid "Leave blank to use the original line date"
+msgstr "Laisser vide pour utiliser la date originale"
+
+#. module: account_move_line_reclassify
+#: code:addons/account_move_line_reclassify/wizards/reclassify_account_move_line.py:127
+#, python-format
+msgid "No accounting entry have been posted."
+msgstr "Aucune pièce comptable n'a été enregistrée."
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "Other Information"
+msgstr "Autres informations"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_partner_id
+msgid "Partner"
+msgstr "Partenaire"
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "Reclassify"
+msgstr "Recalsser"
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "Reclassify Journal Items"
+msgstr "Reclasser les écritures comptables"
+
+#. module: account_move_line_reclassify
+#: model:ir.actions.act_window,name:account_move_line_reclassify.action_reclassify_move_lines
+msgid "Reclassify Move Lines"
+msgstr "Reclasser les écritures comptables"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,help:account_move_line_reclassify.field_reclassify_account_move_line_transitory_account_id
+msgid "This is the account through which the items will transit for the duration of the transit. It should be a balance sheet account."
+msgstr "Ceci est le compte à travers lequel les écritures vont transiter pour la durée du transit. C'est un compte de bilan."
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,help:account_move_line_reclassify.field_reclassify_account_move_line_line_prefix
+msgid "This label will be inserted in entries description."
+msgstr "Ce libellé sera inséré dans la description des écritures"
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid ""
+"This wizard allows you to reclassify multiple\n"
+"                        journal items at once. This is useful to change the general account, the analytic account,\n"
+"                        the analytic tags and/or the partner of multiple lines at once."
+msgstr ""
+"Cet assistant permet de reclasser\n"
+"                        de nombreuses écritures à la fois. Ceci est utile modifier le compte général,\n"
+"                        le compte analytique, les étiquettes analytiques et/ou le partenaire sur plusieurs écritures à la fois."
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_account_move_line_to_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_move_line_filter
+msgid "To Reclassify"
+msgstr "À reclasser"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_transitory_account_id
+msgid "Transitory Account"
+msgstr "Compte transitoire"
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "Transitory Move"
+msgstr "Pièce transitoire"
+
+#. module: account_move_line_reclassify
+#: model:ir.model.fields,field_description:account_move_line_reclassify.field_reclassify_account_move_line_use_transitory_account
+msgid "Use Transitory Account"
+msgstr "Utiliser un compte transitoire"
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "When the non-required fields are left blank, the wizard will use the information from the line to reclassify."
+msgstr "Quand les champs optionnels sont laissés vides, l'assistant utilise l'information de la ligne à reclasser."
+
+#. module: account_move_line_reclassify
+#: model:ir.ui.view,arch_db:account_move_line_reclassify.view_reclassify_account_move_line_form
+msgid "or"
+msgstr "ou"
+
+#. module: account_move_line_reclassify
+#: model:ir.model,name:account_move_line_reclassify.model_reclassify_account_move_line
+msgid "reclassify.account.move.line"
+msgstr "reclassify.account.move.line"

--- a/account_move_line_reclassify/models/__init__.py
+++ b/account_move_line_reclassify/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import account_move_line

--- a/account_move_line_reclassify/models/account_move_line.py
+++ b/account_move_line_reclassify/models/account_move_line.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 FIEF Management SA <svalaeys@fiefmanage.ch>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    to_reclassify = fields.Boolean(string='To Reclassify')

--- a/account_move_line_reclassify/views/account_move_line_view.xml
+++ b/account_move_line_reclassify/views/account_move_line_view.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2018 FIEF Management SA <svalaeys@fiefmanage.ch>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <data>
+        <record id="view_reclassify_move_line_form" model="ir.ui.view">
+            <field name="name">reclassify.account.move.line.form</field>
+            <field name="model">account.move.line</field>
+            <field ref="account.view_move_line_form" name="inherit_id"/>
+            <field name="arch" type="xml">
+                <field name="invoice_id" position="after">
+                    <field name="to_reclassify" groups="account.group_account_manager"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_reclassify_move_line_filter" model="ir.ui.view">
+            <field name="name">reclassify.account.move.line.filter</field>
+            <field name="model">account.move.line</field>
+            <field name="inherit_id" ref="account.view_account_move_line_filter" />
+            <field name="arch" type="xml">
+                <field name="account_id" position="before">
+                    <filter string="To Reclassify" domain="[('to_reclassify', '=', True)]"/>
+                    <separator/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+
+</odoo>

--- a/account_move_line_reclassify/wizards/__init__.py
+++ b/account_move_line_reclassify/wizards/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import reclassify_account_move_line

--- a/account_move_line_reclassify/wizards/reclassify_account_move_line.py
+++ b/account_move_line_reclassify/wizards/reclassify_account_move_line.py
@@ -10,23 +10,36 @@ from odoo.exceptions import UserError
 class ReclassifyAccountMoveLine(models.TransientModel):
     _name = 'reclassify.account.move.line'
 
-    journal_id = fields.Many2one('account.journal', 'Journal', domain="[('type','=','general')]", required=True)
+    journal_id = fields.Many2one('account.journal', 'Journal',
+                                 domain="[('type','=','general')]",
+                                 required=True)
     line_prefix = fields.Char('Entry prefix', size=100, default="RECLASS -",
-                              help="This label will be inserted in entries description.")
-    destination_account_id = fields.Many2one('account.account', 'Destination Account',
-                                             help="Leave blank to use the original line account")
-    destination_date = fields.Date('Date On The Move To The Destination Account',
-                                   help="Leave blank to use the original line date")
+                              help="This label will be inserted "
+                                   "in entries description.")
+    destination_account_id = fields.Many2one('account.account',
+                                             'Destination Account',
+                                             help="Leave blank to use the "
+                                                  "original line account")
+    destination_date = fields.Date('Date On The Move To The '
+                                   'Destination Account',
+                                   help="Leave blank to use the original "
+                                        "line date")
     use_transitory_account = fields.Boolean('Use Transitory Account')
-    transitory_account_id = fields.Many2one('account.account', 'Transitory Account',
-                                            help="This is the account through which the items will transit "
-                                                 "for the duration of the transit. It should be a balance "
-                                                 "sheet account.")
+    transitory_account_id = fields.Many2one('account.account',
+                                            'Transitory Account',
+                                            help="This is the account through "
+                                                 "which the items will "
+                                                 "transit for the duration "
+                                                 "of the transit. It should be"
+                                                 " a balance  sheet account.")
     transitory_date = fields.Date('Date On The Move To The Transitory Account',
                                   help="Leave blank to use original line date")
-    analytic_account_id = fields.Many2one('account.analytic.account', 'Analytic Account')
-    analytic_tag_ids = fields.Many2many('account.analytic.tag', 'reclassify_analytic_tag_rel',
-                                        'wizard_id', 'analytic_tag_id', string='Analytic Tags')
+    analytic_account_id = fields.Many2one('account.analytic.account',
+                                          'Analytic Account')
+    analytic_tag_ids = fields.Many2many('account.analytic.tag',
+                                        'reclassify_analytic_tag_rel',
+                                        'wizard_id', 'analytic_tag_id',
+                                        string='Analytic Tags')
     partner_id = fields.Many2one('res.partner', 'Partner')
 
     def _prepare_additional_fields(self, res, line=None):
@@ -58,7 +71,9 @@ class ReclassifyAccountMoveLine(models.TransientModel):
         if self.analytic_account_id:
             vals['analytic_account_id'] = self.analytic_account_id.id
         if self.analytic_tag_ids:
-            vals['analytic_tag_ids'] = [(6, 0, [x.id for x in self.analytic_tag_ids])]
+            vals['analytic_tag_ids'] = [(6, 0,
+                                         [x.id for x in self.analytic_tag_ids]
+                                         )]
 
         self._prepare_additional_fields(vals)
         return vals
@@ -69,59 +84,75 @@ class ReclassifyAccountMoveLine(models.TransientModel):
 
         @return: dict to open a view filtered on generated move lines
         """
-        lines_to_reclassify = self.env['account.move.line'].browse(self.env.context['active_ids'])
+        lines_to_reclassify = self.env['account.move.line']. \
+            browse(self.env.context['active_ids'])
         newly_created_line_ids = self.env['account.move.line']
         for original_line in lines_to_reclassify:
             move_name = self.line_prefix + original_line.name
             original_values = self._get_line_values(original_line)
-            # We determine the first line of the move: this one "cancels" out the line to reclassify.
+            # We determine the first line of the move:
+            # this one "cancels" out the line to reclassify.
             # It is therefore identical, save for the financial fields
             first_line_dict = self._reverse_financial_fields(original_values)
             if self.use_transitory_account:
-                # The second line of the transitory move goes into the transitory account.
+                # The second line of the transitory move goes
+                # into the transitory account.
                 # We start from the values of the original line
                 trans_second_line_dict = original_values.copy()
                 # We change the fields specified by the user
                 self._prepare_fields(trans_second_line_dict)
                 # The account is the transitory account
-                trans_second_line_dict['account_id'] = self.transitory_account_id.id
+                trans_second_line_dict['account_id'] = \
+                    self.transitory_account_id.id
                 # Both lines are created, we can create the move
-                transitory_move_vals = {'journal_id': self.journal_id.id,
-                                        'date': self.transitory_date or original_line.date,
-                                        'ref': move_name,
-                                        'line_ids': [(0, 0, first_line_dict), (0, 0, trans_second_line_dict)]
-                                        }
-                transitory_move = self.env['account.move'].create(transitory_move_vals)
+                transitory_move_vals = \
+                    {'journal_id': self.journal_id.id,
+                     'date': self.transitory_date or original_line.date,
+                     'ref': move_name,
+                     'line_ids': [(0, 0, first_line_dict),
+                                  (0, 0, trans_second_line_dict)]}
+                transitory_move = self.env['account.move']. \
+                    create(transitory_move_vals)
                 newly_created_line_ids = transitory_move.line_ids
 
-                # The use of the transitory account affects the values of the first line of the destination move.
+                # The use of the transitory account affects the
+                # values of the first line of the destination move.
                 # We overwrite the first_line_dic to take this into account
-                first_line_dict = self._reverse_financial_fields(trans_second_line_dict)
+                first_line_dict = self. \
+                    _reverse_financial_fields(trans_second_line_dict)
 
-            # The second line of the destination move goes into the destination account
-            # If a transitory account was used, it is allowed to go back to the original_line account
+            # The second line of the destination
+            # move goes into the destination account
+            # If a transitory account was used,
+            # it is allowed to go back to the original_line account
             # (pure transitory operation)
             second_line_dict = self._reverse_financial_fields(first_line_dict)
-            second_line_dict['account_id'] = self.destination_account_id.id or original_line.account_id.id
-            destination_move_vals = {'journal_id': self.journal_id.id,
-                                     'date': self.destination_date or self.transitory_date or original_line.date,
-                                     'ref': move_name,
-                                     'line_ids': [(0, 0, first_line_dict), (0, 0, second_line_dict)]}
-            destination_move = self.env['account.move'].create(destination_move_vals)
-            newly_created_line_ids = newly_created_line_ids | destination_move.line_ids
+            second_line_dict['account_id'] = \
+                self.destination_account_id.id or original_line.account_id.id
+            destination_move_vals = \
+                {'journal_id': self.journal_id.id,
+                 'date': self.destination_date or
+                    self.transitory_date or original_line.date,
+                 'ref': move_name, 'line_ids': [(0, 0, first_line_dict),
+                                                (0, 0, second_line_dict)]}
+            destination_move = self.env['account.move']. \
+                create(destination_move_vals)
+            newly_created_line_ids = \
+                newly_created_line_ids | destination_move.line_ids
 
             # Now we mark the original line as not to reclassify anymore
             original_line.to_reclassify = False
 
         if newly_created_line_ids:
-            return {'domain': "[('id', 'in', %s)]" % newly_created_line_ids.ids,
-                    'name': _("Created Lines"),
-                    'view_type': 'form',
-                    'view_mode': 'tree,form',
-                    'auto_search': True,
-                    'res_model': 'account.move.line',
-                    'view_id': False,
-                    'search_view_id': False,
-                    'type': 'ir.actions.act_window'}
+            return {
+                'domain': "[('id', 'in', %s)]" % newly_created_line_ids.ids,
+                'name': _("Created Lines"),
+                'view_type': 'form',
+                'view_mode': 'tree,form',
+                'auto_search': True,
+                'res_model': 'account.move.line',
+                'view_id': False,
+                'search_view_id': False,
+                'type': 'ir.actions.act_window'}
         else:
             raise UserError(_("No accounting entry have been posted."))

--- a/account_move_line_reclassify/wizards/reclassify_account_move_line.py
+++ b/account_move_line_reclassify/wizards/reclassify_account_move_line.py
@@ -1,0 +1,127 @@
+# -*- encoding: utf-8 -*-
+# Copyright 2018 FIEF Management SA <svalaeys@fiefmanage.ch>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models, api
+from odoo.tools.translate import _
+from odoo.exceptions import UserError
+
+
+class ReclassifyAccountMoveLine(models.TransientModel):
+    _name = 'reclassify.account.move.line'
+
+    journal_id = fields.Many2one('account.journal', 'Journal', domain="[('type','=','general')]", required=True)
+    line_prefix = fields.Char('Entry prefix', size=100, default="RECLASS -",
+                              help="This label will be inserted in entries description.")
+    destination_account_id = fields.Many2one('account.account', 'Destination Account',
+                                             help="Leave blank to use the original line account")
+    destination_date = fields.Date('Date On The Move To The Destination Account',
+                                   help="Leave blank to use the original line date")
+    use_transitory_account = fields.Boolean('Use Transitory Account')
+    transitory_account_id = fields.Many2one('account.account', 'Transitory Account',
+                                            help="This is the account through which the items will transit "
+                                                 "for the duration of the transit. It should be a balance "
+                                                 "sheet account.")
+    transitory_date = fields.Date('Date On The Move To The Transitory Account',
+                                  help="Leave blank to use original line date")
+    analytic_account_id = fields.Many2one('account.analytic.account', 'Analytic Account')
+    analytic_tag_ids = fields.Many2many('account.analytic.tag', 'reclassify_analytic_tag_rel',
+                                        'wizard_id', 'analytic_tag_id', string='Analytic Tags')
+    partner_id = fields.Many2one('res.partner', 'Partner')
+
+    def _prepare_additional_fields(self, res, line=None):
+        return res
+
+    @api.model
+    def _reverse_financial_fields(self, vals):
+        res = vals.copy()
+
+        res['debit'] = vals['credit']
+        res['credit'] = vals['debit']
+        res['amount_currency'] = vals['amount_currency'] * -1
+        return res
+
+    @api.model
+    def _get_list_of_fields_to_pop(self):
+        return ['move_id', 'invoice_id', 'to_reclassify', 'blocked']
+
+    def _get_line_values(self, line):
+        vals = line.copy_data()[0]
+        for x in self._get_list_of_fields_to_pop():
+            vals.pop(x)
+        vals['name'] = self.line_prefix + line.name
+        return vals
+
+    def _prepare_fields(self, vals):
+        if self.partner_id:
+            vals['partner_id'] = self.partner_id.id
+        if self.analytic_account_id:
+            vals['analytic_account_id'] = self.analytic_account_id.id
+        if self.analytic_tag_ids:
+            vals['analytic_tag_ids'] = [(6, 0, [x.id for x in self.analytic_tag_ids])]
+
+        self._prepare_additional_fields(vals)
+        return vals
+
+    def reclassify(self):
+        """
+        Reclassify the selected line items
+
+        @return: dict to open a view filtered on generated move lines
+        """
+        lines_to_reclassify = self.env['account.move.line'].browse(self.env.context['active_ids'])
+        newly_created_line_ids = self.env['account.move.line']
+        for original_line in lines_to_reclassify:
+            move_name = self.line_prefix + original_line.name
+            original_values = self._get_line_values(original_line)
+            # We determine the first line of the move: this one "cancels" out the line to reclassify.
+            # It is therefore identical, save for the financial fields
+            first_line_dict = self._reverse_financial_fields(original_values)
+            if self.use_transitory_account:
+                # The second line of the transitory move goes into the transitory account.
+                # We start from the values of the original line
+                trans_second_line_dict = original_values.copy()
+                # We change the fields specified by the user
+                self._prepare_fields(trans_second_line_dict)
+                # The account is the transitory account
+                trans_second_line_dict['account_id'] = self.transitory_account_id.id
+                # Both lines are created, we can create the move
+                transitory_move_vals = {'journal_id': self.journal_id.id,
+                                        'date': self.transitory_date or original_line.date,
+                                        'ref': move_name,
+                                        'line_ids': [(0, 0, first_line_dict), (0, 0, trans_second_line_dict)]
+                                        }
+                transitory_move = self.env['account.move'].create(transitory_move_vals)
+                newly_created_line_ids = transitory_move.line_ids
+
+                # The use of the transitory account affects the values of the first line of the destination move.
+                # We overwrite the first_line_dic to take this into account
+                first_line_dict = self._reverse_financial_fields(trans_second_line_dict)
+
+            # The second line of the destination move goes into the destination account
+            # If a transitory account was used, it is allowed to go back to the original_line account
+            # (pure transitory operation)
+            second_line_dict = self._reverse_financial_fields(first_line_dict)
+            second_line_dict['account_id'] = self.destination_account_id.id or original_line.account_id.id
+            destination_move_vals = {'journal_id': self.journal_id.id,
+                                     'date': self.destination_date or self.transitory_date or original_line.date,
+                                     'ref': move_name,
+                                     'line_ids': [(0, 0, first_line_dict), (0, 0, second_line_dict)]}
+            destination_move = self.env['account.move'].create(destination_move_vals)
+            newly_created_line_ids = newly_created_line_ids | destination_move.line_ids
+
+            # Now we mark the original line as not to reclassify anymore
+            original_line.to_reclassify = False
+
+        if newly_created_line_ids:
+            return {'domain': "[('id', 'in', %s)]" % newly_created_line_ids.ids,
+                    'name': _("Created Lines"),
+                    'view_type': 'form',
+                    'view_mode': 'tree,form',
+                    'auto_search': True,
+                    'res_model': 'account.move.line',
+                    'view_id': False,
+                    'search_view_id': False,
+                    'type': 'ir.actions.act_window'}
+        else:
+            raise UserError(_("No accounting entry have been posted."))

--- a/account_move_line_reclassify/wizards/reclassify_account_move_line_view.xml
+++ b/account_move_line_reclassify/wizards/reclassify_account_move_line_view.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_reclassify_account_move_line_form" model="ir.ui.view">
+            <field name="name">Reclassify Journal Items</field>
+            <field name="model">reclassify.account.move.line</field>
+            <field name="arch" type="xml">
+                <form string="Reclassify Journal Items" version="7.0">
+                    <p class="o_default_snippet_text">This wizard allows you to reclassify multiple
+                        journal items at once. This is useful to change the general account, the analytic account,
+                        the analytic tags and/or the partner of multiple lines at once.</p>
+                    <p class="o_default_snippet_text">When the non-required fields are left blank, the wizard will use the information from the line to reclassify.</p>
+                    <p class="o_default_snippet_text">If necessary, you can specify a transitory account.</p>
+                    <group string="General Accounting Information">
+                        <field name="journal_id" class="oe_inline"/>
+                        <field name="line_prefix" class="oe_inline"/>
+                        <field name="use_transitory_account"/>
+                    </group>
+                    <group>
+                        <group string="Transitory Move" attrs="{'invisible': [('use_transitory_account', '=', False)]}">
+                            <field name="transitory_account_id" class="oe_inline"
+                                   attrs="{'required': [('use_transitory_account', '=', True)]}"/>
+                            <field name="transitory_date" class="oe_inline"/>
+                        </group>
+                        <group string="Destination Move">
+                            <field name="destination_account_id" attrs="{'required': [('use_transitory_account', '=', False)]}" class="oe_inline"/>
+                            <field name="destination_date" attrs="{'required': [('use_transitory_account', '=', False)]}"  class="oe_inline"/>
+                        </group>
+                    </group>
+                    <group string="Analytic Accounting Information" groups="analytic.group_analytic_accounting">
+                        <field name="analytic_account_id" class="oe_inline"/>
+                        <field name="analytic_tag_ids" widget="many2many_tags"/>
+                    </group>
+                    <group string="Other Information">
+                        <field name="partner_id"/>
+                    </group>
+                    <footer>
+                        <button name="reclassify" type="object" string="Reclassify" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <act_window
+            id="action_reclassify_move_lines"
+            res_model="reclassify.account.move.line"
+            src_model="account.move.line"
+            target="new"
+            multi="True"
+            key2="client_action_multi"
+            view_mode="form"
+            name="Reclassify Move Lines"/>
+
+    </data>
+</openerp>
+


### PR DESCRIPTION
Hello,
In our accounting firm there are two use cases that this module addresses:
- At the end of the year, all clients who have temporarily overpaid us need to be moved to a special account on Dec 31st, only to be moved back to the initial account on Jan 1st. This operation takes place through a transitory account
- During the year, revenue recorded for the following fiscal year is put into a balance sheet account. On Jan 1st of the new fiscal year, all this revenue is moved out of the balance sheet account and moved to the regular revenue account.
This module proposes a wizard capable of handling these two cases. Given a selection of move lines, it will reverse those specific lines (not the same as revering a complete move) as a first leg and use the data specified in the wizard to make the second leg, as well as the eventual transitory move. 
To make it as complete as possible, the module allows to change various fields, like analytic data and partner data. Because it becomes faster to reverse and correct instead of cancel and correct, accountants are more prone to use the right way to do things.
I hope this can be useful to some of you.
Stephane