### PR TITLE
[13.0][FIX] account_move_line_purchase_info: Overwrite _compute_invoice

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -9,4 +9,4 @@ line_length=88
 known_odoo=odoo
 known_odoo_addons=odoo.addons
 sections=FUTURE,STDLIB,THIRDPARTY,ODOO,ODOO_ADDONS,FIRSTPARTY,LOCALFOLDER
-known_third_party=dateutil,setuptools
+known_third_party=dateutil,openupgradelib,setuptools

--- a/account_move_line_purchase_info/__manifest__.py
+++ b/account_move_line_purchase_info/__manifest__.py
@@ -1,11 +1,11 @@
-# Copyright 2019 ForgeFlow S.L.
+# Copyright 2019-2020 ForgeFlow S.L.
 #   (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Account Move Line Purchase Info",
     "summary": "Introduces the purchase order line to the journal items",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.1.0",
     "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://www.github.com/OCA/account-financial-tools",
     "category": "Generic",

--- a/account_move_line_purchase_info/migrations/13.0.1.1.0/post-migration.py
+++ b/account_move_line_purchase_info/migrations/13.0.1.1.0/post-migration.py
@@ -1,0 +1,13 @@
+# Copyright 2020 ForgeFlow (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    pos = (
+        env["account.move.line"]
+        .search([("purchase_id", "!=", False), ("move_id.type", "=", "entry")])
+        .mapped("purchase_id")
+    )
+    pos._compute_invoice()

--- a/account_move_line_purchase_info/models/purchase_order_line.py
+++ b/account_move_line_purchase_info/models/purchase_order_line.py
@@ -1,8 +1,23 @@
-# Copyright 2019 ForgeFlow S.L.
+# Copyright 2019-2020 ForgeFlow S.L.
 #   (https://www.forgeflow.com)
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import api, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    @api.depends("order_line.invoice_lines.move_id")
+    def _compute_invoice(self):
+        """Overwritten compute to avoid show all Journal Entries with
+        purchase_order_line as invoice_lines One2many would take them into account."""
+        for order in self:
+            invoices = order.mapped("order_line.invoice_lines.move_id").filtered(
+                lambda m: m.is_invoice(include_receipts=True)
+            )
+            order.invoice_ids = [(6, 0, invoices.ids)]
+            order.invoice_count = len(invoices)
 
 
 class PurchaseOrderLine(models.Model):

--- a/account_move_line_purchase_info/readme/CONTRIBUTORS.rst
+++ b/account_move_line_purchase_info/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
+* Héctor Villarreal <hector.villarreal@forgeflow.com>

--- a/account_move_line_purchase_info/tests/test_account_move_line_purchase_info.py
+++ b/account_move_line_purchase_info/tests/test_account_move_line_purchase_info.py
@@ -76,9 +76,9 @@ class TestAccountMoveLinePurchaseInfo(common.TransactionCase):
         )
         return user.id
 
-    def _create_account_type(self, name, type):
+    def _create_account_type(self, name, a_type):
         acc_type = self.acc_type_model.create(
-            {"name": name, "type": type, "internal_group": name}
+            {"name": name, "type": a_type, "internal_group": name}
         )
         return acc_type
 


### PR DESCRIPTION
On v13 Invoice Smart Button on Purchase Order is computed with a [invoice_lines](https://github.com/odoo/odoo/blob/761ae16634b14bec7be522666bb2163490566ecc/addons/purchase/models/purchase.py#L461). As in this module we are adding purchase_order_line on every stock_move_line, this overwrite is required to filter invoices correctly.

CC @ForgeFlow @LoisRForgeFlow @AaronHForgeFlow @AdriaGForgeFlow 

PD: don't bump version