### PR TITLE
[13.0][imp][account_asset_management] change menu

### DIFF
--- a/account_asset_management/__manifest__.py
+++ b/account_asset_management/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Assets Management",
     "version": "13.0.2.0.0",
     "license": "AGPL-3",
-    "depends": ["account", "report_xlsx_helper"],
+    "depends": ["account", "report_xlsx_helper", "account_menu"],
     "excludes": ["account_asset"],
     "external_dependencies": {"python": ["python-dateutil"]},
     "author": "Noviat, Odoo Community Association (OCA)",

--- a/account_asset_management/readme/CONFIGURATION.rst
+++ b/account_asset_management/readme/CONFIGURATION.rst
@@ -1,0 +1,2 @@
+To see all the menus, make sure that your user is member of the group
+"Technical Settings / Show Full Accounting Features"

--- a/account_asset_management/views/menuitem.xml
+++ b/account_asset_management/views/menuitem.xml
@@ -3,7 +3,7 @@
     <menuitem
         id="menu_finance_assets"
         name="Assets"
-        parent="account.menu_finance"
+        parent="account.menu_finance_entries"
         sequence="9"
     />
     <menuitem


### PR DESCRIPTION
Make the menu entries accessible regardless if you use Odoo CE or EE. 

Adds dependency with the module account_menu for the menu entries to become accessible.

In Odoo CE:
![image](https://user-images.githubusercontent.com/7683926/107622104-a4563600-6c57-11eb-90b0-e4af0843c976.png)

In Odoo EE:
![image](https://user-images.githubusercontent.com/7683926/107622115-a8825380-6c57-11eb-8c75-0985ccc308a9.png)

Users now need to make sure to activate the setting *Show full accounting features* in order to display the menus.