### PR TITLE
[13.0][NEW][account_asset_management_menu] Make asset management menu entries accessible regardless if you use Odoo CE or EE.

### DIFF
--- a/account_asset_management_menu/__manifest__.py
+++ b/account_asset_management_menu/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Assets Management Menu",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "depends": ["account_asset_management", "account_menu"],
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/account-financial-tools",
+    "category": "Accounting & Finance",
+    "data": ["views/menuitem.xml"],
+    "auto_install": True,
+}

--- a/account_asset_management_menu/readme/CONFIGURATION.rst
+++ b/account_asset_management_menu/readme/CONFIGURATION.rst
@@ -1,0 +1,1 @@
+Users now need to make sure to activate the setting Show full accounting features in order to display the asset menus.

--- a/account_asset_management_menu/readme/CONTRIBUTORS.rst
+++ b/account_asset_management_menu/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Jordi Ballester (ForgeFlow)

--- a/account_asset_management_menu/readme/DESCRIPTION.rst
+++ b/account_asset_management_menu/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module changes the menu from which assets can be accessed, making it compatible with both Odoo Community
+and Enterprise versions.

--- a/account_asset_management_menu/views/menuitem.xml
+++ b/account_asset_management_menu/views/menuitem.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <menuitem
+        id="account_asset_management.menu_finance_assets"
+        name="Assets"
+        parent="account.menu_finance_entries"
+    />
+</odoo>

--- a/setup/account_asset_management_menu/odoo/addons/account_asset_management_menu
+++ b/setup/account_asset_management_menu/odoo/addons/account_asset_management_menu
@@ -1,0 +1,1 @@
+../../../../account_asset_management_menu

--- a/setup/account_asset_management_menu/setup.py
+++ b/setup/account_asset_management_menu/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module adds dependency with the module account_menu for the menu entries to become accessible.

Users need to make sure to activate the setting Show full accounting features in order to display the asset menus.

In Odoo EE:
![image](https://user-images.githubusercontent.com/7683926/107623977-77efe900-6c5a-11eb-9c7e-5b9e49138797.png)


In Odoo CE:
![image](https://user-images.githubusercontent.com/7683926/107623985-7d4d3380-6c5a-11eb-9a82-0e42e538fd57.png)

