### PR TITLE
[FIX] account_document_reversal: modify to correct development_status 

### DIFF
--- a/account_document_reversal/__manifest__.py
+++ b/account_document_reversal/__manifest__.py
@@ -17,6 +17,6 @@
     'license': 'AGPL-3',
     'installable': True,
     'application': False,
-    'development_status': 'beta',
+    'development_status': 'Beta',
     'maintainers': ['kittiu'],
 }


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

For changes in pylint configuration, travis marks error in account_document_reversal for 'development_status' with 'beta' data.

Current behavior before PR: pylint error in travis for development status unknown in job 4983.1

Desired behavior after PR is merged: job 4983.1 in travis without error about development status unknown.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
