### PR TITLE
[12.0][FIX][account_asset_management] local variable 'asset' referenced before assignment

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -1035,8 +1035,10 @@ class AccountAsset(models.Model):
             except Exception:
                 e = exc_info()[0]
                 tb = ''.join(format_exception(*exc_info()))
-                asset_ref = depreciation.asset_id.code and '%s (ref: %s)' \
-                    % (asset.name, asset.code) or asset.name
+                asset_ref = depreciation.asset_id.name
+                if depreciation.asset_id.code:
+                    asset_ref = '[%s] %s' % (
+                        depreciation.asset_id.code, asset_ref)
                 error_log += _(
                     "\nError while processing asset '%s': %s"
                 ) % (asset_ref, str(e))


### PR DESCRIPTION
- Fix

local variable 'asset' referenced before assignment

tools/account_asset_management/models/account_asset.py", line 970, in _compute_entries
    % (asset.name, asset.code) or asset.name
UnboundLocalError: local variable 'asset' referenced before assignment

