### PR TITLE
[IMP] Added option to not automatically post the created moves. 

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -185,6 +185,10 @@ class AccountAsset(models.Model):
     account_analytic_id = fields.Many2one(
         comodel_name='account.analytic.account',
         string='Analytic account')
+    post_move = fields.Boolean(
+        string='Post created moves',
+        default=True,
+        help="Do automatically post created moves or not.")
 
     @api.model
     def _default_company_id(self):

--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -229,7 +229,8 @@ class AccountAssetLine(models.Model):
             aml_e_vals = line._setup_move_line_data(
                 depreciation_date, exp_acc, 'expense', move)
             self.env['account.move.line'].with_context(ctx).create(aml_e_vals)
-            move.post()
+            if asset.post_move:
+                move.post()
             line.with_context(allow_asset_line_update=True).write({
                 'move_id': move.id
             })

--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -56,6 +56,7 @@
                 <field name="group_ids" widget="many2many_tags"/>
                 <field name="partner_id"/>
                 <field name="account_analytic_id" groups="analytic.group_analytic_accounting"/>
+                <field name="post_move"/>
               </group>
               <group colspan="4">
                 <group>


### PR DESCRIPTION
Default is kept as it is.
Some users like to modify the analytic lines after the move was created.