### PR TITLE
[11.0] [ADD] module account_move_trigger

### DIFF
--- a/account_move_trigger/__init__.py
+++ b/account_move_trigger/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_move_trigger/__manifest__.py
+++ b/account_move_trigger/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2018-2020 PESOL (<https://www.pesol.es>).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Account Move Trigger',
+    'version': '11.0.1.0.1',
+    'license': 'AGPL-3',
+    'author': "PESOL, Odoo Community Association (OCA)",
+    'website': 'http://pesol.es',
+    'category': 'Banking addons',
+    'depends': ['account'],
+    'data': ['security/ir.model.access.csv',
+             'views/account_move_trigger.xml',
+             'data/account_move_trigger_data.xml',
+    ],
+    'installable': True,
+}

--- a/account_move_trigger/data/account_move_trigger_data.xml
+++ b/account_move_trigger/data/account_move_trigger_data.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<odoo noupdate="1">
+
+
+    <record forcecreate="True" id="ir_cron_do_auto_reconcile" model="ir.cron">
+        <field name="name">Auto Reconcile Triggered Moves</field>
+        <field eval="True" name="active"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field eval="False" name="doall"/>
+        <field name="model_id" ref="account_move_trigger.model_account_move_trigger"/>
+        <field name="state">code</field>
+        <field name="code">model.do_auto_reconcile()</field>
+    </record>
+
+</odoo>

--- a/account_move_trigger/i18n/es.po
+++ b/account_move_trigger/i18n/es.po
@@ -1,0 +1,127 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_move_trigger
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-10-09 11:09+0000\n"
+"PO-Revision-Date: 2018-10-09 11:09+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_move_trigger
+#: model:ir.model,name:account_move_trigger.model_account_account
+msgid "Account"
+msgstr "Cuenta"
+
+#. module: account_move_trigger
+#: model:ir.model,name:account_move_trigger.model_account_move
+msgid "Account Entry"
+msgstr "Asiento"
+
+#. module: account_move_trigger
+#: model:ir.actions.act_window,name:account_move_trigger.account_move_trigger_action
+#: model:ir.model,name:account_move_trigger.model_account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_account_trigger_account_ids
+#: model:ir.ui.menu,name:account_move_trigger.account_move_trigger_menu
+#: model:ir.ui.view,arch_db:account_move_trigger.view_account_move_trigger_form
+#: model:ir.ui.view,arch_db:account_move_trigger.view_account_move_trigger_search
+#: model:ir.ui.view,arch_db:account_move_trigger.view_account_move_trigger_tree
+msgid "Account Move Trigger"
+msgstr "Asiento Automático"
+
+#. module: account_move_trigger
+#: model:ir.actions.act_window,help:account_move_trigger.account_move_trigger_action
+msgid "Click to create a new Account Move Trigger."
+msgstr "Click to create a new Account Move Trigger."
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_create_uid
+msgid "Created by"
+msgstr "Created by"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_create_date
+msgid "Created on"
+msgstr "Created on"
+
+#. module: account_move_trigger
+#: selection:account.move.trigger,move_type:0
+msgid "Credit"
+msgstr "Haber"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_credit_account_id
+msgid "Credit Account"
+msgstr "Cuenta Haber"
+
+#. module: account_move_trigger
+#: selection:account.move.trigger,move_type:0
+msgid "Debit"
+msgstr "Debe"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_debit_account_id
+msgid "Debit Account"
+msgstr "Cuenta Haber"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_display_name
+msgid "Display Name"
+msgstr "Referencia"
+
+#. module: account_move_trigger
+#: model:ir.ui.view,arch_db:account_move_trigger.view_account_move_trigger_search
+msgid "Group By"
+msgstr "Group By"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_journal_id
+msgid "Journal"
+msgstr "Diario"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger___last_update
+msgid "Last Modified on"
+msgstr "Last Modified on"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_write_uid
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_write_date
+msgid "Last Updated on"
+msgstr "Last Updated on"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_name
+msgid "Name"
+msgstr "Referencia"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_account_id
+msgid "Trigger Account"
+msgstr "Cuenta"
+
+#. module: account_move_trigger
+#: model:ir.model.fields,field_description:account_move_trigger.field_account_move_trigger_move_type
+msgid "Trigger Move Type"
+msgstr "Tipo de movimiento"
+
+#. module: account_move_trigger
+#: model:ir.ui.view,arch_db:account_move_trigger.view_account_move_trigger_search
+msgid "account_id"
+msgstr "Cuenta"

