### PR TITLE
[11.0][Backport] account_asset_management - add days_calc, use_leap_years

### DIFF
--- a/account_asset_management/__manifest__.py
+++ b/account_asset_management/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Assets Management',
-    'version': '11.0.1.0.2',
+    'version': '11.0.1.1.0',
     'license': 'AGPL-3',
     'depends': [
         'account_fiscal_year',

--- a/account_asset_management/__manifest__.py
+++ b/account_asset_management/__manifest__.py
@@ -1,9 +1,10 @@
 # Copyright 2009-2018 Noviat
+# Copyright 2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     'name': 'Assets Management',
-    'version': '11.0.1.0.1',
+    'version': '11.0.1.0.2',
     'license': 'AGPL-3',
     'depends': [
         'account_fiscal_year',

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -836,7 +836,7 @@ class AccountAsset(models.Model):
         day_amount = 0.0
         if self.days_calc:
             days = (depreciation_stop_date - depreciation_start_date).days + 1
-            day_amount = round(self.depreciation_base / days, digits)
+            day_amount = self.depreciation_base / days
         for i, entry in enumerate(table):
             if self.method_time == 'year':
                 year_amount = self._compute_year_amount(fy_residual_amount)

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -749,6 +749,15 @@ class AccountAsset(models.Model):
             amount = entry['fy_amount'] - amount * full_periods
         return amount
 
+    def _get_amount_linear(
+            self, depreciation_start_date, depreciation_stop_date):
+        """
+        Override this method if you want to compute differently the
+        yearly amount.
+        """
+        days = (depreciation_stop_date - depreciation_start_date).days + 1
+        return (self.depreciation_base / days) * 365
+
     def _compute_year_amount(self, residual_amount, depreciation_start_date,
                              depreciation_stop_date):
         """
@@ -759,8 +768,8 @@ class AccountAsset(models.Model):
             raise UserError(
                 _("The '_compute_year_amount' method is only intended for "
                   "Time Method 'Number of Years."))
-        days = (depreciation_stop_date - depreciation_start_date).days + 1
-        year_amount_linear = (self.depreciation_base / days) * 365
+        year_amount_linear = self._get_amount_linear(
+            depreciation_start_date, depreciation_stop_date)
         if self.method == 'linear':
             return year_amount_linear
         if self.method == 'linear-limit':

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -172,6 +172,18 @@ class AccountAsset(models.Model):
         default=False,
         help="Use number of days to calculate depreciation amount",
     )
+    use_leap_years = fields.Boolean(
+        string='Use leap years',
+        default=False,
+        help="If not set, the system will distribute evenly the amount to "
+             "amortize across the years, based on the number of years. "
+             "So the amount per year will be the "
+             "depreciation base / number of years.\n "
+             "If set, the system will consider if the current year "
+             "is a leap year. The amount to depreciate per year will be "
+             "calculated as depreciation base / (depreciation end date - "
+             "start date + 1) * days in the current year.",
+    )
     prorata = fields.Boolean(
         string='Prorata Temporis', readonly=True,
         states={'draft': [('readonly', False)]},
@@ -309,6 +321,7 @@ class AccountAsset(models.Model):
                 'method_time': profile.method_time,
                 'method_period': profile.method_period,
                 'days_calc': profile.days_calc,
+                'use_leap_years': profile.use_leap_years,
                 'method_progress_factor': profile.method_progress_factor,
                 'prorata': profile.prorata,
                 'account_analytic_id': profile.account_analytic_id,
@@ -606,14 +619,14 @@ class AccountAsset(models.Model):
                     if amount:
                         vals = {
                             'previous_id': depr_line.id,
-                            'amount': amount,
+                            'amount': round(amount, digits),
                             'asset_id': asset.id,
                             'name': name,
                             'line_date': line['date'].strftime('%Y-%m-%d'),
                             'line_days': line['days'],
                             'init_entry': entry['init'],
                         }
-                        depreciated_value += amount
+                        depreciated_value += round(amount, digits)
                         depr_line = line_obj.create(vals)
                     else:
                         seq -= 1
@@ -750,16 +763,20 @@ class AccountAsset(models.Model):
         return amount
 
     def _get_amount_linear(
-            self, depreciation_start_date, depreciation_stop_date):
+            self, depreciation_start_date, depreciation_stop_date, entry):
         """
         Override this method if you want to compute differently the
         yearly amount.
         """
+        if not self.use_leap_years:
+            return self.depreciation_base / self.method_number
+        year = entry['date_stop'].year
+        cy_days = calendar.isleap(year) and 366 or 365
         days = (depreciation_stop_date - depreciation_start_date).days + 1
-        return (self.depreciation_base / days) * 365
+        return (self.depreciation_base / days) * cy_days
 
     def _compute_year_amount(self, residual_amount, depreciation_start_date,
-                             depreciation_stop_date):
+                             depreciation_stop_date, entry):
         """
         Localization: override this method to change the degressive-linear
         calculation logic according to local legislation.
@@ -769,7 +786,7 @@ class AccountAsset(models.Model):
                 _("The '_compute_year_amount' method is only intended for "
                   "Time Method 'Number of Years."))
         year_amount_linear = self._get_amount_linear(
-            depreciation_start_date, depreciation_stop_date)
+            depreciation_start_date, depreciation_stop_date, entry)
         if self.method == 'linear':
             return year_amount_linear
         if self.method == 'linear-limit':
