### PR TITLE
[12.0] account_asset_management: date & datetime objects could get mixed when using fiscalyears in depreciation computation

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import calendar
-from datetime import datetime
+from datetime import date
 from dateutil.relativedelta import relativedelta
 import logging
 from sys import exc_info
@@ -596,11 +596,11 @@ class AccountAsset(models.Model):
                         duration = (fy_date_stop - fy_date_start).days + 1
                     else:
                         duration = (
-                            datetime(year, 12, 31) - fy_date_start).days + 1
+                            date(year, 12, 31) - fy_date_start).days + 1
                     factor = float(duration) / cy_days
                 elif i == cnt - 1:  # last year
                     duration = (
-                        fy_date_stop - datetime(year, 1, 1)).days + 1
+                        fy_date_stop - date(year, 1, 1)).days + 1
                     factor += float(duration) / cy_days
                 else:
                     factor += 1.0


### PR DESCRIPTION
When using a prorata temporis Asset Profile and having a fiscal year defined that does not overlap the 'natural' year, computing depreciations fails as it tries to subtract a `datetime.date` object (coming from `account.fiscal.year` object) with a `datetime.datetime` object.

The issue can be reproduced on [this runbot instance and object](http://3386187-12-0-c12d49.runbot3.odoo-community.org/web?debug=1#id=3&action=323&model=account.asset&view_type=form&menu_id=124) (_Depreciation Board_ > click on _Compute_)