### PR TITLE
[9.0][FIX] account_credit_control migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 cache: pip
 
 addons:
-  postgresql: "9.2" # minimal postgresql version for the daterange method
+  postgresql: "9.6" # minimal postgresql version for the daterange method
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/account_credit_control/migrations/9.0.1.0.0/post-migration.py
+++ b/account_credit_control/migrations/9.0.1.0.0/post-migration.py
@@ -42,7 +42,7 @@ def migrate_followup_data(env):
 
 
 def set_followup_data(env):
-    today = fields.Date.context_today
+    today = fields.Date.context_today(env.user)
     policy = env['credit.control.policy.level'].search([])[:-1]
     if policy:
         env.cr.execute("""
@@ -52,7 +52,7 @@ def set_followup_data(env):
             AND aa.internal_type = 'receivable'
             AND aml.reconciled IS NULL
             AND aml.date_maturity < %s
-        """, today)
+        """, (today,))
         data = env.cr.dictfetchall()
         for line in data:
             env['credit.control.line'].create({


### PR DESCRIPTION
Fixes
```
File "/home/openupgrade/ou9/parts/account-financial-tools/account_credit_control/migrations/9.0.1.0.0/post-migration.py", line 55, in set_followup_data
    """, today)
  File "/home/openupgrade/ou9/parts/odoo/openerp/sql_db.py", line 154, in wrapper
    return f(self, *args, **kwargs)
  File "/home/openupgrade/ou9/parts/odoo/openerp/sql_db.py", line 227, in execute
    raise ValueError("SQL query parameters should be a tuple, list or dict; got %r" % (params,))
ValueError: SQL query parameters should be a tuple, list or dict; got <function context_today at 0x7f43cc69a9d0>
```