### PR TITLE
[13.0] [FIX] account lock to date crash fix

### DIFF
--- a/account_lock_to_date/models/account_move.py
+++ b/account_lock_to_date/models/account_move.py
@@ -1,25 +1,33 @@
 # Copyright 2019 ForgeFlow S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import _, models
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
 
     def _check_lock_to_dates(self):
+        """Prevent moves that are on or after lock to date.
+
+        Advisors have more freedom then other users and are only constrained
+        by the ficalyear_lock_to_date.
+        Other users will also be restricted by the period_lock_to_date.
+        """
+        is_advisor = self.user_has_groups("account.group_account_manager")
         for move in self:
-            lock_to_date = (
-                min(
-                    move.company_id.period_lock_to_date,
-                    move.company_id.fiscalyear_lock_to_date,
+            advisor_lock_to_date = move.company_id.fiscalyear_lock_to_date
+            user_lock_to_date = move.company_id.period_lock_to_date
+            if is_advisor:
+                lock_to_date = advisor_lock_to_date or False
+            else:
+                lock_to_date = (
+                    min(user_lock_to_date, advisor_lock_to_date)
+                    if user_lock_to_date and advisor_lock_to_date
+                    else user_lock_to_date or advisor_lock_to_date or False
                 )
-                or False
-            )
-            if self.user_has_groups("account.group_account_manager"):
-                lock_to_date = move.company_id.fiscalyear_lock_to_date or False
             if lock_to_date and move.date >= lock_to_date:
-                if self.user_has_groups("account.group_account_manager"):
+                if is_advisor:
                     message = _(
                         "You cannot add/modify entries after and "
                         "inclusive of the lock to date %s"
@@ -31,7 +39,7 @@ class AccountMove(models.Model):
                         "Check the company settings or ask someone "
                         "with the 'Adviser' role"
                     ) % (lock_to_date)
-                raise UserError(message)
+                raise ValidationError(message)
 
     def action_post(self):
         self._check_lock_to_dates()

--- a/account_lock_to_date/models/res_company.py
+++ b/account_lock_to_date/models/res_company.py
@@ -91,7 +91,7 @@ class ResCompany(models.Model):
                     _(
                         "You cannot lock a period that is not finished yet. "
                         "Please make sure that the lock date for advisors is "
-                        "not set after the last day of the previous month."
+                        "set at or after the last day of the next month."
                     )
                 )
 

--- a/account_lock_to_date/tests/test_account_lock_to_date_update.py
+++ b/account_lock_to_date/tests/test_account_lock_to_date_update.py
@@ -1,9 +1,9 @@
 # Copyright 2019 ForgeFlow S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from datetime import datetime
 
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 from odoo.tools.misc import DEFAULT_SERVER_DATE_FORMAT
 
@@ -88,7 +88,7 @@ class TestAccountLockToDateUpdate(TransactionCase):
             }
         )
         self.demo_user.write({"groups_id": [(3, self.adviser_group.id)]})
-        with self.assertRaises(UserError):
+        with self.assertRaises(ValidationError):
             wizard.with_user(self.demo_user.id).execute()
 
     def test_02_update_with_access(self):
@@ -116,7 +116,7 @@ class TestAccountLockToDateUpdate(TransactionCase):
         self.company.period_lock_to_date = "2900-01-01"
         self.company.fiscalyear_lock_to_date = "2900-02-01"
         move = self.create_account_move("2900-01-01")
-        with self.assertRaises(UserError):
+        with self.assertRaises(ValidationError):
             move.with_user(self.demo_user.id).action_post()
 
     def test_04_create_move_inside_period(self):

--- a/account_lock_to_date/wizards/account_update_lock_to_date.py
+++ b/account_lock_to_date/wizards/account_update_lock_to_date.py
@@ -1,8 +1,8 @@
 # Copyright 2019 ForgeFlow S.L.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import SUPERUSER_ID, _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 
 class AccountUpdateLockToDate(models.TransientModel):
@@ -45,7 +45,7 @@ class AccountUpdateLockToDate(models.TransientModel):
         self.ensure_one()
         has_adviser_group = self.env.user.has_group("account.group_account_manager")
         if not (has_adviser_group or self.env.uid == SUPERUSER_ID):
-            raise UserError(_("You are not allowed to execute this action."))
+            raise ValidationError(_("You are not allowed to execute this action."))
 
     def execute(self):
         self.ensure_one()


### PR DESCRIPTION
This solves issue https://github.com/OCA/account-financial-tools/issues/1010

There is a better handling of False / NULL values in the lock to dates, and also an corrected message when setting the date for Advisors, and selecting a date that is too early.