### PR TITLE
[12.0][ENH] account_move_line_purchase_info: display PO name and stat…

### DIFF
--- a/account_move_line_purchase_info/__manifest__.py
+++ b/account_move_line_purchase_info/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Account Move Line Purchase Info",
     "summary": "Introduces the purchase order line to the journal items",
-    "version": "12.0.1.0.1",
+    "version": "12.0.2.0.0",
     "author": "Eficent, "
               "Odoo Community Association (OCA)",
     "website": "https://www.github.com/OCA/account-financial-tools",

--- a/account_move_line_purchase_info/models/__init__.py
+++ b/account_move_line_purchase_info/models/__init__.py
@@ -2,4 +2,5 @@
 
 from . import account_move
 from . import account_invoice
+from . import purchase_order_line
 from . import stock_move

--- a/account_move_line_purchase_info/models/account_move.py
+++ b/account_move_line_purchase_info/models/account_move.py
@@ -14,3 +14,10 @@ class AccountMoveLine(models.Model):
         string='Purchase Order Line',
         ondelete='set null', index=True,
     )
+
+    purchase_id = fields.Many2one(
+        comodel_name='purchase.order',
+        related='purchase_line_id.order_id',
+        string='Purchase Order',
+        store=True, index=True,
+    )

--- a/account_move_line_purchase_info/models/purchase_order_line.py
+++ b/account_move_line_purchase_info/models/purchase_order_line.py
@@ -1,0 +1,20 @@
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo import api, models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    @api.multi
+    def name_get(self):
+        result = []
+        orig_name = dict(super(PurchaseOrderLine, self).name_get())
+        for line in self:
+            name = orig_name[line.id]
+            if self.env.context.get('po_line_info', False):
+                name = "[%s] %s (%s)" % (line.order_id.name, name,
+                                         line.order_id.state)
+            result.append((line.id, name))
+        return result

--- a/account_move_line_purchase_info/tests/test_account_move_line_purchase_info.py
+++ b/account_move_line_purchase_info/tests/test_account_move_line_purchase_info.py
@@ -199,3 +199,14 @@ class TestAccountMoveLinePurchaseInfo(common.TransactionCase):
                 self.assertEqual(aml.purchase_line_id, po_line,
                                  'Purchase Order line has not been copied '
                                  'from the invoice to the account move line.')
+
+    def test_name_get(self):
+        purchase = self._create_purchase([(self.product, 1)])
+        po_line = purchase.order_line[0]
+        name_get = po_line.with_context({'po_line_info': True}).name_get()
+        self.assertEqual(name_get, [(po_line.id, "[%s] %s (%s)" % (
+            po_line.order_id.name, po_line.name,
+            po_line.order_id.state,
+        ))])
+        name_get_no_ctx = po_line.name_get()
+        self.assertEqual(name_get_no_ctx, [(po_line.id, po_line.name)])

--- a/account_move_line_purchase_info/views/account_move_view.xml
+++ b/account_move_line_purchase_info/views/account_move_view.xml
@@ -7,6 +7,8 @@
         <field name="inherit_id" ref="account.view_move_line_form"/>
         <field name="arch" type="xml">
             <field name="quantity" position="before">
+                <field name="purchase_id"
+                       groups="account_move_line_purchase_info.group_account_move_purchase_info"/>
                 <field name="purchase_line_id"
                        groups="account_move_line_purchase_info.group_account_move_purchase_info"/>
             </field>
@@ -19,11 +21,14 @@
         <field name="inherit_id" ref="account.view_move_line_tree"/>
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
+                <field name="purchase_id"
+                       groups="account_move_line_purchase_info.group_account_move_purchase_info"/>
                 <field name="purchase_line_id"
-                groups="account_move_line_purchase_info.group_account_move_purchase_info"/>
+                       groups="account_move_line_purchase_info.group_account_move_purchase_info"/>
             </field>
         </field>
     </record>
+
 
     <record id="view_account_move_line_filter" model="ir.ui.view">
         <field name="name">Journal Items</field>
@@ -33,7 +38,17 @@
             <field name="partner_id" position="after">
                 <field name="purchase_line_id"
                 groups="account_move_line_purchase_info.group_account_move_purchase_info"/>
+                <field name="purchase_id"
+                groups="account_move_line_purchase_info.group_account_move_purchase_info"/>
             </field>
+            <group expand="0" position="inside">
+                <filter string="Purchase Order" name="purchase_order" domain="[]"
+                    context="{'group_by':'purchase_id'}"
+                    groups="account_move_line_purchase_info.group_account_move_purchase_info"/>
+                <filter string="Purchase Order Line" name="purchase_order_line" domain="[]"
+                        context="{'group_by':'purchase_line_id','po_line_info':True}"
+                        groups="account_move_line_purchase_info.group_account_move_purchase_info"/>
+            </group>
         </field>
     </record>
 
@@ -45,7 +60,7 @@
         <field name="arch" type="xml">
             <xpath
                     expr="//field[@name='line_ids']/tree//field[@name='partner_id']" position="after">
-                <field name="purchase_line_id"
+                <field name="purchase_line_id" context="{'po_line_info': True}"
                        groups="account_move_line_purchase_info.group_account_move_purchase_info"/>
             </xpath>
         </field>


### PR DESCRIPTION
…us on PO lines

This commit was omitted during the migration.

CC @Eficent 