### PR TITLE
[11.0][REF] migrate numpy to numpy-financial

### DIFF
--- a/account_loan/README.rst
+++ b/account_loan/README.rst
@@ -24,7 +24,7 @@ Installation
 
 To install this module, you need to:
 
-#. Install numpy : ``pip install numpy``
+#. Install numpy-financial : ``pip install numpy-financial``
 #. Follow the standard process
 
 Usage

--- a/account_loan/__manifest__.py
+++ b/account_loan/__manifest__.py
@@ -23,7 +23,7 @@
     'installable': True,
     'external_dependencies': {
         'python': [
-            'numpy',
+            'numpy_financial',
         ],
     },
 }

--- a/account_loan/model/account_loan.py
+++ b/account_loan/model/account_loan.py
@@ -11,7 +11,7 @@ import math
 
 _logger = logging.getLogger(__name__)
 try:
-    import numpy
+    import numpy_financial as npf
 except (ImportError, IOError) as err:
     _logger.debug(err)
 
@@ -276,7 +276,7 @@ class AccountLoan(models.Model):
         """
         for record in self:
             if record.loan_type == 'fixed-annuity':
-                record.fixed_amount = - record.currency_id.round(numpy.pmt(
+                record.fixed_amount = - record.currency_id.round(npf.pmt(
                     record.loan_rate() / 100,
                     record.fixed_periods,
                     record.fixed_loan_amount,

--- a/account_loan/model/account_loan_line.py
+++ b/account_loan/model/account_loan_line.py
@@ -7,7 +7,7 @@ import logging
 
 _logger = logging.getLogger(__name__)
 try:
-    import numpy
+    import numpy_financial as npf
 except (ImportError, IOError) as err:
     _logger.error(err)
 
@@ -160,7 +160,7 @@ class AccountLoanLine(models.Model):
         if self.loan_type == 'fixed-annuity' and self.loan_id.round_on_end:
             return self.loan_id.fixed_amount
         if self.loan_type == 'fixed-annuity':
-            return self.currency_id.round(- numpy.pmt(
+            return self.currency_id.round(- npf.pmt(
                 self.loan_id.loan_rate() / 100,
                 self.loan_id.periods - self.sequence + 1,
                 self.pending_principal_amount,

--- a/account_loan/tests/test_loan.py
+++ b/account_loan/tests/test_loan.py
@@ -12,7 +12,7 @@ import logging
 
 _logger = logging.getLogger(__name__)
 try:
-    import numpy
+    import numpy_financial as npf
 except (ImportError, IOError) as err:
     _logger.error(err)
 
@@ -118,7 +118,7 @@ class TestLoan(TransactionCase):
         self.assertEqual(len(loan.line_ids), periods)
         line = loan.line_ids.filtered(lambda r: r.sequence == 1)
         self.assertAlmostEqual(
-            - numpy.pmt(1 / 100 / 12, 24, 10000), line.payment_amount, 2)
+            - npf.pmt(1 / 100 / 12, 24, 10000), line.payment_amount, 2)
         self.assertEqual(line.long_term_principal_amount, 0)
         loan.long_term_loan_account_id = self.lt_loan_account
         loan.compute_lines()
@@ -182,7 +182,7 @@ class TestLoan(TransactionCase):
         self.assertEqual(len(loan.line_ids), periods)
         line = loan.line_ids.filtered(lambda r: r.sequence == 1)
         self.assertAlmostEqual(
-            - numpy.pmt(1 / 100 / 12, 24, 10000), line.payment_amount, 2)
+            - npf.pmt(1 / 100 / 12, 24, 10000), line.payment_amount, 2)
         self.assertEqual(line.long_term_principal_amount, 0)
         loan.long_term_loan_account_id = self.lt_loan_account
         loan.compute_lines()
@@ -205,11 +205,11 @@ class TestLoan(TransactionCase):
         loan.compute_lines()
         line = loan.line_ids.filtered(lambda r: r.sequence == 1)
         self.assertAlmostEqual(
-            - numpy.pmt(1 / 100 / 12, periods, amount), line.payment_amount, 2)
+            - npf.pmt(1 / 100 / 12, periods, amount), line.payment_amount, 2)
         line = loan.line_ids.filtered(lambda r: r.sequence == 2)
         self.assertAlmostEqual(
-            - numpy.pmt(2 / 100 / 12, periods - 1,
-                        line.pending_principal_amount),
+            - npf.pmt(2 / 100 / 12, periods - 1,
+                      line.pending_principal_amount),
             line.payment_amount, 2
         )
         line = loan.line_ids.filtered(lambda r: r.sequence == 3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-numpy
+numpy==1.15
+numpy-financial==1.0.0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The financial functions in NumPy are deprecated and eventually will be removed from NumP.

Current behavior before PR: functions with NumPy in module account_loan working correctly.

Desired behavior after PR is merged: same behavior that before PR, just using functions from NumPy Financial.

Fix #1077

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
