### PR TITLE
[11.0][FIX] Add Credit Control Policy rule for multicompany

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2018 Access Bookings Ltd (https://accessbookings.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Account Credit Control',
- 'version': '11.0.1.0.2',
+ 'version': '11.0.1.0.3',
  'author': "Camptocamp,"
            "Odoo Community Association (OCA),"
            "Okia,"

--- a/account_credit_control/security/account_security.xml
+++ b/account_credit_control/security/account_security.xml
@@ -37,5 +37,11 @@
         <field name="global" eval="True"/>
         <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
     </record>
+    <record id="credit_control_policy_rule" model="ir.rule">
+        <field name="name">Credit Control Policy</field>
+        <field name="model_id" ref="model_credit_control_policy"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+    </record>
 </data>
 </odoo>


### PR DESCRIPTION
As proposed in https://github.com/OCA/account-financial-tools/issues/691#issuecomment-473225096, this PR adds a multi company rule on credit_control_policy.
The reason is that when you create a run, you can select all the policies from all the companies. But when you run it, it just only creates the credit control lines of the company that you're logged into. So it's not useful to see every policy from other companies.