@@ -851,7 +868,7 @@ class AccountAsset(models.Model):
             if self.method_time == 'year':
                 year_amount = self._compute_year_amount(
                     fy_residual_amount, depreciation_start_date,
-                    depreciation_stop_date)
+                    depreciation_stop_date, entry)
                 if self.method_period == 'year':
                     period_amount = year_amount
                 elif self.method_period == 'quarter':

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -332,6 +332,16 @@ class AccountAsset(models.Model):
         if self.method_time != 'year':
             self.prorata = True
 
+    @api.onchange('method_number')
+    def _onchange_method_number(self):
+        if self.method_number and self.method_end:
+            self.method_end = False
+
+    @api.onchange('method_end')
+    def _onchange_method_end(self):
+        if self.method_end and self.method_number:
+            self.method_number = 0
+
     @api.onchange('type')
     def _onchange_type(self):
         if self.type == 'view':
@@ -726,7 +736,7 @@ class AccountAsset(models.Model):
         return depreciation_start_date
 
     def _get_depreciation_stop_date(self, depreciation_start_date):
-        if self.method_time == 'year':
+        if self.method_time == 'year' and not self.method_end:
             depreciation_stop_date = depreciation_start_date + \
                 relativedelta(years=self.method_number, days=-1)
         elif self.method_time == 'number':
@@ -744,7 +754,7 @@ class AccountAsset(models.Model):
             elif self.method_period == 'year':
                 depreciation_stop_date = depreciation_start_date + \
                     relativedelta(years=self.method_number, days=-1)
-        elif self.method_time == 'end':
+        elif self.method_time == 'year' and self.method_end:
             depreciation_stop_date = fields.Datetime.from_string(
                 self.method_end)
         return depreciation_stop_date
