### PR TITLE
[11.0][FIX] account_asset_management: Fix computation of depreciation lines when having multiple assets in invoice

### DIFF
--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -74,19 +74,26 @@ class AccountAssetLine(models.Model):
         dlines = dlines.filtered(lambda l: l.type == 'depreciate')
         dlines = dlines.sorted(key=lambda l: l.line_date)
 
-        for i, dl in enumerate(dlines):
-            if i == 0:
-                depreciation_base = dl.depreciation_base
-                depreciated_value = dl.previous_id \
-                    and (depreciation_base - dl.previous_id.remaining_value) \
-                    or 0.0
-                remaining_value = \
-                    depreciation_base - depreciated_value - dl.amount
-            else:
-                depreciated_value += dl.previous_id.amount
-                remaining_value -= dl.amount
-            dl.depreciated_value = depreciated_value
-            dl.remaining_value = remaining_value
+        # Group depreciation lines per asset
+        asset_ids = dlines.mapped('asset_id')
+        grouped_dlines = []
+        for asset in asset_ids:
+            grouped_dlines.append(
+                dlines.filtered(lambda l: l.asset_id.id == asset.id))
+
+        for dlines in grouped_dlines:
+            for i, dl in enumerate(dlines):
+                if i == 0:
+                    depreciation_base = dl.depreciation_base
+                    tmp = depreciation_base - dl.previous_id.remaining_value
+                    depreciated_value = dl.previous_id and tmp or 0.0
+                    remaining_value = \
+                        depreciation_base - depreciated_value - dl.amount
+                else:
+                    depreciated_value += dl.previous_id.amount
+                    remaining_value -= dl.amount
+                dl.depreciated_value = depreciated_value
+                dl.remaining_value = remaining_value
 
     @api.depends('move_id')
     @api.multi

--- a/account_asset_management/readme/CONTRIBUTORS.rst
+++ b/account_asset_management/readme/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@
 - Stéphane Bidoul (Acsone)
 - Adrien Peiffer (Acsone)
 - Akim Juillerat <akim.juillerat@camptocamp.com>
+- Maxence Groine <mgroine@fiefmanage.ch>

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -90,6 +90,26 @@ class TestAssetManagement(SavepointCase):
             'journal_id': cls.journal.id,
             'invoice_line_ids': [(4, cls.invoice_line.id)]})
 
+        cls.invoice_line_2 = cls.account_invoice_line.create({
+            'name': 'test 2',
+            'account_id': cls.account_payable.id,
+            'price_unit': 10000.00,
+            'quantity': 1,
+            'product_id': cls.product.id})
+        cls.invoice_line_3 = cls.account_invoice_line.create({
+            'name': 'test 3',
+            'account_id': cls.account_payable.id,
+            'price_unit': 20000.00,
+            'quantity': 1,
+            'product_id': cls.product_id})
+
+        cls.invoice_2 = cls.account_invoice.create({
+            'partner_id': cls.partner.id,
+            'account_id': cls.account_recv.id,
+            'journal_id': cls.journal.id,
+            'invoice_line_ids': [(4, cls.invoice_line_2.id),
+                                 (4, cls.invoice_line_3.id)]})
+
     def test_01_nonprorata_basic(self):
         """Basic tests of depreciation board computations and postings."""
         #
@@ -467,3 +487,31 @@ class TestAssetManagement(SavepointCase):
             # I check that the new asset has the correct purchase value
             self.assertAlmostEqual(
                 asset.purchase_value, -line.price_unit, places=2)
+
+    def test_11_assets_from_invoice(self):
+        all_assets = self.env['account.asset'].search([])
+        invoice = self.invoice_2
+        asset_profile = self.env.ref(
+            'account_asset_management.account_asset_profile_car_5Y')
+        asset_profile.asset_product_item = True
+        # Compute depreciation lines on invoice validation
+        asset_profile.open_asset = True
+
+        self.assertTrue(len(invoice.invoice_line_ids) == 2)
+        invoice.invoice_line_ids.write({
+            'quantity': 1,
+            'asset_profile_id': asset_profile.id,
+        })
+        invoice.action_invoice_open()
+        # Retrieve all assets after invoice validation
+        current_assets = self.env['account.asset'].search([])
+        # What are the new assets?
+        new_assets = current_assets - all_assets
+        self.assertEqual(len(new_assets), 2)
+
+        for asset in new_assets:
+            dlines = asset.depreciation_line_ids.filtered(
+                lambda l: l.type == 'depreciate')
+            dlines = dlines.sorted(key=lambda l: l.line_date)
+            self.assertAlmostEqual(dlines[0].depreciated_value, 0.0)
+            self.assertAlmostEqual(dlines[-1].remaining_value, 0.0)

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -101,7 +101,7 @@ class TestAssetManagement(SavepointCase):
             'account_id': cls.account_payable.id,
             'price_unit': 20000.00,
             'quantity': 1,
-            'product_id': cls.product_id})
+            'product_id': cls.product.id})
 
         cls.invoice_2 = cls.account_invoice.create({
             'partner_id': cls.partner.id,


### PR DESCRIPTION
Fixes #827 by grouping depreciation lines per asset before computing values.