### PR TITLE
[13.0][IMP+FIX] account_asset_management: Add chatter entry in invoice for generated asset, FIX reference empty

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -59,6 +59,7 @@ class AccountMove(models.Model):
         return super().write(vals)
 
     def post(self):
+        super().post()
         for move in self:
             for aml in move.line_ids.filtered("asset_profile_id"):
                 depreciation_base = aml.debit or -aml.credit
@@ -79,8 +80,6 @@ class AccountMove(models.Model):
                     .create(vals)
                 )
                 aml.with_context(allow_asset=True).asset_id = asset.id
-        super().post()
-        for move in self:
             refs = [
                 "<a href=# data-oe-model=account.asset data-oe-id=%s>%s</a>"
                 % tuple(name_get)
@@ -88,7 +87,7 @@ class AccountMove(models.Model):
                     "asset_profile_id"
                 ).asset_id.name_get()
             ]
-            message = _("This invoice created the asset/s: %s") % ", ".join(refs)
+            message = _("This invoice created the asset(s): %s") % ", ".join(refs)
             move.message_post(body=message)
 
     def button_draft(self):

--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -80,6 +80,16 @@ class AccountMove(models.Model):
                 )
                 aml.with_context(allow_asset=True).asset_id = asset.id
         super().post()
+        for move in self:
+            refs = [
+                "<a href=# data-oe-model=account.asset data-oe-id=%s>%s</a>"
+                % tuple(name_get)
+                for name_get in move.line_ids.filtered(
+                    "asset_profile_id"
+                ).asset_id.name_get()
+            ]
+            message = _("This invoice created the asset/s: %s") % ", ".join(refs)
+            move.message_post(body=message)
 
     def button_draft(self):
         invoices = self.filtered(lambda r: not r.is_sale_document())


### PR DESCRIPTION
**IMP**:
Coming from: https://github.com/OCA/account-financial-tools/issues/1006
Added chatter entry with the link to the asset.

**FIX** (empty asset reference):
If the assets are created before posting the invoice, they wouldn't have a name and the "code" field of the assets will be empty, but they would have the invoice name.