@@ -768,7 +778,7 @@ class AccountAsset(models.Model):
         Override this method if you want to compute differently the
         yearly amount.
         """
-        if not self.use_leap_years:
+        if not self.use_leap_years and self.method_number:
             return self.depreciation_base / self.method_number
         year = entry['date_stop'].year
         cy_days = calendar.isleap(year) and 366 or 365
@@ -1006,7 +1016,8 @@ class AccountAsset(models.Model):
     def _compute_depreciation_table(self):
 
         table = []
-        if self.method_time in ['year', 'number'] and not self.method_number:
+        if self.method_time in ['year', 'number']  \
+                and not self.method_number and not self.method_end:
             return table
 
         company = self.company_id

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -1,4 +1,5 @@
 # Copyright 2009-2018 Noviat
+# Copyright 2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import calendar
@@ -815,6 +816,53 @@ class AccountAsset(models.Model):
 
         return line_dates
 
+    def _compute_depreciation_amount_per_fiscal_year(self, table, line_dates):
+        digits = self.env['decimal.precision'].precision_get('Account')
+        fy_residual_amount = self.depreciation_base
+        i_max = len(table) - 1
+        asset_sign = self.depreciation_base >= 0 and 1 or -1
+        for i, entry in enumerate(table):
+            if self.method_time == 'year':
+                year_amount = self._compute_year_amount(fy_residual_amount)
+                if self.method_period == 'year':
+                    period_amount = year_amount
+                elif self.method_period == 'quarter':
+                    period_amount = year_amount / 4
+                elif self.method_period == 'month':
+                    period_amount = year_amount / 12
+                if i == i_max:
+                    if self.method in ['linear-limit', 'degr-limit']:
+                        fy_amount = fy_residual_amount - self.salvage_value
+                    else:
+                        fy_amount = fy_residual_amount
+                else:
+                    firstyear = i == 0 and True or False
+                    fy_factor = self._get_fy_duration_factor(
+                        entry, firstyear)
+                    fy_amount = year_amount * fy_factor
+                if asset_sign * (fy_amount - fy_residual_amount) > 0:
+                    fy_amount = fy_residual_amount
+                period_amount = round(period_amount, digits)
+                fy_amount = round(fy_amount, digits)
+            else:
+                fy_amount = False
+                if self.method_time == 'number':
+                    number = self.method_number
+                else:
+                    number = len(line_dates)
+                period_amount = round(self.depreciation_base / number, digits)
+            entry.update({
+                'period_amount': period_amount,
+                'fy_amount': fy_amount,
+            })
+            if self.method_time == 'year':
+                fy_residual_amount -= fy_amount
+                if round(fy_residual_amount, digits) == 0:
+                    break
+        i_max = i
+        table = table[:i_max + 1]
+        return table
+
     def _compute_depreciation_table_lines(self, table, depreciation_start_date,
                                           depreciation_stop_date, line_dates):
 
@@ -984,55 +1032,11 @@ class AccountAsset(models.Model):
         # Step 1:
         # Calculate depreciation amount per fiscal year.
         # This is calculation is skipped for method_time != 'year'.
-        digits = self.env['decimal.precision'].precision_get('Account')
-        fy_residual_amount = self.depreciation_base
-        i_max = len(table) - 1
-        asset_sign = self.depreciation_base >= 0 and 1 or -1
         line_dates = self._compute_line_dates(
             table, depreciation_start_date, depreciation_stop_date)
-        for i, entry in enumerate(table):
-
-            if self.method_time == 'year':
-                year_amount = self._compute_year_amount(fy_residual_amount)
-                if self.method_period == 'year':
-                    period_amount = year_amount
-                elif self.method_period == 'quarter':
-                    period_amount = year_amount / 4
-                elif self.method_period == 'month':
-                    period_amount = year_amount / 12
-                if i == i_max:
-                    if self.method in ['linear-limit', 'degr-limit']:
-                        fy_amount = fy_residual_amount - self.salvage_value
-                    else:
-                        fy_amount = fy_residual_amount
-                else:
-                    firstyear = i == 0 and True or False
-                    fy_factor = self._get_fy_duration_factor(
-                        entry, firstyear)
-                    fy_amount = year_amount * fy_factor
-                if asset_sign * (fy_amount - fy_residual_amount) > 0:
-                    fy_amount = fy_residual_amount
-                period_amount = round(period_amount, digits)
-                fy_amount = round(fy_amount, digits)
-            else:
-                fy_amount = False
-                if self.method_time == 'number':
-                    number = self.method_number
-                elif self.method_time == 'end':
-                    number = len(line_dates)
-                period_amount = round(self.depreciation_base / number, digits)
-
-            entry.update({
-                'period_amount': period_amount,
-                'fy_amount': fy_amount,
-            })
-            if self.method_time == 'year':
-                fy_residual_amount -= fy_amount
-                if round(fy_residual_amount, digits) == 0:
-                    break
-        i_max = i
-        table = table[:i_max + 1]
-
+        table = self._compute_depreciation_amount_per_fiscal_year(
+            table, line_dates,
+        )
         # Step 2:
         # Spread depreciation amount per fiscal year
         # over the depreciation periods.

--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -45,6 +45,10 @@ class AccountAssetLine(models.Model):
         string='Amount Already Depreciated',
         store=True)
     line_date = fields.Date(string='Date', required=True)
+    line_days = fields.Integer(
+        string='Days',
+        readonly=True,
+    )
     move_id = fields.Many2one(
         comodel_name='account.move',
         string='Depreciation Entry', readonly=True)

--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -88,6 +88,10 @@ class AccountAssetProfile(models.Model):
              "number of depreciation lines.\n"
              "  * Number of Years: Specify the number of years "
              "for the depreciation.\n")
+    days_calc = fields.Boolean(
+        string='Calculate by days',
+        default=False,
+        help="Use number of days to calculate depreciation amount")
     prorata = fields.Boolean(
         string='Prorata Temporis',
         help="Indicates that the first depreciation entry for this asset "

--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -151,7 +151,7 @@ class AccountAssetProfile(models.Model):
         'Number' and 'End' Time Methods.
         """
         return [
-            ('year', _('Number of Years')),
+            ('year', _('Number of Years or end date')),
         ]
 
     @api.multi

