### PR TITLE
[12.0][FIX]  account_asset_management: asset table wrong leapyear calc

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -866,6 +866,16 @@ class AccountAsset(models.Model):
                 else:
                     number = len(line_dates)
                 period_amount = round(self.depreciation_base / number, digits)
+            if self.method[:4] == 'degr':
+                if i == 0:
+                    days = (
+                        entry['date_stop'] - depreciation_start_date).days + 1
+                elif i == i_max:
+                    days = (
+                        depreciation_stop_date - entry['date_start']).days + 1
+                else:
+                    days = (entry['date_stop'] - entry['date_start']).days + 1
+                day_amount = fy_amount / days
             entry.update({
                 'period_amount': period_amount,
                 'fy_amount': fy_amount,

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -619,8 +619,8 @@ class AccountAsset(models.Model):
         elif option == 'years':
             year = fy_date_start.year
             cnt = fy_date_stop.year - fy_date_start.year + 1
+            cy_days = isleap(fy) and 366 or 365
             for i in range(cnt):
-                cy_days = calendar.isleap(year) and 366 or 365
                 if i == 0:  # first year
                     if fy_date_stop.year == year:
                         duration = (fy_date_stop - fy_date_start).days + 1
@@ -1059,3 +1059,18 @@ class AccountAsset(models.Model):
                 triggers.sudo().write(recompute_vals)
 
         return (result, error_log)
+
+
+def isleap(fy):
+    """
+    A fiscalyear is considered a leap year when the last day of february
+    within the fiscalyear falls in a leap year.
+    """
+    isleap = False
+    end_of_month = fy.date_from + relativedelta(day=31)
+    while end_of_month <= fy.date_to:
+        if end_of_month.month == 2 and end_of_month.day == 29:
+            isleap = True
+            break
+        end_of_month = end_of_month + relativedelta(months=1, day=31)
+    return isleap

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -174,12 +174,8 @@ class TestAssetManagement(SavepointCase):
         })
         asset.compute_depreciation_board()
         asset.refresh()
-        if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount,
-                                   46.44, places=2)
-        else:
-            self.assertAlmostEqual(asset.depreciation_line_ids[1].amount,
-                                   47.33, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[1].amount,
+                               45.63, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[2].amount,
                                55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[3].amount,
@@ -189,7 +185,7 @@ class TestAssetManagement(SavepointCase):
         self.assertAlmostEqual(asset.depreciation_line_ids[5].amount,
                                55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[6].amount,
-                               55.55, places=2)
+                               56.36, places=2)
         if calendar.isleap(date.today().year):
             self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount,
                                    9.11, places=2)


### PR DESCRIPTION
This PR fixes the following 'leap year' calculation error:

Consider an asset of 5000 EUR, depreciated of 5 years, pro-rata temporis, linear depreciation.
Fiscal year terminates at june 30.
Asset start date is 2015-01-28.
The pro-rata temporis calc should result in the following depreciation amounts:
2015-06-30: 421.92 EUR
2016-06-30 up to 20106-30 : 1000 EUR
2020-06-30: 578,08 EUR

But is goes wrong (without this patch) because 2016 is a leap year.