### PR TITLE
[FIX][12.0]asset_management - fix date string compare

### DIFF
--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -139,7 +139,7 @@ class AccountAssetLine(models.Model):
                     check = asset_lines.filtered(
                         lambda l: l.type != 'create' and
                         (l.init_entry or l.move_check) and
-                        l.line_date < vals['line_date'])
+                        l.line_date < fields.Date.to_date(vals['line_date']))
                     if check:
                         raise UserError(
                             _("You cannot set the Asset Start Date "


### PR DESCRIPTION
Fix  'TypeError: unorderable types: datetime.date() < str()' when adding depreciation line prior to already posted line

