### PR TITLE
[IMP] account_loan: Fix rounding issues

### DIFF
--- a/account_loan/__manifest__.py
+++ b/account_loan/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Account Loan management",
-    "version": "11.0.1.1.1",
+    "version": "11.0.1.2.0",
     "author": "Creu Blanca,Odoo Community Association (OCA)",
     "website": "http://github.com/OCA/account-financial-tools",
     "license": "AGPL-3",

--- a/account_loan/model/account_loan.py
+++ b/account_loan/model/account_loan.py
@@ -277,7 +277,7 @@ class AccountLoan(models.Model):
         for record in self:
             if record.loan_type == 'fixed-annuity':
                 record.fixed_amount = - record.currency_id.round(numpy.pmt(
-                    record.rate_period / 100,
+                    record.loan_rate() / 100,
                     record.fixed_periods,
                     record.fixed_loan_amount,
                     -record.residual_amount
@@ -308,8 +308,12 @@ class AccountLoan(models.Model):
     @api.depends('rate', 'method_period', 'rate_type')
     def _compute_rate_period(self):
         for record in self:
-            record.rate_period = record.compute_rate(
-                record.rate, record.rate_type, record.method_period)
+            record.rate_period = record.loan_rate()
+
+    def loan_rate(self):
+        return self.compute_rate(
+            self.rate, self.rate_type, self.method_period
+        )
 
     @api.depends('journal_id', 'company_id')
     def _compute_currency(self):

--- a/account_loan/tests/test_loan.py
+++ b/account_loan/tests/test_loan.py
@@ -94,9 +94,9 @@ class TestLoan(TransactionCase):
         loan.round_on_end = True
         loan.compute_lines()
         line_1 = loan.line_ids.filtered(lambda r: r.sequence == 1)
-        line_end = loan.line_ids.filtered(lambda r: r.sequence == 60)
-        self.assertNotAlmostEqual(
-            line_1.payment_amount, line_end.payment_amount, 2)
+        for line in loan.line_ids:
+            self.assertAlmostEqual(
+                line_1.payment_amount, line.payment_amount, 2)
         loan.loan_type = 'fixed-principal'
         loan.compute_lines()
         line_1 = loan.line_ids.filtered(lambda r: r.sequence == 1)


### PR DESCRIPTION
Some errors where found due to rounding issues. Now, the rate is computed when needed without rounding.