--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -92,6 +92,18 @@ class AccountAssetProfile(models.Model):
         string='Calculate by days',
         default=False,
         help="Use number of days to calculate depreciation amount")
+    use_leap_years = fields.Boolean(
+        string='Use leap years',
+        default=False,
+        help="If not set, the system will distribute evenly the amount to "
+             "amortize across the years, based on the number of years. "
+             "So the amount per year will be the "
+             "depreciation base / number of years.\n "
+             "If set, the system will consider if the current year "
+             "is a leap year. The amount to depreciate per year will be "
+             "calculated as depreciation base / (depreciation end date - "
+             "start date + 1) * days in the current year.",
+    )
     prorata = fields.Boolean(
         string='Prorata Temporis',
         help="Indicates that the first depreciation entry for this asset "

--- a/account_asset_management/readme/CONTRIBUTORS.rst
+++ b/account_asset_management/readme/CONTRIBUTORS.rst
@@ -6,3 +6,5 @@
 - Adrien Peiffer (Acsone)
 - Akim Juillerat <akim.juillerat@camptocamp.com>
 - Maxence Groine <mgroine@fiefmanage.ch>
+- Kitti Upariphutthiphong <kittiu@ecosoft.co.th>
+- Saran Lim. <saranl@ecosoft.co.th>

--- a/account_asset_management/readme/HISTORY.rst
+++ b/account_asset_management/readme/HISTORY.rst
@@ -1,0 +1,4 @@
+11.0.1.1.0 (2019-10-17)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [IMP] Add option to calculate depreciation table by days

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -530,15 +530,15 @@ class TestAssetManagement(SavepointCase):
             'method_period': 'month',
             'prorata': True,
             'days_calc': True,
+            'use_leap_years': False,
         })
         asset.compute_depreciation_board()
         asset.refresh()
-        day_rate = 0.0
         if calendar.isleap(date.today().year) or \
                 calendar.isleap(date.today().year + 1):
-            day_rate = 1.82  # 3333 / 1827 depreciation days
+            day_rate = 3333 / 1827  # 3333 / 1827 depreciation days
         else:
