### PR TITLE
[12.0][FIX] account_move_fiscal_month: error when creating account.move

### DIFF
--- a/account_move_fiscal_month/models/account_move.py
+++ b/account_move_fiscal_month/models/account_move.py
@@ -20,7 +20,8 @@ class AccountMove(models.Model):
         for rec in self:
             date = rec.date
             company = rec.company_id
-            rec.date_range_fm_id = company.find_daterange_fm(date)
+            rec.date_range_fm_id =\
+                company and company.find_daterange_fm(date) or False
 
     @api.model
     def _search_date_range_fm(self, operator, value):


### PR DESCRIPTION
PR to fix error when trying to create a new account move. The company isn't defined on create.