### PR TITLE
[FIX] account_asset_management : empty message is posted if there are no no asset

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -87,8 +87,9 @@ class AccountMove(models.Model):
                     "asset_profile_id"
                 ).asset_id.name_get()
             ]
-            message = _("This invoice created the asset(s): %s") % ", ".join(refs)
-            move.message_post(body=message)
+            if refs:
+                message = _("This invoice created the asset(s): %s") % ", ".join(refs)
+                move.message_post(body=message)
 
     def button_draft(self):
         invoices = self.filtered(lambda r: not r.is_sale_document())


### PR DESCRIPTION
If there are no asset during post() a message is posted:

![image](https://user-images.githubusercontent.com/16716992/94144014-eaf5f000-fe70-11ea-9683-3dd8c9b64505.png)
