### PR TITLE
[10.0] account_fiscal_year: add full rights on date.range* to account manager

### DIFF
--- a/account_fiscal_year/__manifest__.py
+++ b/account_fiscal_year/__manifest__.py
@@ -16,6 +16,7 @@
     'data': [
         'data/date_range_type.xml',
         'views/date_range_type.xml',
+        'security/ir.model.access.csv',
     ],
     'installable': True,
     'application': True,

--- a/account_fiscal_year/__manifest__.py
+++ b/account_fiscal_year/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Account Fiscal Year',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Accounting',
     'author': 'Camptocamp SA,'
               'Odoo Community Association (OCA)',

--- a/account_fiscal_year/security/ir.model.access.csv
+++ b/account_fiscal_year/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_date_range_account_manager,Full rights on date.range to Account Manager,date_range.model_date_range,account.group_account_manager,1,1,1,1
+access_date_range_type_account_manager,Full rights on date.range.type to Account Manager,date_range.model_date_range_type,account.group_account_manager,1,1,1,1


### PR DESCRIPTION
The account_fiscal_year module adds a menu entry for date.range and date.range.type under "Accounting > Configuration > ...", but the account manager only has read rights on it by default. This PR adds full rights on date.range* objects to Account Manager.