--- a/account_move_trigger/models/__init__.py
+++ b/account_move_trigger/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move_trigger
+from . import account_move

--- a/account_move_trigger/models/account_move.py
+++ b/account_move_trigger/models/account_move.py
@@ -1,0 +1,32 @@
+# Copyright 2018 PESOL (<https://www.pesol.es>).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, api, fields
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    tirggered_from_id = fields.Many2one(
+        comodel_name='account.move.line',
+        string='Triggered From')
+    auto_reconcile = fields.Boolean(
+        string='Auto Reconcile')
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.multi
+    def post(self):
+        trigger_account_obj = self.env['account.move.trigger']
+        trigger_accounts = trigger_account_obj.search([])
+        trigger_account_list = trigger_accounts.mapped(
+            lambda t: (t.account_id.id, t.move_type)
+        )
+        for line in self.mapped('line_ids').filtered(
+                lambda l: (l.account_id.id, l.debit and 'debit' or 'credit') in
+                trigger_account_list
+        ):
+            line.account_id.trigger_account_ids.trigger(line)
+
+        return super(AccountMove, self).post()

--- a/account_move_trigger/models/account_move_trigger.py
+++ b/account_move_trigger/models/account_move_trigger.py
@@ -1,0 +1,90 @@
+# Copyright 2018 PESOL (<https://www.pesol.es>).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models, fields
+
+
+class AccountMoveTrigger(models.Model):
+    _name = 'account.move.trigger'
+    _rec_name = 'account_id'
+    _description = "Account Move Trigger"
+
+    name = fields.Char(
+        string='Name',
+        required=True)
+    account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Trigger Account',
+        required=True)
+    move_type = fields.Selection(
+        [('debit', 'Debit'),
+         ('credit', 'Credit')],
+        string='Trigger Move Type',
+        required=True)
+    journal_id = fields.Many2one(
+        comodel_name='account.journal',
+        string='Journal',
+        required=True)
+    debit_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Debit Account',
+        required=True)
+    credit_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Credit Account',
+        required=True)
+    auto_reconcile = fields.Boolean(
+        string='Auto Reconcile')
+
+
+    @api.multi
+    def trigger(self, line):
+        ref = line.move_id.ref
+        amount = line.debit or line.credit
+        move_obj = self.env['account.move']
+        for move in self:
+            debit_values = {
+                'account_id': move.debit_account_id.id,
+                'debit': amount,
+                'tirggered_from_id': line.credit and line.id,
+                'date_maturity': line.date_maturity,
+                'auto_reconcile': self.auto_reconcile
+            }
+            credit_values = {
+                'account_id': move.credit_account_id.id,
+                'credit': amount,
+                'tirggered_from_id': line.debit and  line.id,
+                'date_maturity': line.date_maturity,
+                'auto_reconcile': self.auto_reconcile
+            }
+            move = move_obj.create({
+                'journal_id': move.journal_id.id,
+                'ref': '%s: %s' % (move.name, ref or ''),
+                'line_ids': [(0, 0, debit_values), (0, 0, credit_values)]
+            })
+            move.post()
+
+    @api.model
+    def do_auto_reconcile(self):
+        today = fields.Date.today()
+        to_reconcile = self.env['account.move.line'].search([
+            ('tirggered_from_id', '!=', False),
+            ('full_reconcile_id', '=', False),
+            ('balance','!=', 0),
+            ('account_id.reconcile','=',True),
+            ('date_maturity', '<=', today)
+        ])
+        for line in to_reconcile:
+            move_lines = self.env['account.move.line']
+            move_lines += line
+            move_lines += line.tirggered_from_id
+            move_lines.force_full_reconcile()
+
+
+class AccountAccount(models.Model):
+    _inherit = 'account.account'
+
+    trigger_account_ids = fields.One2many(
+        comodel_name='account.move.trigger',
+        inverse_name='account_id',
+        string='Account Move Trigger')

