### PR TITLE
[12.0] [FIX] Fixed update account reconcile first

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -874,8 +874,8 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 # Update the account
                 try:
                     with self.env.cr.savepoint():
-                        for key, value in (iter(self.diff_fields(
-                                template, account).items())):
+                        for key, value in (iter(sorted(self.diff_fields(
+                                template, account).items()))):
                             account[key] = value
                             _logger.info(
                                 _("Updated account %s."),


### PR DESCRIPTION
When updating accounts (Update Chart Template) I've found a bug when an account's internal_type and reconcile fields need to be updated. If **internal_type** get's updated to 'receivable' or 'payable' before **reconcile** to True, an Exception is thrown: _You cannot have a receivable/payable account that is not reconcilable._

The fix for this issue is to update reconcile field before internal_type. To fix this, I sorted the "fields-to-update" dictionary alphabetical order so that reconcile is updated first.

 