### PR TITLE
[13.0] account_chart_update FIX: not delete tax repartition lines

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -447,9 +447,24 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                     (inverse_name, "=", tax_id),
                     ("factor_percent", "=", factor_percent),
                     ("repartition_type", "=", repartition_type),
-                    ("account_id", "=", account_id),
                 ]
             )
+            # before try create new record, try compare without account_id
+            if existing:
+                if existing.account_id.id != account_id:
+                    # update record
+                    result.append(
+                        (
+                            1,
+                            existing.id,
+                            {
+                                "factor_percent": factor_percent,
+                                "repartition_type": repartition_type,
+                                "account_id": account_id,
+                                "tag_ids": [(6, 0, tpl.tag_ids.ids)],
+                            },
+                        )
+                    )
             if not existing:
                 # create a new mapping
                 result.append(
@@ -684,6 +699,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                     )
             # Register detected differences
             if expected is not None:
+                # FIXME: on fields m2m are Comparing apples and oranges
                 if expected != [] and expected != real[key]:
                     result[key] = expected
             else:


### PR DESCRIPTION
When update taxes and only change account_id(on repartition lines), in BD with data is impossible run this wizard because try delete repartition lines but `ondelete=restrict` in `account.move.line` avoid this unlink. see https://github.com/odoo/odoo/blob/13.0/addons/account/models/account_move.py#L2587-L2588


![image](https://user-images.githubusercontent.com/7775116/92134496-3582d000-edcf-11ea-8e2f-21a91d56594e.png)

Before, commands to execute are: `create`(0, 0, vals) and `unlink`(2, ID)
![image](https://user-images.githubusercontent.com/7775116/92134587-51867180-edcf-11ea-9d12-f484e4179a82.png)

after commit, commands are: `write `(1, ID, vals) if account has changes


**Note**: logger show `warning to comparing apples and orange`, see https://github.com/OCA/account-financial-tools/blob/13.0/account_chart_update/wizard/wizard_chart_update.py#L687 because operator left is `list(dict)` and operator right is `recordset`. this change is out commit scope only is observation.

![image](https://user-images.githubusercontent.com/7775116/92135066-eab58800-edcf-11ea-9659-da65a9509c6a.png)