--- a/account_move_trigger/readme/CONFIGURE.rst
+++ b/account_move_trigger/readme/CONFIGURE.rst
@@ -1,0 +1,8 @@
+Go to Accounting/Configuration/Management/Account Move Trigger and set:
+- Name: The name that will be used on the account move
+- Trigger Account: The account that will be used as a trigger when you post on it.
+- Trigger Move Type: Set Credit or Debit, and system will trigger the account move only when you post on Credit or Debit.
+- Journal: In which the account move will be created.
+- Debit Account: Account in wich you will post amount on debit.
+- Credit Account: Account in wich you will post amount on credit.
+- Auto Reconcile: If you want to reconcile original move with trigered move on maturity date.

--- a/account_move_trigger/readme/CONTRIBUTORS.rst
+++ b/account_move_trigger/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* PESOL (https://pesol.es):
+  * Angel Moya <angel.moya@pesol.es>

--- a/account_move_trigger/readme/DESCRIPTION.rst
+++ b/account_move_trigger/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module allows you to trigger an account move, when another account move is
+posted within the configured account. Also in maturity date this two moves will
+be reconciled.

--- a/account_move_trigger/readme/USAGE.rst
+++ b/account_move_trigger/readme/USAGE.rst
@@ -1,0 +1,2 @@
+After configure an Account Move Trigger, if you post account move with account,
+credit or debit on an Account Move Trigger, new account move will be created.

--- a/account_move_trigger/security/ir.model.access.csv
+++ b/account_move_trigger/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_move_trigger_all,access_account_move_trigger_all,model_account_move_trigger,account.group_account_invoice,1,0,0,0
+access_account_move_trigger,access_account_move_trigger,model_account_move_trigger,account.group_account_manager,1,1,1,1

--- a/account_move_trigger/views/account_move_trigger.xml
+++ b/account_move_trigger/views/account_move_trigger.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="view_account_move_trigger_form" model="ir.ui.view">
+    <field name="name">view.account_move_trigger.form</field>
+    <field name="model">account.move.trigger</field>
+    <field name="arch" type="xml">
+      <form string="Account Move Trigger">
+        <sheet>
+          <group name="main">
+            <field name="name"/>
+            <field name="account_id"/>
+            <field name="move_type"/>
+            <field name="journal_id"/>
+            <field name="debit_account_id"/>
+            <field name="credit_account_id"/>
+            <field name="auto_reconcile"/>
+          </group>
+        </sheet>
+      </form>
+    </field>
+  </record>
+
+  <record id="view_account_move_trigger_tree" model="ir.ui.view">
+    <field name="name">view.account_move_trigger.tree</field>
+    <field name="model">account.move.trigger</field>
+    <field name="arch" type="xml">
+      <tree string="Account Move Trigger">
+        <field name="name"/>
+        <field name="account_id"/>
+        <field name="move_type"/>
+        <field name="journal_id"/>
+        <field name="debit_account_id"/>
+        <field name="credit_account_id"/>
+        <field name="auto_reconcile"/>
+      </tree>
+    </field>
+  </record>
+
+  <record id="view_account_move_trigger_search" model="ir.ui.view">
+    <field name="name">view.account_move_trigger.search</field>
+    <field name="model">account.move.trigger</field>
+    <field name="arch" type="xml">
+      <search string="Account Move Trigger">
+        <field name="account_id"/>
+        <group string="Group By" name="groupby">
+          <filter name="account_id " string="account_id " context="{'group_by': 'account_id'}"/>
+        </group>
+      </search>
+    </field>
+  </record>
+
+  <record id="account_move_trigger_action" model="ir.actions.act_window">
+    <field name="name">Account Move Trigger</field>
+    <field name="res_model">account.move.trigger</field>
+    <field name="view_mode">tree,form</field>
+    <field name="help" type="html">
+      <p class="oe_view_nocontent_create">
+        Click to create a new Account Move Trigger.
+      </p>
+    </field>
+  </record>
+
+  <menuitem id="account_move_trigger_menu" parent="account.account_management_menu" action="account_move_trigger_action" sequence="20"/>
+
+</odoo>


### PR DESCRIPTION
## Description
This module allows you to trigger an account move, when another account move is
posted within the configured account.

## Configure
Go to Accounting/Configuration/Management/Account Move Trigger and set:
- Name: The name that will be used on the account move
- Trigger Account: The account that will be used as a trigger when you post on it.
- Trigger Move Type: Set Credit or Debit, and system will trigger the account move
  only when you post on Credit or Debit.
- Journal: In which the account move will be created
- Debit Account: Account in wich you will post amount on debit.
- Credit Account: Account in wich you will post amount on credit.