-            day_rate = 1.83  # 3333 / 1826 depreciation days
+            day_rate = 3333 / 1826  # 3333 / 1826 depreciation days
         for i in range(1, 10):
             self.assertAlmostEqual(
                 asset.depreciation_line_ids[i].amount,
@@ -548,7 +548,63 @@ class TestAssetManagement(SavepointCase):
         if calendar.isleap(date.today().year) or \
                 calendar.isleap(date.today().year + 1):
             self.assertAlmostEqual(
-                asset.depreciation_line_ids[-1].amount, 18.78, places=2)
+                asset.depreciation_line_ids[-1].amount, 11.05, places=2)
         else:
             self.assertAlmostEqual(
-                asset.depreciation_line_ids[-1].amount, 2.4, places=2)
+                asset.depreciation_line_ids[-1].amount, 11.05, places=2)
+
+    def test_13_use_leap_year(self):
+        # When you use the depreciation with years method and using lap years,
+        # the depreciation amount is calculated as 10000 / 1826 days * 365 days
+        # = yearly depreciation amount of 1998.90.
+        # Then 1998.90 / 12 = 166.58
+        asset = self.asset_model.create({
+            'name': 'test asset',
+            'profile_id': self.ref('account_asset_management.'
+                                   'account_asset_profile_car_5Y'),
+            'purchase_value': 10000,
+            'salvage_value': 0,
+            'date_start': time.strftime('2019-01-01'),
+            'method_time': 'year',
+            'method_number': 5,
+            'method_period': 'month',
+            'prorata': False,
+            'days_calc': False,
+            'use_leap_years': True,
+        })
+        asset.compute_depreciation_board()
+        asset.refresh()
+        for i in range(2, 11):
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[i].amount, 166.58, places=2)
+        self.assertAlmostEqual(
+            asset.depreciation_line_ids[13].depreciated_value, 1998.90,
+            places=2)
+
+    def test_14_not_use_leap_year(self):
+        # When you run a depreciation with method = 'year' and no not use
+        # lap years you divide 1000 / 5 years = 2000, then divided by 12 months
+        # to get 166.67 per month, equal for all periods.
+        asset = self.asset_model.create({
+            'name': 'test asset',
+            'profile_id': self.ref('account_asset_management.'
+                                   'account_asset_profile_car_5Y'),
+            'purchase_value': 10000,
+            'salvage_value': 0,
+            'date_start': time.strftime('2019-01-01'),
+            'method_time': 'year',
+            'method_number': 5,
+            'method_period': 'month',
+            'prorata': False,
+            'days_calc': False,
+            'use_leap_years': False,
+        })
+        asset.compute_depreciation_board()
+        asset.refresh()
+        for i in range(1, 11):
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[1].amount, 166.67, places=2)
+        # In the last month of the fiscal year we compensate for the small
+        # deviations if that is necessary.
+        self.assertAlmostEqual(
+            asset.depreciation_line_ids[12].amount, 166.63, places=2)

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -515,3 +515,40 @@ class TestAssetManagement(SavepointCase):
             dlines = dlines.sorted(key=lambda l: l.line_date)
             self.assertAlmostEqual(dlines[0].depreciated_value, 0.0)
             self.assertAlmostEqual(dlines[-1].remaining_value, 0.0)
+
+    def test_12_prorata_days_calc(self):
+        """Prorata temporis depreciation with days calc option."""
+        asset = self.asset_model.create({
+            'name': 'test asset',
+            'profile_id': self.ref('account_asset_management.'
+                                   'account_asset_profile_car_5Y'),
+            'purchase_value': 3333,
+            'salvage_value': 0,
+            'date_start': time.strftime('%Y-07-07'),
+            'method_time': 'year',
+            'method_number': 5,
+            'method_period': 'month',
+            'prorata': True,
+            'days_calc': True,
+        })
+        asset.compute_depreciation_board()
+        asset.refresh()
+        day_rate = 0.0
+        if calendar.isleap(date.today().year) or \
+                calendar.isleap(date.today().year + 1):
+            day_rate = 1.82  # 3333 / 1827 depreciation days
+        else:
+            day_rate = 1.83  # 3333 / 1826 depreciation days
+        for i in range(1, 10):
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[i].amount,
+                asset.depreciation_line_ids[i].line_days * day_rate, places=2)
+
+        # Last depreciation remaining
+        if calendar.isleap(date.today().year) or \
+                calendar.isleap(date.today().year + 1):
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[-1].amount, 18.78, places=2)
+        else:
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[-1].amount, 2.4, places=2)

