### PR TITLE
[12.0][FIX] account_asset_management: Prevent create lines with init=True when account_lock_date_update addon is installed and lock date defined

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -471,6 +471,10 @@ class AccountAsset(models.Model):
 
         line_obj = self.env['account.asset.line']
         digits = self.env['decimal.precision'].precision_get('Account')
+        company = self.company_id
+        fiscalyear_lock_date = (
+            company.fiscalyear_lock_date or fields.Date.to_date('1901-01-01')
+        )
 
         for asset in self:
             if asset.value_residual == 0.0:
@@ -593,7 +597,7 @@ class AccountAsset(models.Model):
                             'name': name,
                             'line_date': line['date'],
                             'line_days': line['days'],
-                            'init_entry': entry['init'],
+                            'init_entry': fiscalyear_lock_date >= line['date'],
                         }
                         depreciated_value += round(amount, digits)
                         depr_line = line_obj.create(vals)
@@ -871,6 +875,10 @@ class AccountAsset(models.Model):
         i_max = len(table) - 1
         remaining_value = self.depreciation_base
         depreciated_value = 0.0
+        company = self.company_id
+        fiscalyear_lock_date = (
+            company.fiscalyear_lock_date or fields.Date.to_date('1901-01-01')
+        )
 
         for i, entry in enumerate(table):
 
@@ -923,6 +931,7 @@ class AccountAsset(models.Model):
                     'amount': amount,
                     'depreciated_value': depreciated_value,
                     'remaining_value': remaining_value,
+                    'init': fiscalyear_lock_date >= line_date,
                 }
                 lines.append(line)
                 depreciated_value += amount
@@ -972,10 +981,7 @@ class AccountAsset(models.Model):
         if self.method_time in ['year', 'number'] \
                 and not self.method_number and not self.method_end:
             return table
-        company = self.company_id
         asset_date_start = self.date_start
-        fiscalyear_lock_date = (
-            company.fiscalyear_lock_date or fields.Date.to_date('1901-01-01'))
         depreciation_start_date = self._get_depreciation_start_date(
             self._get_fy_info(asset_date_start)['record'])
         depreciation_stop_date = self._get_depreciation_stop_date(
@@ -987,7 +993,6 @@ class AccountAsset(models.Model):
                 'fy': fy_info['record'],
                 'date_start': fy_info['date_from'],
                 'date_stop': fy_info['date_to'],
-                'init': fiscalyear_lock_date >= fy_info['date_from'],
             })
             fy_date_start = fy_info['date_to'] + relativedelta(days=1)
         # Step 1:

--- a/account_asset_management/readme/CONTRIBUTORS.rst
+++ b/account_asset_management/readme/CONTRIBUTORS.rst
@@ -9,3 +9,8 @@
 - Maxence Groine <mgroine@fiefmanage.ch>
 - Kitti Upariphutthiphong <kittiu@ecosoft.co.th>
 - Saran Lim. <saranl@ecosoft.co.th>
+
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+    * Víctor Martínez

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -110,6 +110,40 @@ class TestAssetManagement(SavepointCase):
             'invoice_line_ids': [(4, cls.invoice_line_2.id),
                                  (4, cls.invoice_line_3.id)]})
 
+    def test_00_fiscalyear_lock_date_month(self):
+        asset = self.asset_model.create({
+            'name': 'test asset',
+            'profile_id': self.ref('account_asset_management.'
+                                   'account_asset_profile_car_5Y'),
+            'purchase_value': 1500,
+            'date_start': '1901-02-01',
+            'method_time': 'year',
+            'method_number': 3,
+            'method_period': 'month',
+        })
+        asset.compute_depreciation_board()
+        asset.refresh()
+        self.assertTrue(asset.depreciation_line_ids[0].init_entry)
+        for i in range(1, 36):
+            self.assertFalse(asset.depreciation_line_ids[i].init_entry)
+
+    def test_00_fiscalyear_lock_date_year(self):
+        asset = self.asset_model.create({
+            'name': 'test asset',
+            'profile_id': self.ref('account_asset_management.'
+                                   'account_asset_profile_car_5Y'),
+            'purchase_value': 1500,
+            'date_start': '1901-02-01',
+            'method_time': 'year',
+            'method_number': 3,
+            'method_period': 'year',
+        })
+        asset.compute_depreciation_board()
+        asset.refresh()
+        self.assertTrue(asset.depreciation_line_ids[0].init_entry)
+        for i in range(1, 4):
+            self.assertFalse(asset.depreciation_line_ids[i].init_entry)
+
     def test_01_nonprorata_basic(self):
         """Basic tests of depreciation board computations and postings."""
         #


### PR DESCRIPTION
Related to: #1012

Prevent create lines with `init=True` when `account_lock_date_update` addon is installed and lock date defined.

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT27946