### PR TITLE
Change admin.ch currency update service url fixes #766

### DIFF
--- a/currency_rate_update/services/update_service_CH_ADMIN.py
+++ b/currency_rate_update/services/update_service_CH_ADMIN.py
@@ -46,8 +46,8 @@ class ChAdminGetter(CurrencyGetterInterface):
     def get_updated_currency(self, currency_array, main_currency,
                              max_delta_days):
         """Implementation of abstract method of Curreny_getter_interface"""
-        url = ('http://www.afd.admin.ch/publicdb/newdb/'
-               'mwst_kurse/wechselkurse.php')
+        url = ('http://www.pwebapps.ezv.admin.ch/apps/rates/rate/'
+               'getxml?activeSearchType=today')
         # We do not want to update the main currency
         if main_currency in currency_array:
             currency_array.remove(main_currency)
@@ -58,7 +58,7 @@ class ChAdminGetter(CurrencyGetterInterface):
         dom = etree.fromstring(rawfile)
         _logger.debug("Admin.ch sent a valid XML file")
         adminch_ns = {
-            'def': 'http://www.afd.admin.ch/publicdb/newdb/mwst_kurse'
+            'def': 'http://www.pwebapps.ezv.admin.ch/apps/rates'
         }
         rate_date = dom.xpath(
             '/def:wechselkurse/def:datum/text()',


### PR DESCRIPTION
It looks like the URL of the currency update service has changed. This changes the URL with one that works.