### PR TITLE
Improved dependency - account_credit_control, account_move_line_purchase_info

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2018 Access Bookings Ltd (https://accessbookings.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Account Credit Control',
- 'version': '11.0.1.0.1',
+ 'version': '11.0.1.1.1',
  'author': "Camptocamp,"
            "Odoo Community Association (OCA),"
            "Okia,"
@@ -12,9 +12,7 @@
  'maintainer': 'Camptocamp',
  'category': 'Finance',
  'depends': [
-     'base',
      'account',
-     'mail',
  ],
  'website': 'https://github.com/OCA/account-financial-tools',
  'data': [

--- a/account_move_line_purchase_info/__manifest__.py
+++ b/account_move_line_purchase_info/__manifest__.py
@@ -5,12 +5,12 @@
 {
     "name": "Account Move Line Purchase Info",
     "summary": "Introduces the purchase order line to the journal items",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
     "website": "http://www.github.com/OCA/account-financial-tools",
     "category": "Generic",
-    "depends": ["account", "purchase"],
+    "depends": ["purchase"],
     "license": "AGPL-3",
     "data": [
         "security/account_security.xml",


### PR DESCRIPTION
1. account_credit_control
    After installation of `account`, `base` and `mail` will be installed automatically so no need to put in depends

2. account_move_line_purchase_info
    After installation of `purchase`, `account` will be installed automatically so no need to put in depends