### PR TITLE
[8.0][FIX] currency_rate_update: admin.ch service url changed

### DIFF
--- a/currency_rate_update/services/update_service_CH_ADMIN.py
+++ b/currency_rate_update/services/update_service_CH_ADMIN.py
@@ -51,8 +51,8 @@ class CH_ADMIN_getter(Currency_getter_interface):
     def get_updated_currency(self, currency_array, main_currency,
                              max_delta_days):
         """Implementation of abstract method of Curreny_getter_interface"""
-        url = ('http://www.afd.admin.ch/publicdb/newdb/'
-               'mwst_kurse/wechselkurse.php')
+        url = ('http://www.pwebapps.ezv.admin.ch/apps/rates/rate/'
+               'getxml?activeSearchType=today')
         # We do not want to update the main currency
         if main_currency in currency_array:
             currency_array.remove(main_currency)
@@ -63,7 +63,7 @@ class CH_ADMIN_getter(Currency_getter_interface):
         dom = etree.fromstring(rawfile)
         _logger.debug("Admin.ch sent a valid XML file")
         adminch_ns = {
-            'def': 'http://www.afd.admin.ch/publicdb/newdb/mwst_kurse'
+            'def': 'http://www.pwebapps.ezv.admin.ch/apps/rates'
         }
         rate_date = dom.xpath(
             '/def:wechselkurse/def:datum/text()',


### PR DESCRIPTION
URL of Admin.ch Service used by currency_rate_update module has been changed.

Already merged in 7.0 and 10.0.
See https://github.com/OCA/account-financial-tools/pull/770 and
https://github.com/OCA/account-financial-tools/commit/b131a5d812d8c2f0c97b62bd48a8595983f2ea49