### PR TITLE
[12.0][FIX] modify to correct development_status

### DIFF
--- a/account_document_reversal/__manifest__.py
+++ b/account_document_reversal/__manifest__.py
@@ -18,6 +18,6 @@
     'license': 'AGPL-3',
     'installable': True,
     'application': False,
-    'development_status': 'beta',
+    'development_status': 'Beta',
     'maintainers': ['kittiu'],
 }

--- a/account_payment_netting/__manifest__.py
+++ b/account_payment_netting/__manifest__.py
@@ -18,6 +18,6 @@
         'views/account_payment_view.xml',
     ],
     'installable': True,
-    'development_status': 'beta',
+    'development_status': 'Beta',
     'maintainers': ['kittiu'],
 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

For changes in pylint configuration, travis marks error in account_document_reversal and account_payment_netting for 'development_status' with 'beta' data.

Current behavior before PR: pylint error in travis for development status unknown.

Desired behavior after PR is merged: travis without error about development status unknown.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr