### PR TITLE
[10.0][FIX]account_asset_management_xls fix sort

### DIFF
--- a/account_asset_management_xls/report/account_asset_report_xls.py
+++ b/account_asset_management_xls/report/account_asset_report_xls.py
@@ -390,8 +390,11 @@ class AssetReportXlsx(AbstractReportXlsx):
 
         def _child_get(parent):
             assets = self.env['account.asset']
-            children = parent.child_ids.filtered(lambda r: r.state != 'draft')
-            children = children.sorted(lambda r: (r.date_start, r.code))
+            children = parent.child_ids.filtered(
+                lambda r: r.type == 'view' or
+                (r.type == 'normal' and r.state != 'draft'))
+            children = children.sorted(
+                lambda r: (r.date_start or '', r.code))
             for child in children:
                 assets += child
                 assets += _child_get(child)


### PR DESCRIPTION
part 2 of https://github.com/OCA/account-financial-tools/pull/720

xls report may sort incorrectly because of 'view' accounts.