### PR TITLE
[12.0] account_asset_management Fix name of view called when errors occur

### DIFF
--- a/account_asset_management/wizard/account_asset_compute.py
+++ b/account_asset_management/wizard/account_asset_compute.py
@@ -26,7 +26,7 @@ class AccountAssetCompute(models.TransientModel):
             module = __name__.split('addons.')[1].split('.')[0]
             result_view = self.env.ref(
                 '%s.%s_view_form_result'
-                % (module, self._name))
+                % (module, self._table))
             self.note = _("Compute Assets errors") + ':\n' + error_log
             return {
                 'name': _('Compute Assets result'),


### PR DESCRIPTION
When the wizard account_asset_compute encounters an error, it logs it. At the end of the process, the the wizard display all errors in a view whose ref is dynamically built. Currently this fails because in building of the view name, the object name is inserted as is. However, dots in the object name should be replaced by underscores.