### PR TITLE
[IMP] currency_rate_date_check: Activate the check for currency rate max delta

### DIFF
--- a/currency_rate_date_check/__init__.py
+++ b/currency_rate_date_check/__init__.py
@@ -22,3 +22,4 @@
 
 from . import company
 from . import currency_rate_date_check
+from . import res_config

--- a/currency_rate_date_check/__openerp__.py
+++ b/currency_rate_date_check/__openerp__.py
@@ -43,8 +43,8 @@ for any help or question about this module.
     """,
     'author': "Akretion,Odoo Community Association (OCA)",
     'website': 'http://www.akretion.com',
-    'depends': ['base'],
-    'data': ['company_view.xml'],
+    'depends': ['base_setup'],
+    'data': ['company_view.xml', 'res_config_views.xml'],
     'images': [
         'images/date_check_error_popup.jpg',
         'images/date_check_company_config.jpg',

--- a/currency_rate_date_check/company.py
+++ b/currency_rate_date_check/company.py
@@ -32,6 +32,11 @@ class ResCompany(models.Model):
         "the date associated with the amount to convert and the date "
         "of the nearest currency rate available in Odoo.")
 
+    activate_currency_rate_max_delta = fields.Boolean(
+        default=False, string='Activate check of the max date rate',
+        help="This must be true to execute the validation of Max Time Delta "
+        "in Days for Currency Rates")
+
     _sql_constraints = [
         ('currency_rate_max_delta_positive',
          'CHECK (currency_rate_max_delta >= 0)',

--- a/currency_rate_date_check/company_view.xml
+++ b/currency_rate_date_check/company_view.xml
@@ -17,6 +17,7 @@
     <field name="arch" type="xml">
         <field name="currency_id" position="after">
             <field name="currency_rate_max_delta" />
+            <field name="activate_currency_rate_max_delta" invisible="1" />
         </field>
     </field>
 </record>

--- a/currency_rate_date_check/currency_rate_date_check.py
+++ b/currency_rate_date_check/currency_rate_date_check.py
@@ -51,14 +51,16 @@ class ResCurrency(models.Model):
         # on today's date with an old rate, but otherwize it would raise
         # too often, for example it would raise entering the
         # Currencies menu entry !
-        if context.get('date') and not context.get('disable_rate_date_check'):
+
+        user = self.pool['res.users'].browse(cr, uid, uid, context=context)
+        if context.get('date') and not context.get('disable_rate_date_check') \
+                and user.company_id.activate_currency_rate_max_delta:
             date = context.get('date')
             for currency_id in ids:
                 # We could get the company from the currency, but it's not a
                 # 'required' field, so we should probably continue to get it
                 # from the user, shouldn't we ?
-                user = self.pool['res.users'].browse(cr, uid, uid,
-                                                     context=context)
+
                 # if it's the company currency, don't do anything
                 # (there is just one old rate at 1.0)
                 if user.company_id.currency_id.id == currency_id:

--- a/currency_rate_date_check/res_config.py
+++ b/currency_rate_date_check/res_config.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from openerp import fields, models, api
+
+
+class BaseConfigSettings(models.TransientModel):
+    _inherit = 'base.config.settings'
+
+    activate_currency_rate_max_delta = fields.Boolean(
+        default=False, string='Activate check of the max date rate',
+        help="This must be true to execute the validation of Max Time Delta "
+        "in Days for Currency Rates")
+
+    @api.model
+    def _default_company(self):
+        return self.env.user.company_id
+
+    @api.model
+    def default_get(self, fields):
+        res = super(BaseConfigSettings, self).default_get(fields)
+        company_id = self._default_company()
+        max_delta_activate = company_id.activate_currency_rate_max_delta
+        res.update({
+            'activate_currency_rate_max_delta': max_delta_activate
+        })
+        return res
+
+    @api.multi
+    def set_activate_currency_rate_max_delta(self):
+        """Activate currency rate max delta validation"""
+        for record in self:
+            company_id = self._default_company()
+            company_id.activate_currency_rate_max_delta = \
+                record.activate_currency_rate_max_delta

--- a/currency_rate_date_check/res_config_views.xml
+++ b/currency_rate_date_check/res_config_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="inherited_account_view_general_configuration" model="ir.ui.view">
+            <field name="name">General accounting settings</field>
+            <field name="model">base.config.settings</field>
+            <field name="priority" eval="12"/>
+            <field name="inherit_id" ref="base_setup.view_general_configuration"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@name='multi_company']" position="after">
+                   <div name="activate_currency_rate_check">
+                       <field name="activate_currency_rate_max_delta" class="oe_inline"/>
+                       <label for="activate_currency_rate_max_delta"/>
+                   </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
- The validation made for this module can be optional.
- Must be selected the field `activate_currency_rate_max_delta` in general settings if the validation is needed.

This change was made because if there are modules that add policies or accounting movements with previous dates, the validation can not be avoided and some tests fail to consult the dates.