### PR TITLE
[FIX] Freeze numpy version to 1.19.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy
+numpy<=1.19.4
 


### PR DESCRIPTION
Main
-

[FIX] Freeze numpy version to 1.19.4 which recently was updated to
1.19.5 but it is causing the runbot to fail with a MemoryError.

<img width="1122" alt="Screen Shot 2021-01-05 at 23 16 59" src="https://user-images.githubusercontent.com/7598010/103732004-1ded6b00-4fac-11eb-9a12-c74d61262e68.png">
