### PR TITLE
[11.0][FIX] .travis.yml: postgresql 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 cache: pip
 
 addons:
-  postgresql: "9.2" # minimal postgresql version for the daterange method
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility


### PR DESCRIPTION
Branch 11.0 seems broken as postgres is not found by Travis. This PR specifies postgresql 9.6 in .travis.yml in order to fix it.