### PR TITLE
[10.0][FIX] account_asset_management - issues #731

### DIFF
--- a/account_asset_management/README.rst
+++ b/account_asset_management/README.rst
@@ -20,6 +20,9 @@ Excel based reporting is available via the 'account_asset_management_xls' module
 The module contains a large number of functional enhancements compared to
 the standard account_asset module from Odoo.
 
+* When the depreciation board an asset is compute, lines computed are flagged 'Init'
+  if they are before **Lock Date** `fiscalyear_lock_date`
+
 Configuration
 =============
 

--- a/account_asset_management/README.rst
+++ b/account_asset_management/README.rst
@@ -20,7 +20,7 @@ Excel based reporting is available via the 'account_asset_management_xls' module
 The module contains a large number of functional enhancements compared to
 the standard account_asset module from Odoo.
 
-* When the depreciation board an asset is compute, lines computed are flagged 'Init'
+* When you compute the asset depreciation board, lines are flagged 'Init'
   if they are before **Lock Date** `fiscalyear_lock_date`
 
 Configuration

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -857,11 +857,11 @@ class AccountAsset(models.Model):
                     remaining_value -= amount
                 fy_amount_check += amount
 
-                fiscalyear_lock_date_formated = fields.Datetime.from_string(
+                fiscalyear_lock_date_formatted = fields.Datetime.from_string(
                     fiscalyear_lock_date
                 )
 
-                if line_date <= fiscalyear_lock_date_formated:
+                if line_date <= fiscalyear_lock_date_formatted:
                     init_entry = True
                 else:
                     init_entry = False

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -498,8 +498,8 @@ class AccountAsset(models.Model):
                 continue
 
             # group lines prior to depreciation start period
-            depreciation_start_date = datetime.strptime(
-                asset.date_start, '%Y-%m-%d')
+            depreciation_start_date = fields.Datetime.from_string(
+                asset.date_start)
             lines = table[0]['lines']
             lines1 = []
             lines2 = []
@@ -523,8 +523,8 @@ class AccountAsset(models.Model):
             # recompute in case of deviation
             depreciated_value_posted = depreciated_value = 0.0
             if posted_lines:
-                last_depreciation_date = datetime.strptime(
-                    last_line.line_date, '%Y-%m-%d')
+                last_depreciation_date = fields.Datetime.from_string(
+                    last_line.line_date)
                 last_date_in_table = table[-1]['lines'][-1]['date']
                 if last_date_in_table <= last_depreciation_date:
                     raise UserError(
@@ -616,8 +616,8 @@ class AccountAsset(models.Model):
         - years: duration in calendar years, considering also leap years
         """
         fy = self.env['date.range'].browse(fy_id)
-        fy_date_start = datetime.strptime(fy.date_start, '%Y-%m-%d')
-        fy_date_stop = datetime.strptime(fy.date_end, '%Y-%m-%d')
+        fy_date_start =fields.Datetime.from_string(fy.date_start)
+        fy_date_stop = fields.Datetime.from_string(fy.date_end)
         days = (fy_date_stop - fy_date_start).days + 1
         months = (fy_date_stop.year - fy_date_start.year) * 12  \
             + (fy_date_stop.month - fy_date_start.month) + 1
@@ -655,8 +655,8 @@ class AccountAsset(models.Model):
         fy_id = entry['fy_id']
         if self.prorata:
             if firstyear:
-                depreciation_date_start = datetime.strptime(
-                    self.date_start, '%Y-%m-%d')
+                depreciation_date_start = fields.Datetime.from_string(
+                    self.date_start)
                 fy_date_stop = entry['date_stop']
                 first_fy_asset_days = \
                     (fy_date_stop - depreciation_date_start).days + 1
@@ -689,10 +689,10 @@ class AccountAsset(models.Model):
         if the fiscal year starts in the middle of a month.
         """
         if self.prorata:
-            depreciation_start_date = datetime.strptime(
-                self.date_start, '%Y-%m-%d')
+            depreciation_start_date = fields.Datetime.from_string(
+                self.date_start)
         else:
-            fy_date_start = datetime.strptime(fy.date_start, '%Y-%m-%d')
+            fy_date_start = fields.Datetime.from_string(fy.date_start)
             depreciation_start_date = datetime(
                 fy_date_start.year, fy_date_start.month, 1)
         return depreciation_start_date
@@ -717,8 +717,8 @@ class AccountAsset(models.Model):
                 depreciation_stop_date = depreciation_start_date + \
                     relativedelta(years=self.method_number, days=-1)
         elif self.method_time == 'end':
-            depreciation_stop_date = datetime.strptime(
-                self.method_end, '%Y-%m-%d')
+            depreciation_stop_date = fields.Datetime.from_string(
+                self.method_end)
         return depreciation_stop_date
 
     def _get_first_period_amount(self, table, entry, depreciation_start_date,
@@ -813,11 +813,10 @@ class AccountAsset(models.Model):
         depreciation_start_date,
         depreciation_stop_date,
         line_dates,
-        fiscalyear_lock_date
-    ):
+        fiscalyear_lock_date):
 
         digits = self.env['decimal.precision'].precision_get('Account')
-        asset_sign = self.depreciation_base >= 0 and 1 or -1
+        asset_sign = 1 if self.depreciation_base >= 0 else -1
         i_max = len(table) - 1
         remaining_value = self.depreciation_base
         depreciated_value = 0.0
@@ -858,8 +857,8 @@ class AccountAsset(models.Model):
                     remaining_value -= amount
                 fy_amount_check += amount
 
-                fiscalyear_lock_date_formated = datetime.strptime(
-                    fiscalyear_lock_date, '%Y-%m-%d'
+                fiscalyear_lock_date_formated = fields.Datetime.from_string(
+                    fiscalyear_lock_date
                 )
 
                 if line_date <= fiscalyear_lock_date_formated:
@@ -872,7 +871,7 @@ class AccountAsset(models.Model):
                     'amount': amount,
                     'depreciated_value': depreciated_value,
                     'remaining_value': remaining_value,
-                    'init_entry': init_entry
+                    'init_entry': init_entry,
                 }
                 lines.append(line)
                 depreciated_value += amount
@@ -915,15 +914,15 @@ class AccountAsset(models.Model):
 
         company = self.company_id
         init_flag = False
-        asset_date_start = datetime.strptime(self.date_start, '%Y-%m-%d')
+        asset_date_start = fields.Datetime.from_string(self.date_start)
         fy = company.find_daterange_fy(asset_date_start)
         fiscalyear_lock_date = company.fiscalyear_lock_date
         if fiscalyear_lock_date and fiscalyear_lock_date >= self.date_start:
             init_flag = True
         if fy:
             fy_id = fy.id
-            fy_date_start = datetime.strptime(fy.date_start, '%Y-%m-%d')
-            fy_date_stop = datetime.strptime(fy.date_end, '%Y-%m-%d')
+            fy_date_start = fields.Datetime.from_string(fy.date_start)
+            fy_date_stop = fields.Datetime.from_string(fy.date_end)
         else:
             # The following logic is used when no fiscal year
             # is defined for the asset start date:
@@ -937,8 +936,8 @@ class AccountAsset(models.Model):
             if not first_fy:
                 raise UserError(
                     _("No Fiscal Year defined."))
-            first_fy_date_start = datetime.strptime(
-                first_fy.date_start, '%Y-%m-%d')
+            first_fy_date_start = fields.Datetime.from_string(
+                first_fy.date_start)
             fy_date_start = first_fy_date_start
             if asset_date_start > fy_date_start:
                 asset_ref = self.code and '%s (ref: %s)' \
@@ -980,7 +979,7 @@ class AccountAsset(models.Model):
                     init_flag = True
                 else:
                     init_flag = False
-                fy_date_stop = datetime.strptime(fy.date_end, '%Y-%m-%d')
+                fy_date_stop = fields.Datetime.from_string(fy.date_end)
             else:
                 fy_date_stop = fy_date_stop + relativedelta(years=1)
                 if (
@@ -1041,6 +1040,10 @@ class AccountAsset(models.Model):
                     break
         i_max = i
         table = table[:i_max + 1]
+
+        if not fiscalyear_lock_date:
+            raise UserError(
+                _("You should set in account settings the 'Lock Date' first."))
 
         # Step 2:
         # Spread depreciation amount per fiscal year

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -616,7 +616,7 @@ class AccountAsset(models.Model):
         - years: duration in calendar years, considering also leap years
         """
         fy = self.env['date.range'].browse(fy_id)
-        fy_date_start =fields.Datetime.from_string(fy.date_start)
+        fy_date_start = fields.Datetime.from_string(fy.date_start)
         fy_date_stop = fields.Datetime.from_string(fy.date_end)
         days = (fy_date_stop - fy_date_start).days + 1
         months = (fy_date_stop.year - fy_date_start.year) * 12  \
@@ -809,11 +809,12 @@ class AccountAsset(models.Model):
         return line_dates
 
     def _compute_depreciation_table_lines(
-        self, table,
-        depreciation_start_date,
-        depreciation_stop_date,
-        line_dates,
-        fiscalyear_lock_date):
+            self,
+            table,
+            depreciation_start_date,
+            depreciation_stop_date,
+            line_dates,
+            fiscalyear_lock_date):
 
         digits = self.env['decimal.precision'].precision_get('Account')
         asset_sign = 1 if self.depreciation_base >= 0 else -1

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -42,6 +42,13 @@ class TestAssetManagement(common.TransactionCase):
         # Instance: company
         self.company = self.env.ref('base.main_company')
 
+        # Instance: Account settings
+        self.acs_model = self.env['account.config.settings']
+
+        values = {'fiscalyear_lock_date': "%s-12-31" % (date.today().year - 2)}
+
+        self.acs_model.create(values)
+
         # Instance: account type (receivable)
         self.type_recv = self.env.ref('account.data_account_type_receivable')
 

--- a/account_asset_management_method_number_end/tests/test_account_asset_management.py
+++ b/account_asset_management_method_number_end/tests/test_account_asset_management.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import time
+from datetime import date
 
 import odoo.tests.common as common
 from odoo import tools
@@ -26,6 +27,13 @@ class TestAssetManagement(common.TransactionCase):
 
         self.asset_model = self.env['account.asset']
         self.dl_model = self.env['account.asset.line']
+
+        # Instance: Account settings
+        self.acs_model = self.env['account.config.settings']
+
+        values = {'fiscalyear_lock_date': "%s-12-31" % (date.today().year - 2)}
+
+        self.acs_model.create(values)
 
     def test_1_linear_number(self):
         """Linear with Method Time 'Number'."""


### PR DESCRIPTION
#### To Fix this issue [https://github.com/OCA/account-financial-tools/issues/731](https://github.com/OCA/account-financial-tools/issues/731)

* When we press compute on the depreciation board of an asset, lines computed must be flagged 'Init' if before or equal of **Lock Date**

![image](https://user-images.githubusercontent.com/32262135/48562824-4826cf00-e8f3-11e8-8ef6-1c9e190724be.png)
