### PR TITLE
[FIX] protect import if module is not present

### DIFF
--- a/account_asset_management_xls/report/__init__.py
+++ b/account_asset_management_xls/report/__init__.py
@@ -1,2 +1,10 @@
-# -*- coding: utf-8 -*-
-from . import account_asset_report_xls
+
+try:
+    from odoo.addons.report_xlsx_helper.report.abstract_report_xlsx \
+        import AbstractReportXlsx
+except (ImportError, IOError) as err:
+    import logging
+    _logger = logging.getLogger(__name__)
+    _logger.debug(err)
+else:
+    from . import account_asset_report_xls

--- a/account_asset_management_xls/report/__init__.py
+++ b/account_asset_management_xls/report/__init__.py
@@ -1,4 +1,7 @@
 
+# The whole python file is ignored when the dependency is missing
+# because it contains an old-style rml_parse report which would
+# be loaded anyway
 try:
     from odoo.addons.report_xlsx_helper.report.abstract_report_xlsx \
         import AbstractReportXlsx

--- a/account_move_batch_validate/__init__.py
+++ b/account_move_batch_validate/__init__.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 Camptocamp SA, 2017 ACSONE
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from . import models
-from . import wizard
+try:
+    from odoo.addons.queue_job.job \
+        import job, Job
+except (ImportError, IOError) as err:
+    import logging
+    _logger = logging.getLogger(__name__)
+    _logger.debug(err)
+else:
+    from . import models
+    from . import wizard


### PR DESCRIPTION
Purpose: 
If module report_xls_helper or queue_job are not in the addons path, we cannot load odoo.

dev:

I have put the test in the __init__.py of the module because the class is used as helper or as 
a decorator. so i test the import a step before