--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -74,6 +74,7 @@
                   <field name="method_period"/>
                   <field name="method_end"
                          attrs="{'required': [('method_time', '=', 'end')], 'invisible': [('method_time', 'in', ['number', 'year'])]}"/>
+                  <field name="days_calc"/>
                 </group>
                 <group>
                   <separator string="Depreciation Method" colspan="2"/>
@@ -94,6 +95,7 @@
                 <tree string="Asset Lines" decoration-info="(move_check == False) and (init_entry == False)" create="false">
                   <field name="type"/>
                   <field name="line_date"/>
+                  <field name="line_days" sum="Total Days"/>
                   <field name="depreciated_value" readonly="1"/>
                   <field name="amount"/>
                   <field name="remaining_value" readonly="1"/>

--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -75,6 +75,8 @@
                   <field name="method_end"
                          attrs="{'required': [('method_time', '=', 'end')], 'invisible': [('method_time', 'in', ['number', 'year'])]}"/>
                   <field name="days_calc"/>
+                  <field name="use_leap_years"
+                         attrs="{'invisible': [('days_calc', '=', True)]}"/>
                 </group>
                 <group>
                   <separator string="Depreciation Method" colspan="2"/>

--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -73,7 +73,7 @@
                          attrs="{'invisible': [('method_time', '=', 'end')], 'required': [('method_time', 'in', ['number', 'year'])]}"/>
                   <field name="method_period"/>
                   <field name="method_end"
-                         attrs="{'required': [('method_time', '=', 'end')], 'invisible': [('method_time', 'in', ['number', 'year'])]}"/>
+                         attrs="{'required': [('method_time', '=', 'end')], 'invisible': [('method_time', 'in', ['number'])]}"/>
                   <field name="days_calc"/>
                   <field name="use_leap_years"
                          attrs="{'invisible': [('days_calc', '=', True)]}"/>

--- a/account_asset_management/views/account_asset_profile.xml
+++ b/account_asset_management/views/account_asset_profile.xml
@@ -29,6 +29,7 @@
               <field name="method_number"
                      attrs="{'invisible': [('method_time', '=', 'end')], 'required': [('method_time', 'in', ['number', 'year'])]}"/>
               <field name="method_period"/>
+              <field name="days_calc"/>
             </group>
             <group string="Depreciation Method">
               <field name="method"/>

--- a/account_asset_management/views/account_asset_profile.xml
+++ b/account_asset_management/views/account_asset_profile.xml
@@ -30,6 +30,8 @@
                      attrs="{'invisible': [('method_time', '=', 'end')], 'required': [('method_time', 'in', ['number', 'year'])]}"/>
               <field name="method_period"/>
               <field name="days_calc"/>
+              <field name="use_leap_years"
+                     attrs="{'invisible': [('days_calc', '=', True)]}"/>
             </group>
             <group string="Depreciation Method">
               <field name="method"/>


### PR DESCRIPTION
This is a backport of https://github.com/OCA/account-financial-tools/pull/852
Includes backport of https://github.com/OCA/account-financial-tools/commit/85a305dfe0e3893bb9db25289e2209431dc3d5c3

Includes also an option to use leap years in the calculation of the periodic amounts to depreciate. 
If not set, the system will distribute evenly the amount to amortize across the years, based on the number of years. So the amount per year will be the depreciation base / number of years.

If set, the system will consider if the current year is a leap year. The amount to depreciate per year will be calculated as depreciation base / (depreciation end date - start date + 1) * days in the current year.
