### PR TITLE
[FIX] account_asset_management - Allow editing salvage value

### DIFF
--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -123,7 +123,11 @@ class AccountAssetLine(models.Model):
                     )
             elif list(vals.keys()) == ["asset_id"]:
                 continue
-            elif dl.move_id and not self.env.context.get("allow_asset_line_update"):
+            elif (
+                dl.move_id
+                and not self.env.context.get("allow_asset_line_update")
+                and dl.type != "create"
+            ):
                 raise UserError(
                     _(
                         "You cannot change a depreciation line "

--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -100,7 +100,7 @@
                                         name="salvage_value"
                                         widget="monetary"
                                         options="{'currency_field': 'company_currency_id'}"
-                                        attrs="{'readonly': ['|', ('move_line_check', '=', True), ('state', '!=', 'draft')]}"
+                                        attrs="{'readonly': [('state', '!=', 'draft')]}"
                                     />
                                     <field name="date_remove" />
                                 </group>


### PR DESCRIPTION
issue from version12 : https://github.com/OCA/account-financial-tools/issues/844
reference: https://github.com/OCA/account-financial-tools/pull/859

Editable salvage value when created by vendor bills