### PR TITLE
[FIX] account_asset_management - onchange profile_id

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -330,7 +330,7 @@ class AccountAsset(models.Model):
     @api.onchange("profile_id")
     def _onchange_profile_id(self):
         for line in self.depreciation_line_ids:
-            if line.move_id:
+            if line.type != "create" and line.move_id:
                 raise UserError(
                     _(
                         "You cannot change the profile of an asset "

--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -79,6 +79,7 @@ class AccountMove(models.Model):
                     .with_context(create_asset_from_move_line=True, move_id=move.id)
                     .create(vals)
                 )
+                asset._onchange_profile_id()
                 aml.with_context(allow_asset=True).asset_id = asset.id
             refs = [
                 "<a href=# data-oe-model=account.asset data-oe-id=%s>%s</a>"


### PR DESCRIPTION
[Fix] function onchange not working if asset created by vendor bills

Example : 
My asset profile is configure
- Number of Years = 24
- Period Length = Month
- Check Calculate by days
![Selection_005](https://user-images.githubusercontent.com/20896369/89603822-1a867400-d894-11ea-9705-f4ede5f9e61c.png)

Create Vendor bills and selected asset profile > post > asset will be created but Depreciation Dates in asset not update
![Selection_007](https://user-images.githubusercontent.com/20896369/89603944-646f5a00-d894-11ea-98a2-23947005cd68.png)

