### PR TITLE
[12.0] [IMP] add check for date and date_invoice

### DIFF
--- a/account_invoice_constraint_chronology/README.rst
+++ b/account_invoice_constraint_chronology/README.rst
@@ -31,6 +31,7 @@ It prevents the validation of invoices when:
 
 * there are draft invoices with a prior date
 * there are validated invoices with a later date
+* invoice have a date (which generates account move) prior of date_invoice
 
 **Table of contents**
 
@@ -62,6 +63,7 @@ Contributors
 * Gilles Gilles <meyomesse.gilles@gmail.com>
 * Francesco Apruzzese <f.apruzzese@apuliasoftware.it>
 * Thomas Binsfeld <thomas.binsfeld@acsone.eu>
+* Sergio Corato <https://github.com/sergiocorato>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_invoice_constraint_chronology/model/account_invoice.py
+++ b/account_invoice_constraint_chronology/model/account_invoice.py
@@ -39,6 +39,12 @@ class AccountInvoice(models.Model):
         for inv in self:
             if not inv.journal_id.check_chronology:
                 continue
+            if inv.type in ('in_invoice', 'in_refund'):
+                if inv.date_invoice and inv.date and \
+                        inv.date_invoice > inv.date:
+                    raise UserError(
+                        _("Supplier invoice date cannot be later than"
+                          " the date of registration!"))
             invoices = self.search(
                 self._prepare_previous_invoices_domain(inv), limit=1)
             if invoices:

--- a/account_invoice_constraint_chronology/readme/CONTRIBUTORS.rst
+++ b/account_invoice_constraint_chronology/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Gilles Gilles <meyomesse.gilles@gmail.com>
 * Francesco Apruzzese <f.apruzzese@apuliasoftware.it>
 * Thomas Binsfeld <thomas.binsfeld@acsone.eu>
+* Sergio Corato <https://github.com/sergiocorato>

--- a/account_invoice_constraint_chronology/readme/DESCRIPTION.rst
+++ b/account_invoice_constraint_chronology/readme/DESCRIPTION.rst
@@ -4,3 +4,4 @@ It prevents the validation of invoices when:
 
 * there are draft invoices with a prior date
 * there are validated invoices with a later date
+* invoice have a date (which generates account move) prior of date_invoice

--- a/account_invoice_constraint_chronology/static/description/index.html
+++ b/account_invoice_constraint_chronology/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.14: http://docutils.sourceforge.net/" />
 <title>Account Invoice Constraint Chronology</title>
 <style type="text/css">
 
@@ -373,6 +373,7 @@ ul.auto-toc {
 <ul class="simple">
 <li>there are draft invoices with a prior date</li>
 <li>there are validated invoices with a later date</li>
+<li>invoice have a date (which generates account move) prior of date_invoice</li>
 </ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
@@ -409,6 +410,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Gilles Gilles &lt;<a class="reference external" href="mailto:meyomesse.gilles&#64;gmail.com">meyomesse.gilles&#64;gmail.com</a>&gt;</li>
 <li>Francesco Apruzzese &lt;<a class="reference external" href="mailto:f.apruzzese&#64;apuliasoftware.it">f.apruzzese&#64;apuliasoftware.it</a>&gt;</li>
 <li>Thomas Binsfeld &lt;<a class="reference external" href="mailto:thomas.binsfeld&#64;acsone.eu">thomas.binsfeld&#64;acsone.eu</a>&gt;</li>
+<li>Sergio Corato &lt;<a class="reference external" href="https://github.com/sergiocorato">https://github.com/sergiocorato</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_invoice_constraint_chronology/tests/test_account_constraint_chronology.py
+++ b/account_invoice_constraint_chronology/tests/test_account_constraint_chronology.py
@@ -133,3 +133,16 @@ class TestAccountConstraintChronology(common.SavepointCase):
         self.account_journal_sale.type = 'bank'
         self.account_journal_sale._onchange_type()
         self.assertFalse(self.account_journal_sale.check_chronology)
+
+    def test_invoice_date(self):
+        journal = self.get_journal_check(True)
+        today = datetime.now()
+        yesterday = today - timedelta(days=1)
+        invoice = self.create_simple_invoice(journal.id, today.strftime(
+            DEFAULT_SERVER_DATE_FORMAT))
+        invoice.date = yesterday.strftime(DEFAULT_SERVER_DATE_FORMAT)
+        with self.assertRaises(UserError):
+            invoice.action_invoice_open()
+        invoice.date = today.strftime(DEFAULT_SERVER_DATE_FORMAT)
+        invoice.action_invoice_open()
+        self.assertTrue(invoice.state == 'open', 'Invoice was not created')


### PR DESCRIPTION
Add a check for invoice received from suppliers:
- an invoice cannot be registered in a date prior of the date of the invoice.