### PR TITLE
12.0 imp account check deposit

### DIFF
--- a/account_check_deposit/__manifest__.py
+++ b/account_check_deposit/__manifest__.py
@@ -6,16 +6,16 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
-    'name': 'Account Check Deposit',
-    'version': '12.0.1.0.1',
+    'name': 'Account Deposit in Bank',
+    'version': '12.0.2.0.1',
     'category': 'Accounting',
     'license': 'AGPL-3',
-    'summary': 'Manage deposit of checks to the bank',
+    'summary': 'Manage deposit of checks, cash, etc. to the bank',
     'author': "Odoo Community Association (OCA),"
               "Akretion,"
-              "Tecnativa",
-    'website': 'https://github.com/OCA/account-financial-tools'
-               'account_check_deposit',
+              "Tecnativa,"
+              "GRAP",
+    'website': 'https://github.com/OCA/account-financial-tools',
     'depends': [
         'account',
     ],
@@ -25,6 +25,7 @@
         'security/check_deposit_security.xml',
         'data/sequence.xml',
         'views/account_deposit_view.xml',
+        'views/account_journal_view.xml',
         'views/account_move_line_view.xml',
         'views/res_config_settings_views.xml',
         'report/report.xml',

--- a/account_check_deposit/migrations/12.0.2.0.1/post-migration.py
+++ b/account_check_deposit/migrations/12.0.2.0.1/post-migration.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2019-Today: GTRAP (<http://www.grap.coop/>)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(env, version):
+    if not version:
+        return
+
+    # Update values for journal that can be deposited
+    env.execute("""
+        UPDATE account_journal
+        SET can_be_deposited = true,
+        deposit_debit_account_id = default_debit_account_id
+        WHERE type = 'bank'
+        AND bank_account_id IS NULL
+    ;""")
+
+    env.execute("""
+        UPDATE account_journal
+        SET can_receive_deposit = true
+        WHERE type = 'bank'
+        AND bank_account_id IS NOT NULL
+    ;""")

--- a/account_check_deposit/models/__init__.py
+++ b/account_check_deposit/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_deposit
+from . import account_journal
 from . import account_move_line
 from . import res_company
 from . import res_config_settings

--- a/account_check_deposit/models/account_journal.py
+++ b/account_check_deposit/models/account_journal.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2019-Today: GTRAP (<http://www.grap.coop/>)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import api, fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    can_be_deposited = fields.Boolean(string="Can be Deposited")
+
+    can_receive_deposit = fields.Boolean(string="Can Receive Deposit")
+
+    deposit_debit_account_id = fields.Many2one(
+        comodel_name="account.account",
+        domain="[('deprecated', '=', False)]",
+        string="Debit Account for Deposit")
+
+    @api.onchange('can_be_deposited', 'default_debit_account_id')
+    def _onchange_default_debit_account_id(self):
+        # Prefill deposit account with debit account by default
+        for journal in self.filtered(lambda x: (
+                not x.deposit_debit_account_id and x.can_be_deposited)):
+            journal.deposit_debit_account_id =\
+                journal.default_debit_account_id.id

--- a/account_check_deposit/readme/DESCRIPTION.rst
+++ b/account_check_deposit/readme/DESCRIPTION.rst
@@ -1,5 +1,6 @@
-This module allows you to easily manage check deposits : you can select all
-the checks you received and create a global deposit for the selected checks.
+This module allows you to easily manage deposits : you can select all
+the payment lines you received and create a global deposit for the selected
+payments lines.
 This module supports multi-currency ; each deposit has a currency and all the
-checks of the deposit must have the same currency (so, if you have checks in
-EUR and checks in USD, you must create 2 deposits: one in EUR and one in USD).
+lines of the deposit must have the same currency (so, if you have payments in
+EUR and payments in USD, you must create 2 deposits: one in EUR and one in USD).

--- a/account_check_deposit/readme/ROADMAP.rst
+++ b/account_check_deposit/readme/ROADMAP.rst
@@ -1,0 +1,12 @@
+* Add an option on journals that can be deposited ``grouped_move_line``
+  to generate an account move with a single main line, that reconciles
+  all the lines.
+
+* Move the configuration ``check_deposit_offsetting_account`` and
+  ``check_deposit_transfer_account_id`` from ``res.company`` to the
+  ``account.journal`` that can be deposited.
+  Make required the ``bank_journal_id`` field, only in the ``bank_account``
+  option and not in the ``transfer_account`` option.
+
+* Rename fields that belong ``check`` as this module allow to make deposit
+  of checks, cash, etc...

--- a/account_check_deposit/report/report_checkdeposit.xml
+++ b/account_check_deposit/report/report_checkdeposit.xml
@@ -12,30 +12,40 @@
 
 <t t-call="web.html_container">
 <t t-foreach="docs" t-as="o">
-<t t-call="web.internal_layout">
+<t t-call="web.external_layout">
 
 <div class="page">
 
-<h1>Check Deposit n°<span t-field="o.name"/></h1>
+<h2>Deposit n°<span t-field="o.name"/></h2>
 
-<h3>Bank:</h3>
-<p><span t-field="o.bank_journal_id.bank_account_id.bank_id.name"/><br/>
-<span t-field="o.bank_journal_id.bank_account_id.bank_id.street"/><br/>
-<span t-field="o.bank_journal_id.bank_account_id.bank_id.zip"/> <span t-field="o.bank_journal_id.bank_account_id.bank_id.city"/></p>
+<div id="informations" class="row mt32 mb32">
+    <div class="col-auto mw-100 mb-2" t-if="o.bank_journal_id.bank_account_id" name="bank_journal_id">
+        <strong>Bank:</strong>
+        <p class="m-0">
+            <span t-field="o.bank_journal_id.bank_account_id.bank_id.name"/><br/>
+            <span t-field="o.bank_journal_id.bank_account_id.bank_id.street"/><br/>
+            <span t-field="o.bank_journal_id.bank_account_id.bank_id.zip"/> <span t-field="o.bank_journal_id.bank_account_id.bank_id.city"/>
+        </p>
+    </div>
+    <div class="col-auto mw-100 mb-2" t-if="o.bank_journal_id.bank_account_id" name="acc_number">
+        <strong>Account Number:</strong>
+        <p class="m-0" t-field="o.bank_journal_id.bank_account_id.acc_number"/>
+    </div>
+    <div class="col-auto mw-100 mb-2" name="currency_id">
+        <strong>Currency:</strong>
+        <p class="m-0" t-field="o.currency_id.name"/>
+    </div>
+    <div class="col-auto mw-100 mb-2" name="deposit_date">
+        <strong>Transfer Date:</strong>
+        <p class="m-0" t-field="o.deposit_date"/>
+    </div>
+    <div class="col-auto mw-100 mb-2" name="check_count">
+        <strong>Lines:</strong>
+        <p class="m-0" t-field="o.check_count"/>
+    </div>
+</div>
 
-<h3>Beneficiary:</h3>
-<div t-field="o.company_id.partner_id"
-     t-field-options='{"widget": "contact", "fields": ["address", "name", "phone", "fax"], "no_marker": true}'/>
-
-<p><b>Bank Account Number to Credit:</b> <span t-field="o.bank_journal_id.bank_account_id.acc_number"/></p>
-
-<p><b>Check Currency:</b> <span t-field="o.currency_id.name"/></p>
-
-<p><b>Transfer Date:</b> <span t-field="o.deposit_date"/></p>
-
-<p><b>Number of checks:</b> <span t-field="o.check_count"/></p>
-
-<h3>List of checks:</h3>
+<h3>Details:</h3>
 
     <table class="table table-condensed">
     <thead>
@@ -56,8 +66,14 @@
             <td><span t-field="move_line.partner_id.name"/></td>
             <td>
                 <t t-if="o.currency_id == o.company_id.currency_id">
-                    <span t-field="move_line.debit"
-                        t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                    <t t-if="move_line.debit > 0">
+                        <span t-field="move_line.debit"
+                            t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                    </t>
+                    <t t-if="move_line.credit > 0">
+                        (<span t-field="move_line.credit"
+                            t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>)
+                    </t>
                 </t>
                 <t t-if="o.currency_id != o.company_id.currency_id">
                     <span t-field="move_line.amount_currency"

--- a/account_check_deposit/views/account_deposit_view.xml
+++ b/account_check_deposit/views/account_deposit_view.xml
@@ -29,7 +29,7 @@
                 </header>
                 <sheet>
                     <div class="oe_title">
-                        <label string="Check Deposit" for="name"/>
+                        <label string="Bank Deposit" for="name"/>
                         <h1>
                             <field name="name"/>
                         </h1>
@@ -40,7 +40,7 @@
                             <field name="journal_id"
                                    widget="selection"/>
                             <field name="journal_default_account_id"
-                                   invisible="1"/>
+                                invisible="1"/>
                             <field name="currency_id"
                                    groups="base.group_multi_currency"/>
                             <field name="bank_journal_id" widget="selection"/>
@@ -54,13 +54,13 @@
                             <field name="total_amount" widget="monetary"
                                    options="{'currency_field': 'currency_id'}"/>
                             <field name="move_id"/>
+                            <field name="is_reconcile"/>
                         </group>
                     </group>
-                    <group string="Check Payments" name="check_payments">
+                    <group string="Bank Payments" name="check_payments">
                         <field name="check_payment_ids" nolabel="1"
                                widget="many2many"
                                domain="[('reconciled', '=', False),
-                                        ('debit', '>', 0),
                                         ('check_deposit_id', '=', False),
                                         ('currency_id', '=', currency_none_same_company_id),
                                         ('account_id', '=', journal_default_account_id)]"
@@ -113,7 +113,7 @@
         <field name="model">account.check.deposit</field>
         <field name="arch" type="xml">
             <search>
-                <field name="name" string="Checks Deposit"/>
+                <field name="name" string="Bank Deposit"/>
                 <filter name="draft" string="Draft"
                         domain="[('state', '=', 'draft')]"/>
                 <filter name="done" string="Done"
@@ -133,7 +133,7 @@
     </record>
 
     <record id="action_check_deposit_tree" model="ir.actions.act_window">
-        <field name="name">Checks Deposits</field>
+        <field name="name">Bank Deposits</field>
         <field name="res_model">account.check.deposit</field>
         <field name="view_mode">tree,form</field>
     </record>

--- a/account_check_deposit/views/account_journal_view.xml
+++ b/account_check_deposit/views/account_journal_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2019-Today GRAP (http://www.grap.coop/)
+  @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+-->
+
+<odoo>
+
+    <record id="account_journal_form" model="ir.ui.view">
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="arch" type="xml">
+            <field name="type" position="after">
+                <field name="can_receive_deposit" attrs="{'invisible': [('type', '!=', 'bank')]}"/>
+                <field name="can_be_deposited" attrs="{'invisible': [('type', 'not in', ['bank', 'cash'])]}"/>
+                <field name="deposit_debit_account_id" attrs="{
+                    'invisible': [('can_be_deposited', '=', False)],
+                    'required': [('can_be_deposited', '=', True)]}"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Improve the module ``account_check_deposit``, making it more generic.

### Allow to deposit other journal than Check.
(in my Use case Cash Journal)
-> For that purpose, it remove fixed domain, and add two checkboxes on ``account.journal`` model, named ``can_be_deposited`` (replacing ``[('type', '='bank'), ('account_bank_id, '=', False)]``) and ``can_receive_deposit`` (replacing ``[('type', '='bank'), ('account_bank_id, '!=', False)]``)
-> Provide a migration script to initialize correctly database with the current module installed
-> Make more generic terms of the application, replacing hard coded "Check" by the ``journal_id.name`` field.

### Reconcile "negative payment"
In some cases, it can be interesting to reconcile negative payment. (specially the move line that are a fix of an original bad payment, ie : Bad first payment : Check : 300€ / Fix : -100€, because in reality the user has received a check of 200€.) The case is a blocking point if ``account_cancel`` is not installed, that is a legal requirement in some countries.
-> For that purpose, remove all the conditions related to the ``line.credit > 0``.

### Add possibility to use other account as the default one

Add the possibility to use a different account for the deposit journal to filter the move lines. That is interesting if user is generating cash deposit via the OCA module ``pos_cash_move_reason``.
-> For that purpose, add a new field on ``account.journal`` named ``deposit_debit_account_id``. The value, is by default, the value of ``default_debit_account_id`` but it can be changed.
-> handle migration, for existing databases.

### Improve deposit report

-> remove "check" hard coded string, replaced by the name of the journal
-> Use company header and display more nicely head information. (same convention as for invoice report).

### Add roadmap section

**Note**
when merging, please do not use the ocabot command with auto upgrade revision, to allow breaking migration script.

#GRAPOCA