### PR TITLE
[11.0][account_chart_update][FIX] Update taxes

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -661,7 +661,8 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 continue
             # Create tax
             if wiz_tax.type == 'new':
-                self._generate_tax(self.company_id, template, tax_template_to_tax)
+                self._generate_tax(self.company_id, template,
+                                   tax_template_to_tax)
                 _logger.info(_("Created tax %s."), "'%s'" % template.name)
             # Update tax
             else:


### PR DESCRIPTION
Before this fix, if you created a new tax with child taxes, the parent would not be linked with the children, and the children would not see the accounts assigned, if the account already existed.

With this fix, when adding new taxes we take into account children accounts, and update the account and refund account correctly for the children.


For example, I create a new tax "IVA 21% Adquisición Intracomunitaria no deducible. Bienes de inversión". with 2 children.

Before this fix, the children would be created independently, not linked with this parent account, and no account or refund account assigned.

After this fix, the relationship is created:

![image](https://user-images.githubusercontent.com/7683926/49366976-036ca780-f6eb-11e8-8e53-5894d207deb2.png)


And the accounts are mapped in the children correctly:
![image](https://user-images.githubusercontent.com/7683926/49367047-3151ec00-f6eb-11e8-89e5-cbcbfd95b18b.png)
