### PR TITLE
[FIX] account_asset_management: calculate days when remove asset

### DIFF
--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -432,8 +432,8 @@ class TestAssetManagement(SavepointCase):
         wiz.remove()
         asset.refresh()
         self.assertEqual(len(asset.depreciation_line_ids), 3)
-        self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 81.46, places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 4918.54, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 83.33, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 4916.67, places=2)
 
     def test_09_asset_from_invoice(self):
         all_asset = self.env["account.asset"].search([])

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -155,7 +155,11 @@ class AccountAssetRemove(models.TransientModel):
             residual_value = asset.value_residual
 
         dlines = asset_line_obj.search(
-            [("asset_id", "=", asset.id), ("type", "=", "depreciate")],
+            [
+                ("asset_id", "=", asset.id),
+                ("type", "=", "depreciate"),
+                ("move_check", "!=", False),
+            ],
             order="line_date desc",
         )
         if dlines:
@@ -256,9 +260,9 @@ class AccountAssetRemove(models.TransientModel):
             )
             last_depr_date = create_dl.line_date
 
-        period_number_days = (first_date - last_depr_date).days
+        period_number_days = (first_date - last_depr_date).days + 1
         new_line_date = date_remove + relativedelta(days=-1)
-        to_depreciate_days = (new_line_date - last_depr_date).days
+        to_depreciate_days = (new_line_date - last_depr_date).days + 1
         to_depreciate_amount = round(
             float(to_depreciate_days)
             / float(period_number_days)
@@ -267,7 +271,11 @@ class AccountAssetRemove(models.TransientModel):
         )
         residual_value = asset.value_residual - to_depreciate_amount
         if to_depreciate_amount:
-            update_vals = {"amount": to_depreciate_amount, "line_date": new_line_date}
+            update_vals = {
+                "amount": to_depreciate_amount,
+                "line_date": new_line_date,
+                "line_days": to_depreciate_days,
+            }
             first_to_depreciate_dl.write(update_vals)
             dlines[0].create_move()
             dlines -= dlines[0]


### PR DESCRIPTION
- Fix ratio calculate by days when you remove asset
**Example**
New asset start 01/08/2020 remove this asset at 28/08/2020.
Purchase Value = 1000 and not salvage value
**Normally**, Calculate amount from ratio (26/30) * 28.22 = 24.46
![Selection_001](https://user-images.githubusercontent.com/20896369/91519737-a46aaf80-e91d-11ea-9622-ae70e231be7e.png)
**New**, Calculate amount from ratio (27/31) * 28.22 = 24.58
![Selection_002](https://user-images.githubusercontent.com/20896369/91519807-d24ff400-e91d-11ea-8f16-d7eaeeb2de03.png)

- Fix search asset lines (In case not transient model)