### PR TITLE
[12.0][ADD] account_move_line_tax_groupable: group-by taxes applied

### DIFF
--- a/account_move_line_tax_groupable/__init__.py
+++ b/account_move_line_tax_groupable/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/account_move_line_tax_groupable/__manifest__.py
+++ b/account_move_line_tax_groupable/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Accounting: Account Move Lines group-by Taxes",
+    "summary": "Allows grouping account move lines by taxes applied.",
+    "version": "12.0.1.0.0",
+    "category": "Accounting",
+    "website": "https://github.com/OCA/account-financial-tools",
+    "author": "CorporateHub, Odoo Community Association (OCA)",
+    "maintainers": ["alexey-pelykh"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "account",
+    ],
+    "data": [
+        "views/account_move_line.xml",
+    ],
+}

--- a/account_move_line_tax_groupable/models/__init__.py
+++ b/account_move_line_tax_groupable/models/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import account_move_line

--- a/account_move_line_tax_groupable/models/account_move_line.py
+++ b/account_move_line_tax_groupable/models/account_move_line.py
@@ -1,0 +1,21 @@
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    taxes_applied = fields.Char(
+        string="Taxes Applied (combined)",
+        compute="_compute_taxes_applied",
+        store=True,
+        index=True,
+    )
+
+    @api.multi
+    @api.depends("tax_ids.name")
+    def _compute_taxes_applied(self):
+        for line in self:
+            line.taxes_applied = "; ".join(line.tax_ids.mapped("name"))

--- a/account_move_line_tax_groupable/readme/CONTRIBUTORS.rst
+++ b/account_move_line_tax_groupable/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `CorporateHub <https://corporatehub.eu/>`__
+
+  * Alexey Pelykh <alexey.pelykh@corphub.eu>

--- a/account_move_line_tax_groupable/readme/DESCRIPTION.rst
+++ b/account_move_line_tax_groupable/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module adds field "Taxes Applied (combined)" that allows grouping Account
+Move Lines by it.

--- a/account_move_line_tax_groupable/tests/__init__.py
+++ b/account_move_line_tax_groupable/tests/__init__.py
@@ -1,0 +1,1 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).

--- a/account_move_line_tax_groupable/views/account_move_line.xml
+++ b/account_move_line_tax_groupable/views/account_move_line.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2020 CorporateHub (https://corporatehub.eu)
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="view_account_move_line_filter" model="ir.ui.view">
+        <field name="name">account.move.line.filter</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_account_move_line_filter"/>
+        <field name="arch" type="xml">
+            <field name="tax_ids" position="after">
+                <field name="taxes_applied"/>
+            </field>
+            <filter name="groupby_date" position="after">
+                <filter string="Taxes Applied" name="groupby_taxes_applied" context="{'group_by':'taxes_applied'}"/>
+            </filter>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
When dealing with double-checking entries for period, it may be needed to group by "Taxes Applied", but since it's a M2M field, grouping by it is not really possible, but it's possible to compute a string of tax names and group by it.