### PR TITLE
[IMP] asset mgt: use exclude manifest key

### DIFF
--- a/account_asset_management/__manifest__.py
+++ b/account_asset_management/__manifest__.py
@@ -8,7 +8,7 @@
     'depends': [
         'account_fiscal_year',
     ],
-    'conflicts': ['account_asset'],
+    'excludes': ['account_asset'],
     'author': "Noviat,Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/account-financial-tools',
     'category': 'Accounting & Finance',


### PR DESCRIPTION
This is now supported natively by Odoo 11.

See https://github.com/odoo/odoo/blob/180f5285286c6bf4753935680fb493d4b5e04a36/odoo/addons/base/module/module.py#L711