### PR TITLE
[10.0][FIX] account_credit_control: search included archived obj

### DIFF
--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -81,7 +81,7 @@ class CreditControlPolicy(models.Model):
         """
         self.ensure_one()
         # MARK possible place for a good optimisation
-        my_obj = self.env[model]
+        my_obj = self.env[model].with_context(active_test=False)
         default_domain = self._move_lines_domain(controlling_date)
 
         to_add = self.env['account.move.line']

--- a/account_credit_control/tests/test_account_invoice.py
+++ b/account_credit_control/tests/test_account_invoice.py
@@ -90,7 +90,7 @@ class TestAccountInvoice(TransactionCase):
         })
         control_run.generate_credit_lines()
 
-        self.assertTrue(len(invoice.credit_control_line_ids), 1)
+        self.assertEqual(len(invoice.credit_control_line_ids), 1)
         control_line = invoice.credit_control_line_ids
 
         control_marker = self.env['credit.control.marker']

--- a/account_credit_control/tests/test_credit_control_run.py
+++ b/account_credit_control/tests/test_credit_control_run.py
@@ -110,7 +110,7 @@ class TestCreditControlRun(TransactionCase):
 
         control_run.with_context(lang='en_US').generate_credit_lines()
 
-        self.assertTrue(len(self.invoice.credit_control_line_ids), 1)
+        self.assertEqual(len(self.invoice.credit_control_line_ids), 1)
         self.assertEqual(control_run.state, 'done')
 
         report_regex = \
@@ -136,7 +136,7 @@ class TestCreditControlRun(TransactionCase):
             'policy_ids': [(6, 0, [self.policy.id])]
         })
         first_control_run.with_context(lang='en_US').generate_credit_lines()
-        self.assertTrue(len(self.invoice.credit_control_line_ids), 1)
+        self.assertEqual(len(self.invoice.credit_control_line_ids), 1)
 
         # Second run
         second_control_run = self.env['credit.control.run'].create({
@@ -144,7 +144,7 @@ class TestCreditControlRun(TransactionCase):
             'policy_ids': [(6, 0, [self.policy.id])]
         })
         second_control_run.with_context(lang='en_US').generate_credit_lines()
-        self.assertTrue(len(self.invoice.credit_control_line_ids), 2)
+        self.assertEqual(len(self.invoice.credit_control_line_ids), 2)
 
         # Last run
         last_control_run = self.env['credit.control.run'].create({
@@ -152,4 +152,4 @@ class TestCreditControlRun(TransactionCase):
             'policy_ids': [(6, 0, [self.policy.id])]
         })
         last_control_run.with_context(lang='en_US').generate_credit_lines()
-        self.assertTrue(len(self.invoice.credit_control_line_ids), 2)
+        self.assertEqual(len(self.invoice.credit_control_line_ids), 3)


### PR DESCRIPTION
account move lines doesn't have archive state so they will be all included in selection, but object which need to be checked for credit control policy can be archived, unusually partner 
so on search we should also check archived objects