### PR TITLE
[FIX][12.0] account_asset_management: Exception raised when changing asset profile in a move

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -141,10 +141,6 @@ class AccountMoveLine(models.Model):
                   "an accounting entry to an asset."
                   "\nYou should generate such entries from the asset."))
         if vals.get('asset_profile_id'):
-            if len(self) == 1:
-                raise AssertionError(_(
-                    'This option should only be used for a single id at a '
-                    'time.'))
             asset_obj = self.env['account.asset']
             for aml in self:
                 if vals['asset_profile_id'] == aml.asset_profile_id.id:
@@ -157,6 +153,8 @@ class AccountMoveLine(models.Model):
                     create_asset_from_move_line=True,
                     move_id=aml.move_id.id).create(asset_vals)
                 vals['asset_id'] = asset.id
+                super(AccountMoveLine, aml).write(vals)
+            return True
         return super().write(vals)
 
     @api.model


### PR DESCRIPTION
Very tiny change to prevent an exception from being raised when adding an Asset Profile to a move line within an existing unposted Move.

It seems like the current code is just a typo, given the message of the raised exception as well as the [previous version of this code](https://github.com/OCA/account-financial-tools/commit/264726c7f19b2181bf419429466c03b26825b91e#diff-8e960ef118249d0f50c60aa4924b2629L114) being `assert len(self.ids) == 1`