### PR TITLE
[FIX] account_move_batch_validate: Protect imports from non-core addon

### DIFF
--- a/account_move_batch_validate/models/account_move.py
+++ b/account_move_batch_validate/models/account_move.py
@@ -8,7 +8,7 @@ from odoo import api, fields, models, _
 try:
     from odoo.addons.queue_job.job import job, Job
 except ImportError:
-    job = lambda **kwargs: False
+    job = lambda **kwargs: lambda x: x
     Job = False
 
 

--- a/account_move_batch_validate/models/account_move.py
+++ b/account_move_batch_validate/models/account_move.py
@@ -5,7 +5,11 @@
 import logging
 
 from odoo import api, fields, models, _
-from odoo.addons.queue_job.job import job, Job
+try:
+    from odoo.addons.queue_job.job import job, Job
+except ImportError:
+    job = lambda **kwargs: False
+    Job = False
 
 
 _logger = logging.getLogger(__name__)

--- a/account_move_batch_validate/wizard/account_move_validate.py
+++ b/account_move_batch_validate/wizard/account_move_validate.py
@@ -3,7 +3,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-from odoo.addons.queue_job.job import job
+try:
+    from odoo.addons.queue_job.job import job
+except ImportError:
+    job = lambda **kwargs: False
 
 
 class AccountMoveValidate(models.TransientModel):

--- a/account_move_batch_validate/wizard/account_move_validate.py
+++ b/account_move_batch_validate/wizard/account_move_validate.py
@@ -6,7 +6,7 @@ from odoo import api, fields, models
 try:
     from odoo.addons.queue_job.job import job
 except ImportError:
-    job = lambda **kwargs: False
+    job = lambda **kwargs: lambda x: x
 
 
 class AccountMoveValidate(models.TransientModel):


### PR DESCRIPTION
the imports below will fail for deployments without the module. As it has a static folder by now, this will be loaded when Odoo aggregates assets, and break.