### PR TITLE
[11.0] account_asset: Do not loop on all the lines to search for one linked asset

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -115,22 +115,20 @@ class AccountMoveLine(models.Model):
 
     @api.multi
     def write(self, vals):
-        # Check if at least one asset is linked to a move
-        linked_asset = False
-        for move in self:
-            linked_asset = move.asset_id
-            if linked_asset:
-                break
         if (
-            linked_asset and
             set(vals).intersection(FIELDS_AFFECTS_ASSET_MOVE_LINE) and
             not (
                 self.env.context.get('allow_asset_removal') and
                 list(vals.keys()) == ['asset_id'])
         ):
-            raise UserError(
-                _("You cannot change an accounting item "
-                  "linked to an asset depreciation line."))
+            # Check if at least one asset is linked to a move
+            linked_asset = False
+            for move in self:
+                linked_asset = move.asset_id
+                if linked_asset:
+                    raise UserError(
+                        _("You cannot change an accounting item "
+                          "linked to an asset depreciation line."))
         if vals.get('asset_id'):
             raise UserError(
                 _("You are not allowed to link "

--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -115,8 +115,14 @@ class AccountMoveLine(models.Model):
 
     @api.multi
     def write(self, vals):
+        # Check if at least one asset is linked to a move
+        linked_asset = False
+        for move in self:
+            linked_asset = move.asset_id
+            if linked_asset:
+                break
         if (
-            self.mapped('asset_id') and
+            linked_asset and
             set(vals).intersection(FIELDS_AFFECTS_ASSET_MOVE_LINE) and
             not (
                 self.env.context.get('allow_asset_removal') and


### PR DESCRIPTION
Before this change, the use of `mapped` on self did loop on all the move
lines that are included in self to get the assets, what could be very
costly for a simple write on a lot of move lines. As the goal is to raise
an error only if at least one move is linked to an asset, we break the
loop if the condition is fulfilled.