### PR TITLE
[10.0][FIX] Fix account_asset_management

### DIFF
--- a/account_asset_management/tests/account_asset_test_data.xml
+++ b/account_asset_management/tests/account_asset_test_data.xml
@@ -97,5 +97,19 @@
       <field name="profile_id" ref="account_asset_profile_car_5Y"/>
     </record>
 
+    <record id="account_asset_asset_mini_car" model="account.asset">
+      <field name="parent_id" ref="account_asset_view_vehicle"/>
+      <field name="state">draft</field>
+      <field name="method_time">year</field>
+      <field name="method_number" eval="6"/>
+      <field name="method_period">quarter</field>
+      <field name="date_start" eval="time.strftime('2008-01-01')"/>
+      <field name="name">Mini car</field>
+      <field name="method">linear</field>
+      <field name="purchase_value" eval="5000.0"/>
+      <field name="salvage_value" eval="0"/>
+      <field name="profile_id" ref="account_asset_profile_car_5Y"/>
+    </record>
+
   </data>
 </odoo>

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -290,43 +290,42 @@ class AccountAssetRemove(models.TransientModel):
         }
         move_lines.append((0, 0, move_line_vals))
 
-        if residual_value:
-            if self.posting_regime == 'residual_value':
+        if self.posting_regime == 'residual_value':
+            move_line_vals = {
+                'name': asset.name,
+                'account_id': self.account_residual_value_id.id,
+                'analytic_account_id': asset.account_analytic_id.id,
+                'debit': residual_value,
+                'credit': 0.0,
+                'partner_id': partner_id,
+                'asset_id': asset.id
+            }
+            move_lines.append((0, 0, move_line_vals))
+        elif self.posting_regime == 'gain_loss_on_sale':
+            if self.sale_value:
+                sale_value = self.sale_value
                 move_line_vals = {
                     'name': asset.name,
-                    'account_id': self.account_residual_value_id.id,
+                    'account_id': self.account_sale_id.id,
                     'analytic_account_id': asset.account_analytic_id.id,
-                    'debit': residual_value,
+                    'debit': sale_value,
                     'credit': 0.0,
                     'partner_id': partner_id,
                     'asset_id': asset.id
                 }
                 move_lines.append((0, 0, move_line_vals))
-            elif self.posting_regime == 'gain_loss_on_sale':
-                if self.sale_value:
-                    sale_value = self.sale_value
-                    move_line_vals = {
-                        'name': asset.name,
-                        'account_id': self.account_sale_id.id,
-                        'analytic_account_id': asset.account_analytic_id.id,
-                        'debit': sale_value,
-                        'credit': 0.0,
-                        'partner_id': partner_id,
-                        'asset_id': asset.id
-                    }
-                    move_lines.append((0, 0, move_line_vals))
-                balance = self.sale_value - residual_value
-                account_id = (self.account_plus_value_id.id
-                              if balance > 0
-                              else self.account_min_value_id.id)
-                move_line_vals = {
-                    'name': asset.name,
-                    'account_id': account_id,
-                    'analytic_account_id': asset.account_analytic_id.id,
-                    'debit': balance < 0 and -balance or 0.0,
-                    'credit': balance > 0 and balance or 0.0,
-                    'partner_id': partner_id,
-                    'asset_id': asset.id
-                }
-                move_lines.append((0, 0, move_line_vals))
+            balance = self.sale_value - residual_value
+            account_id = (self.account_plus_value_id.id
+                          if balance > 0
+                          else self.account_min_value_id.id)
+            move_line_vals = {
+                'name': asset.name,
+                'account_id': account_id,
+                'analytic_account_id': asset.account_analytic_id.id,
+                'debit': balance < 0 and -balance or 0.0,
+                'credit': balance > 0 and balance or 0.0,
+                'partner_id': partner_id,
+                'asset_id': asset.id
+            }
+            move_lines.append((0, 0, move_line_vals))
         return move_lines


### PR DESCRIPTION
Fix module _account_asset_management_.

**How to reproduce:**
Create an asset with a residual amount at 0.
Then "remove"/sell it with a price.
Validate the wizard and check account move lines generated.
You can notice that the selling amount doesn't appear anywhere.

**Fix:**
During the "remove", generate move lines about the selling price.

**Note for reviewers:**
The diff seems very strange. I only remove the `if residual_value:` but `git` see that like 2 different parts (1 creation then a big delete). But only the indent change.