### PR TITLE
[14.0] Add multi-company ir.rule on account.fiscal.year

### DIFF
--- a/account_fiscal_year/__manifest__.py
+++ b/account_fiscal_year/__manifest__.py
@@ -19,6 +19,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "security/account_fiscal_year_rule.xml",
         "views/account_fiscal_year_views.xml",
     ],
 }

--- a/account_fiscal_year/security/account_fiscal_year_rule.xml
+++ b/account_fiscal_year/security/account_fiscal_year_rule.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2021 Akretion France (http://www.akretion.com/)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
+
+
+<record id="account_fiscal_year_rule" model="ir.rule">
+    <field name="name">Fiscal Year multi-company</field>
+    <field name="model_id" ref="model_account_fiscal_year" />
+    <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+</record>
+
+
+</odoo>


### PR DESCRIPTION
I think this ir.rule was just forgotten in the initial PR https://github.com/OCA/account-financial-tools/pull/1081