### PR TITLE
[13.0][FIX] account_move_line_tax_editable

### DIFF
--- a/account_move_line_tax_editable/views/account_move.xml
+++ b/account_move_line_tax_editable/views/account_move.xml
@@ -14,12 +14,8 @@
                 <field name="is_tax_editable" invisible="1" />
                 <field
                     name="tax_line_id"
-                    attrs="{'readonly': [('is_tax_editable', '=', False)], 'invisible': [('parent.type', '!=', 'entry')]}"
-                />
-                <field
-                    name="tax_ids"
-                    attrs="{'readonly': [('is_tax_editable', '=', False)], 'invisible': [('parent.type', '!=', 'entry')]}"
-                    widget="many2many_tags"
+                    attrs="{'readonly': [('is_tax_editable', '=', False)]}"
+                    optional="hide"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
* [FIX] Do not hide Originator Tax
* [IMP] Add optional hide option to Originator Tax
* [FIX] Drop tax_ids field from Journal Item page, as it is already displayed.

CC @ForgeFlow @MiquelRForgeFlow @JordiBForgeFlow 