### PR TITLE
[11.0][FIX] account_move_fiscal_*: remove "store=True"

### DIFF
--- a/account_move_fiscal_month/models/account_move_line.py
+++ b/account_move_fiscal_month/models/account_move_line.py
@@ -9,5 +9,6 @@ class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
     date_range_fm_id = fields.Many2one(
-        related='move_id.date_range_fm_id', readonly=True,
-        store=True, copy=False)
+        related='move_id.date_range_fm_id',
+        readonly=True,
+    )

--- a/account_move_fiscal_year/models/account_move_line.py
+++ b/account_move_fiscal_year/models/account_move_line.py
@@ -9,5 +9,6 @@ class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
     date_range_fy_id = fields.Many2one(
-        related='move_id.date_range_fy_id', readonly=True,
-        store=True, copy=False)
+        related='move_id.date_range_fy_id',
+        readonly=True,
+    )


### PR DESCRIPTION
It doesn't make sense to store a field that is related to a non-stored computed field.