### PR TITLE
[REF] 4722 Bug in filter_domain for integer values

### DIFF
--- a/account_group_menu/views/account_tax_group.xml
+++ b/account_group_menu/views/account_tax_group.xml
@@ -33,7 +33,7 @@
             <field name="arch" type="xml">
                 <search string="Account Tax Groups">
                     <field name="name"
-                           filter_domain="['|', ('sequence', '=like', str(self) + '%'), ('name', 'ilike', self)]"
+                           filter_domain="['|', ('sequence', 'ilike', self), ('name', 'ilike', self)]"
                            string="Account Tax Group"/>
                 </search>
             </field>


### PR DESCRIPTION
Account Tax Group filter_domain is changed since entering an integer search term gives an error (ValueError: invalid literal for int () with base 10: '700%').