### PR TITLE
[10.0][FIX] fix missing dependancy on queue_job if is not installes

### DIFF
--- a/account_move_batch_validate/models/account_move.py
+++ b/account_move_batch_validate/models/account_move.py
@@ -5,7 +5,22 @@
 import logging
 
 from odoo import api, fields, models, _
-from odoo.addons.queue_job.job import job, Job
+
+try:
+    # The queue_job module is not necessarily installed
+    from odoo.addons.queue_job.job import job, Job
+except ImportError:
+    import functools
+    Job = False
+
+    def job(func=None, default_channel='root', retry_pattern=None):
+        if func is None:
+            return functools.partial(
+                job,
+                default_channel=default_channel,
+                retry_pattern=retry_pattern
+            )
+        return func
 
 
 _logger = logging.getLogger(__name__)

--- a/account_move_batch_validate/wizard/account_move_validate.py
+++ b/account_move_batch_validate/wizard/account_move_validate.py
@@ -3,7 +3,22 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-from odoo.addons.queue_job.job import job
+
+try:
+    # The queue_job module is not necessarily installed
+    from odoo.addons.queue_job.job import job, Job
+except ImportError:
+    import functools
+    Job = False
+
+    def job(func=None, default_channel='root', retry_pattern=None):
+        if func is None:
+            return functools.partial(
+                job,
+                default_channel=default_channel,
+                retry_pattern=retry_pattern
+            )
+        return func
 
 
 class AccountMoveValidate(models.TransientModel):


### PR DESCRIPTION
To fix 

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 193, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 181, in execute
    application_iter = app(environ, start_response)
  File "/odoo/src/odoo/service/server.py", line 247, in app
    return self.app(e, s)
  File "/odoo/src/odoo/service/wsgi_server.py", line 186, in application
    return application_unproxied(environ, start_response)
  File "/odoo/src/odoo/service/wsgi_server.py", line 172, in application_unproxied
    result = handler(environ, start_response)
  File "/odoo/src/odoo/http.py", line 1325, in __call__
    self.load_addons()
  File "/odoo/src/odoo/http.py", line 1346, in load_addons
    m = __import__('odoo.addons.' + module)
  File "/odoo/src/odoo/modules/module.py", line 81, in load_module
    execfile(modfile, new_mod.__dict__)
  File "/odoo/external-src/account-financial-tools/account_move_batch_validate/__init__.py", line 5, in <module>
    from . import models
  File "/odoo/external-src/account-financial-tools/account_move_batch_validate/models/__init__.py", line 5, in <module>
    from . import account_move
  File "/odoo/external-src/account-financial-tools/account_move_batch_validate/models/account_move.py", line 8, in <module>
    from odoo.addons.queue_job.job import job, Job
  File "/odoo/src/odoo/modules/module.py", line 60, in load_module
    f, path, (_suffix, _mode, type_) = imp.find_module(addon_name, ad_paths)
ImportError: No module named queue_job
```