### PR TITLE
7.0 currency_rate_update: admin.ch service url change

### DIFF
--- a/currency_rate_update/currency_rate_update.py
+++ b/currency_rate_update/currency_rate_update.py
@@ -448,8 +448,8 @@ class Admin_ch_getter(CurrencyGetterInterface):
     def get_updated_currency(self, currency_array, main_currency,
                              max_delta_days):
         """Implementation of abstract method of Curreny_getter_interface"""
-        url = ('http://www.afd.admin.ch/publicdb/newdb/'
-               'mwst_kurse/wechselkurse.php')
+        url = ('http://www.pwebapps.ezv.admin.ch/apps/rates/rate/'
+               'getxml?activeSearchType=today')
         # We do not want to update the main currency
         if main_currency in currency_array:
             currency_array.remove(main_currency)
@@ -460,7 +460,7 @@ class Admin_ch_getter(CurrencyGetterInterface):
         dom = etree.fromstring(rawfile)
         _logger.debug("Admin.ch sent a valid XML file")
         adminch_ns = {
-            'def': 'http://www.afd.admin.ch/publicdb/newdb/mwst_kurse'
+            'def': 'http://www.pwebapps.ezv.admin.ch/apps/rates'
         }
         rate_date = dom.xpath(
             '/def:wechselkurse/def:datum/text()',


### PR DESCRIPTION
URL of Admin.ch Service used by currency_rate_update module has been changed.

I contacted ezv.admin.ch and they confirmed it: 
"New URL for current day rates:
http://www.pwebapps.ezv.admin.ch/apps/rates/rate/getxml?activeSearchType=userDefinedDay
For specific day:
http://www.pwebapps.ezv.admin.ch/apps/rates/rate/getxml?activeSearchType=userDefinedDay&d=20190115" 

I adapted the code for daily rates like in https://github.com/OCA/account-financial-tools/pull/767/files:
activeSearchType=today instead of activeSearchType=userDefinedDay
and like in https://www.ezv.admin.ch/ezv/en/home/information-companies/declaring-goods/exchange-rates--sell-.html

