### PR TITLE
[10.0][IMP] account_credit_control use partner email

### DIFF
--- a/account_credit_control/wizard/credit_control_communication.py
+++ b/account_credit_control/wizard/credit_control_communication.py
@@ -89,7 +89,10 @@ class CreditCommunication(models.TransientModel):
         """ Return a valid email for customer """
         self.ensure_one()
         contact = self.contact_address
-        return contact.email
+        email = contact.email
+        if not email and contact.commercial_partner_id.email:
+            email = contact.commercial_partner_id.email
+        return email
 
     @api.multi
     @api.returns('res.partner')


### PR DESCRIPTION
when no any email avaible on invoice contract use
parent email if exists