### PR TITLE
[13.0][FIX] account_asset_management: values propagation from asset profile to asset

### DIFF
--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -510,6 +510,7 @@ class TestAssetManagement(SavepointCase):
         self.assertEqual(len(new_assets), 2)
 
         for asset in new_assets:
+            asset.compute_depreciation_board()
             dlines = asset.depreciation_line_ids.filtered(
                 lambda l: l.type == "depreciate"
             )


### PR DESCRIPTION
Before this PR, when you posted a move which should create assets based on asset profiles, the newly created asset didn't have the values from the corresponding asset profile. This PR fixes this behavior.