### PR TITLE
[12.0][FIX]traceback when deviating FY

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import calendar
-from datetime import datetime
+from datetime import date
 from dateutil.relativedelta import relativedelta
 import logging
 from sys import exc_info
@@ -626,11 +626,11 @@ class AccountAsset(models.Model):
                         duration = (fy_date_stop - fy_date_start).days + 1
                     else:
                         duration = (
-                            datetime(year, 12, 31).date() - fy_date_start).days + 1
+                            date(year, 12, 31) - fy_date_start).days + 1
                     factor = float(duration) / cy_days
                 elif i == cnt - 1:  # last year
                     duration = (
-                        fy_date_stop - datetime(year, 1, 1).date()).days + 1
+                        fy_date_stop - date(year, 1, 1)).days + 1
                     factor += float(duration) / cy_days
                 else:
                     factor += 1.0

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -626,11 +626,11 @@ class AccountAsset(models.Model):
                         duration = (fy_date_stop - fy_date_start).days + 1
                     else:
                         duration = (
-                            datetime(year, 12, 31) - fy_date_start).days + 1
+                            datetime(year, 12, 31).date() - fy_date_start).days + 1
                     factor = float(duration) / cy_days
                 elif i == cnt - 1:  # last year
                     duration = (
-                        fy_date_stop - datetime(year, 1, 1)).days + 1
+                        fy_date_stop - datetime(year, 1, 1).date()).days + 1
                     factor += float(duration) / cy_days
                 else:
                     factor += 1.0


### PR DESCRIPTION
depreciation table compute fails when fiscal year is not aligned with calendar year:
  File "/opt/odoo12/OCA/account-financial-tools/account_asset_management/models/account_asset.py", line 629, in _get_fy_duration
    datetime(year, 12, 31) - fy_date_start).days + 1
TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'datetime.date'

