### PR TITLE
[12.0] [IMP] Depreciation board compute upon asset confirmation

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -410,6 +410,10 @@ class AccountAsset(models.Model):
                 asset.state = 'close'
             else:
                 asset.state = 'open'
+                if not asset.depreciation_line_ids.filtered(
+                    lambda l: l.type != 'create'
+                ):
+                    asset.compute_depreciation_board()
         return True
 
     @api.multi


### PR DESCRIPTION
See https://github.com/OCA/account-financial-tools/issues/967

The depreciation board can be computed when an asset is validated in case no line has already been added to the board.