### PR TITLE
[14.0][FIX] account_asset_management: Fix onchange account_id and asset_profile_id

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -1,5 +1,6 @@
 # Copyright 2009-2018 Noviat
 # Copyright 2021 Tecnativa - João Marques
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
@@ -121,8 +122,14 @@ class AccountMoveLine(models.Model):
 
     @api.onchange("account_id")
     def _onchange_account_id(self):
-        self.asset_profile_id = self.account_id.asset_profile_id
+        if self.account_id.asset_profile_id:
+            self.asset_profile_id = self.account_id.asset_profile_id
         super()._onchange_account_id()
+
+    @api.onchange("asset_profile_id")
+    def _onchange_asset_profile_id(self):
+        if self.asset_profile_id.account_asset_id:
+            self.account_id = self.asset_profile_id.account_asset_id
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/account_asset_management/readme/CONTRIBUTORS.rst
+++ b/account_asset_management/readme/CONTRIBUTORS.rst
@@ -14,3 +14,4 @@
   * Ernesto Tejeda
   * Pedro M. Baeza
   * João Marques
+  * Víctor Martínez

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -90,6 +90,30 @@ class TestAssetManagement(AccountTestInvoicingCommon):
             }
         )
 
+    def test_invoice_line_without_product(self):
+        tax = self.env["account.tax"].create(
+            {
+                "name": "TAX 15%",
+                "amount_type": "percent",
+                "type_tax_use": "purchase",
+                "amount": 15.0,
+            }
+        )
+        move_form = Form(
+            self.env["account.move"].with_context(
+                default_move_type="in_invoice", check_move_validity=False
+            )
+        )
+        move_form.partner_id = self.partner
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.name = "Line 1"
+            line_form.price_unit = 200.0
+            line_form.quantity = 1
+            line_form.tax_ids.clear()
+            line_form.tax_ids.add(tax)
+        invoice = move_form.save()
+        self.assertEqual(invoice.partner_id, self.partner)
+
     def test_01_nonprorata_basic(self):
         """Basic tests of depreciation board computations and postings."""
         # First create demo assets and do some sanity checks


### PR DESCRIPTION
Related to 13.0: https://github.com/OCA/account-financial-tools/pull/1131

Fix onchange `account_id` and `asset_profile_id` to prevent `account_id` is empty in some use cases.

Add `_onchange_asset_profile_id` (disappear in 14.0)

Please @chienandalu   and @pedrobaeza can you review it?

@Tecnativa TT28467