### PR TITLE
[12.0][FIX] account_asset_management: Move number don't follows journal sequence.

### DIFF
--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -181,7 +181,6 @@ class AccountAssetLine(models.Model):
     def _setup_move_data(self, depreciation_date):
         asset = self.asset_id
         move_data = {
-            'name': asset.name,
             'date': depreciation_date,
             'ref': self.name,
             'journal_id': asset.profile_id.journal_id.id,

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -164,7 +164,6 @@ class AccountAssetRemove(models.TransientModel):
 
         # create move
         move_vals = {
-            'name': asset.name,
             'date': date_remove,
             'ref': line_name,
             'journal_id': journal_id,


### PR DESCRIPTION
Avoid set account move name so that it follows the journal sequence.

@Tecnativa TT28549