### PR TITLE
[12.0][ENH] account_spreaad_cost_revenue, add optional exp/rev account

### DIFF
--- a/account_spread_cost_revenue/models/account_spread.py
+++ b/account_spread_cost_revenue/models/account_spread.py
@@ -44,6 +44,9 @@ class AccountSpread(models.Model):
         default='month',
         help="Period length for the entries",
         required=True)
+    use_invoice_line_account = fields.Boolean(
+        string="Use invoice line's account",
+    )
     credit_account_id = fields.Many2one(
         'account.account',
         string='Credit Account',

--- a/account_spread_cost_revenue/readme/CONTRIBUTORS.rst
+++ b/account_spread_cost_revenue/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Andrea Stirpe <a.stirpe@onestein.nl>
+* Kitti U. <kittiu@ecosoft.co.th>

--- a/account_spread_cost_revenue/readme/HISTORY.rst
+++ b/account_spread_cost_revenue/readme/HISTORY.rst
@@ -1,3 +1,10 @@
+12.0.1.1.0
+~~~~~~~~~~
+
+* [ENH] Add optional Expense/Revenue Account in Chart Template, which can be used
+  in place of account from invoice line to set Expense/Revenue account in the spread
+
+
 12.0.1.0.0
 ~~~~~~~~~~
 

--- a/account_spread_cost_revenue/readme/USAGE.rst
+++ b/account_spread_cost_revenue/readme/USAGE.rst
@@ -69,6 +69,7 @@ Under Invoicing -> Configuration -> Accounting -> Spread Templates, create a new
 
 * *Spread Type*
 * *Spread Balance Sheet Account*
+* *Expense/Revenue Account* This option visible if invoice line account is balance sheet account, user need to specify this too.
 * *Journal*
 
 When creating a new Spread Costs/Revenues Board, select the right template.

--- a/account_spread_cost_revenue/views/account_spread.xml
+++ b/account_spread_cost_revenue/views/account_spread.xml
@@ -37,6 +37,7 @@
                             <field name="display_recompute_buttons" invisible="1"/>
                             <field name="display_move_line_auto_post" invisible="1"/>
                             <field name="all_posted" invisible="1"/>
+                            <field name="use_invoice_line_account" invisible="1"/>
                         </group>
                     </group>
                     <group name="accounts">
@@ -46,14 +47,26 @@
                                    attrs="{'invisible':[('invoice_type','not in',('out_invoice','in_refund'))]}"/>
                             <label for="debit_account_id" colspan="3" string="Expense account"
                                    attrs="{'invisible':[('invoice_type','not in',('in_invoice','out_refund'))]}"/>
-                            <span class="help-block" colspan="2"
-                                  attrs="{'invisible':[('invoice_type','not in',('out_invoice','in_refund'))]}">
-                                  The Balance Sheet account used for the spreading.<br/>This account is the counterpart of the account in the invoice line.
-                            </span>
-                            <span class="help-block" colspan="2"
-                                  attrs="{'invisible':[('invoice_type','not in',('in_invoice','out_refund'))]}">
-                                  The Expense account in the vendor bill line.<br/>Usually the same account of the vendor bill line.
-                            </span>
+                            <div attrs="{'invisible': [('use_invoice_line_account', '=', True)]}" colspan="2">
+                                <span class="help-block" colspan="2"
+                                      attrs="{'invisible':[('invoice_type','not in',('out_invoice','in_refund'))]}">
+                                      The Balance Sheet account used for the spreading.<br/>This account is the counterpart of the account in the invoice line.
+                                </span>
+                                <span class="help-block" colspan="2"
+                                      attrs="{'invisible':[('invoice_type','not in',('in_invoice','out_refund'))]}">
+                                      The Expense account in the vendor bill line.<br/>Usually the same account of the vendor bill line.
+                                </span>
+                            </div>
+                            <div attrs="{'invisible': [('use_invoice_line_account', '!=', True)]}" colspan="2">
+                                <span class="help-block" colspan="2"
+                                      attrs="{'invisible':[('invoice_type','not in',('out_invoice','in_refund'))]}">
+                                      The Balance Sheet account.<br/>This is the account in the invoice line.
+                                </span>
+                                <span class="help-block" colspan="2"
+                                      attrs="{'invisible':[('invoice_type','not in',('in_invoice','out_refund'))]}">
+                                      The Expense account used for the spreading.<br/>This account is the counterpart of the account of the vendor bill line.
+                                </span>
+                            </div>
                             <field name="debit_account_id" required="1" domain="[('company_id', '=', company_id), ('deprecated', '=', False)]" attrs="{'readonly':[('invoice_line_id','!=',False)]}"/>
                             <span class="help-block text-danger" colspan="2"
                                   attrs="{'invisible':[('is_debit_account_deprecated','!=',True)]}">
@@ -66,14 +79,26 @@
                                    attrs="{'invisible':[('invoice_type','not in',('out_invoice','in_refund'))]}"/>
                             <label for="credit_account_id" colspan="3" string="Balance sheet account / Spread account"
                                    attrs="{'invisible':[('invoice_type','not in',('in_invoice','out_refund'))]}"/>
-                            <span class="help-block" colspan="2"
-                                  attrs="{'invisible':[('invoice_type','not in',('out_invoice','in_refund'))]}">
-                                  The Revenue account in the invoice line.<br/>Usually the same account of the invoice line.
-                            </span>
-                            <span class="help-block" colspan="2"
-                                  attrs="{'invisible':[('invoice_type','not in',('in_invoice','out_refund'))]}">
-                                  The Balance Sheet account used for the spreading.<br/>This account is the counterpart of the account in the vendor bill line.
-                            </span>
+                            <div attrs="{'invisible': [('use_invoice_line_account', '=', True)]}" colspan="2">
+                                <span class="help-block" colspan="2"
+                                      attrs="{'invisible':[('invoice_type','not in',('out_invoice','in_refund'))]}">
+                                      The Revenue account in the invoice line.<br/>Usually the same account of the invoice line.
+                                </span>
+                                <span class="help-block" colspan="2"
+                                      attrs="{'invisible':[('invoice_type','not in',('in_invoice','out_refund'))]}">
+                                      The Balance Sheet account used for the spreading.<br/>This account is the counterpart of the account in the vendor bill line.
+                                </span>
+                            </div>
+                            <div attrs="{'invisible': [('use_invoice_line_account', '!=', True)]}" colspan="2">
+                                <span class="help-block" colspan="2"
+                                      attrs="{'invisible':[('invoice_type','not in',('out_invoice','in_refund'))]}">
+                                      The Revenue account used for the spreading.<br/>This account is the counterpart of the account of the invoice line.
+                                </span>
+                                <span class="help-block" colspan="2"
+                                      attrs="{'invisible':[('invoice_type','not in',('in_invoice','out_refund'))]}">
+                                      The Balance Sheet account.<br/>This is the account in the vendor bill line.
+                                </span>
+                            </div>
                             <field name="credit_account_id" required="1" domain="[('company_id', '=', company_id), ('deprecated', '=', False)]" attrs="{'readonly':[('invoice_line_id','!=',False)]}"/>
                             <span class="help-block text-danger" colspan="2"
                                   attrs="{'invisible':[('is_credit_account_deprecated','!=',True)]}">

--- a/account_spread_cost_revenue/views/account_spread_template.xml
+++ b/account_spread_cost_revenue/views/account_spread_template.xml
@@ -21,7 +21,10 @@
                             <field name="start_date"/>
                         </group>
                         <group>
-                            <field name="spread_account_id" domain="[('company_id', '=', company_id), ('deprecated', '=', False)]" options="{'no_create': True}"/>
+                            <field name="use_invoice_line_account"/>
+                            <field name="spread_account_id" domain="[('company_id', '=', company_id), ('deprecated', '=', False)]" options="{'no_create': True}"
+                              attrs="{'required': [('use_invoice_line_account', '!=', True)], 'invisible': [('use_invoice_line_account', '=', True)]}" />
+                            <field name="exp_rev_account_id" attrs="{'invisible': ['|', ('use_invoice_line_account', '=', False)], 'required': [('use_invoice_line_account', '=', True)]}" domain="[('company_id', '=', company_id), ('deprecated', '=', False)]" options="{'no_create': True}"/>
                             <field name="spread_journal_id" domain="[('company_id', '=', company_id)]" widget="selection"/>
                         </group>
                     </group>

--- a/account_spread_cost_revenue/wizards/account_spread_invoice_line_link_wizard.xml
+++ b/account_spread_cost_revenue/wizards/account_spread_invoice_line_link_wizard.xml
@@ -17,7 +17,9 @@
                         <field name="spread_action_type" widget="radio"/>
                         <field name="spread_id" attrs="{'invisible': [('spread_action_type', '!=', 'link')],'required': [('spread_action_type', '=', 'link')]}" domain="[('invoice_type', '=', invoice_type)]" options="{'no_create': True}"/>
                         <field name="template_id" attrs="{'invisible': [('spread_action_type', '!=', 'template')],'required': [('spread_action_type', '=', 'template')]}" domain="[('spread_type', '=', spread_type)]" options="{'no_create': True}"/>
+                        <field name="use_invoice_line_account" attrs="{'invisible': [('spread_action_type', '!=', 'new')]}"/>
                         <field name="spread_account_id" attrs="{'invisible': [('spread_action_type', '!=', 'new')],'required': [('spread_action_type', '=', 'new')]}" domain="[('company_id', '=', company_id), ('deprecated', '=', False)]" options="{'no_create': True}"/>
+                        <field name="exp_rev_account_id" attrs="{'invisible': ['|', ('use_invoice_line_account', '=', False), ('spread_action_type', '!=', 'new')], 'required': [('use_invoice_line_account', '=', True)]}" domain="[('company_id', '=', company_id), ('deprecated', '=', False)]" options="{'no_create': True}"/>
                         <field name="spread_journal_id" attrs="{'invisible': [('spread_action_type', '!=', 'new')],'required': [('spread_action_type', '=', 'new')]}" domain="[('company_id', '=', company_id)]" options="{'no_create': True}"/>
                     </group>
                 </group>


### PR DESCRIPTION
This enhancement did the following,

- Add new optional field `exp_rev_account_id` to Wizard (case new spread), and Spread Template
- If has value, use it to overwrite Expense/Revenue on Spread (instead of account from invoice line)

With the above small changes, it can answer the case when Invoice line is using B/L account, (i.e., Prepaid) and want to recognize/spread it to Expense/Revenue account.

For example,
- Customer Invoice line account = Prepaid Revenue
- Dr: Account Receivable
  - Cr: Prepaid Revenue (use spread_account_id)

And for spread table,
- Dr: Prepaid Revenue
  - Cr: Revenue (use optional exp_rev_account_id instead of invoice line's)
