### PR TITLE
[8.0][FIX] account_cost_center: multicompany compliant + add tests

### DIFF
--- a/account_cost_center/__openerp__.py
+++ b/account_cost_center/__openerp__.py
@@ -1,21 +1,22 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2017 Onestein (<http://www.onestein.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2016-2019 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
     'name': 'Costcenter',
     'summary': 'Cost center information for invoice lines',
-    'author': 'ONESTEiN BV,Odoo Community Association (OCA)',
+    'author': 'Onestein, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
-    'website': 'http://www.onestein.eu',
+    'website': 'https://github.com/OCA/account-financial-tools/',
     'category': 'Accounting',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.0.1',
     'depends': [
         'account',
         'base_view_inheritance_extension'
     ],
     'data': [
         'security/ir.model.access.csv',
+        'security/account_cost_center_security.xml',
         'views/account_cost_center.xml',
         'views/account_move.xml',
         'views/account_move_line.xml',

--- a/account_cost_center/models/account_cost_center.py
+++ b/account_cost_center/models/account_cost_center.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2017 Onestein (<http://www.onestein.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2015-2019 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from openerp import fields, models
 
@@ -14,6 +14,5 @@ class AccountCostCenter(models.Model):
     company_id = fields.Many2one(
         comodel_name='res.company',
         string='Company',
-        required=True,
         default=lambda self: self.env.user.company_id
     )

--- a/account_cost_center/models/account_invoice.py
+++ b/account_cost_center/models/account_invoice.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2017 Onestein (<http://www.onestein.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2015-2019 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from openerp import api, fields, models
 
@@ -11,7 +11,9 @@ class AccountInvoice(models.Model):
     cost_center_id = fields.Many2one(
         'account.cost.center',
         string='Cost Center',
-        help='Default Cost Center'
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+        help='Default Cost Center',
     )
 
     @api.model

--- a/account_cost_center/security/account_cost_center_security.xml
+++ b/account_cost_center/security/account_cost_center_security.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+
+    <data noupdate="1">
+        <record id="account_cost_center_comp_rule" model="ir.rule">
+            <field name="name">Cost center multi company rule</field>
+            <field name="model_id" ref="account_cost_center.model_account_cost_center"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        </record>
+    </data>
+
+</openerp>

--- a/account_cost_center/tests/__init__.py
+++ b/account_cost_center/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_cost_center

--- a/account_cost_center/tests/test_cost_center.py
+++ b/account_cost_center/tests/test_cost_center.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2019 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openerp.tests.common import TransactionCase
+
+
+class TestAccountCostCenter(TransactionCase):
+
+    def test_invoice_costcenter(self):
+        Account = self.env['account.account']
+        CostCenter = self.env['account.cost.center']
+        InvLine = self.env['account.invoice.line']
+
+        invoice_account = Account.search([
+            ('type', '=', 'receivable')
+        ], limit=1).id
+        invoice_line_account = Account.search([
+            ('type', '=', 'payable')],
+            limit=1).id
+
+        invoice = self.env['account.invoice'].create({
+            'partner_id': self.env.ref('base.res_partner_2').id,
+            'account_id': invoice_account,
+            'type': 'in_invoice',
+        })
+
+        line1 = InvLine.create({
+            'product_id': self.env.ref('product.product_product_2').id,
+            'quantity': 1.0,
+            'price_unit': 100.0,
+            'invoice_id': invoice.id,
+            'name': 'product that cost 100',
+            'account_id': invoice_line_account,
+        })
+        empty_cost_center = CostCenter.browse()
+        self.assertTrue(
+            (line1.cost_center_id == empty_cost_center),
+            "Default cost center per line not set")
+
+        costcenter = CostCenter.create({
+            'name': 'Cost Center Test',
+            'code': 'CC1',
+            'company_id': self.env.user.company_id.id
+        })
+        invoice.cost_center_id = costcenter
+
+        line2 = InvLine.with_context(cost_center_id=costcenter.id).create({
+            'product_id': self.env.ref('product.product_product_4').id,
+            'quantity': 1.0,
+            'price_unit': 130.0,
+            'invoice_id': invoice.id,
+            'name': 'product that cost 130',
+            'account_id': invoice_line_account,
+        })
+        self.assertTrue(
+            (line2.cost_center_id == costcenter),
+            "Default cost center per line set")
+
+        invoice.signal_workflow('invoice_open')

--- a/account_cost_center/views/account_cost_center.xml
+++ b/account_cost_center/views/account_cost_center.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
 
@@ -21,6 +21,7 @@
                                 <field name="code"/>
                             </group>
                             <group name="main_group2">
+                                <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                             </group>
                         </group>
                         <notebook name="notebook">
@@ -36,6 +37,7 @@
                 <tree string="Cost Centers">
                     <field name="code"/>
                     <field name="name"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
                 </tree>
             </field>
         </record>
@@ -58,7 +60,7 @@
             <field name="search_view_id" ref="account_cost_center_filter"/>
             <field name="help" type="html">
                 <p class="oe_view_nocontent_create">
-                    Click to add a new event.
+                    Click to add a new cost center.
                 </p>
                 <p>
                     Cost centers provide an extra analytic dimension


### PR DESCRIPTION
This PR is the backport to V8 of the following fixes:

- ease to manage the cost center in a multicompany environment
- avoid changing of cost center on an invoice in case it's not in draft
- fix typo in view
- fix manifest url
- add tests