### PR TITLE
[12.0][IMP] account_asset_management: Add analytic tags and propagate

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -202,6 +202,9 @@ class AccountAsset(models.Model):
     account_analytic_id = fields.Many2one(
         comodel_name='account.analytic.account',
         string='Analytic account')
+    analytic_tag_ids = fields.Many2many(
+        comodel_name='account.analytic.tag',
+        string='Analytic tags')
 
     @api.model
     def _default_company_id(self):
@@ -298,6 +301,7 @@ class AccountAsset(models.Model):
                 'method_progress_factor': profile.method_progress_factor,
                 'prorata': profile.prorata,
                 'account_analytic_id': profile.account_analytic_id,
+                'analytic_tag_ids': profile.analytic_tag_ids,
                 'group_ids': profile.group_ids,
             })
 

--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -189,9 +189,11 @@ class AccountAssetLine(models.Model):
         return move_data
 
     def _setup_move_line_data(self, depreciation_date, account, ml_type, move):
+        """Prepare data to be propagated to account.move.line"""
         asset = self.asset_id
         amount = self.amount
         analytic_id = False
+        analytic_tags = self.env["account.analytic.tag"]
         if ml_type == 'depreciation':
             debit = amount < 0 and -amount or 0.0
             credit = amount > 0 and amount or 0.0
@@ -199,6 +201,7 @@ class AccountAssetLine(models.Model):
             debit = amount > 0 and amount or 0.0
             credit = amount < 0 and -amount or 0.0
             analytic_id = asset.account_analytic_id.id
+            analytic_tags = asset.analytic_tag_ids
         move_line_data = {
             'name': asset.name,
             'ref': self.name,
@@ -209,6 +212,7 @@ class AccountAssetLine(models.Model):
             'journal_id': asset.profile_id.journal_id.id,
             'partner_id': asset.partner_id.id,
             'analytic_account_id': analytic_id,
+            'analytic_tag_ids': [(4, tag.id) for tag in analytic_tags],
             'date': depreciation_date,
             'asset_id': asset.id,
         }

--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -15,6 +15,9 @@ class AccountAssetProfile(models.Model):
     account_analytic_id = fields.Many2one(
         comodel_name='account.analytic.account',
         string='Analytic account')
+    analytic_tag_ids = fields.Many2many(
+        comodel_name='account.analytic.tag',
+        string='Analytic tags')
     account_asset_id = fields.Many2one(
         comodel_name='account.account',
         domain="[('company_id', '=', company_id), "

--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -161,6 +161,8 @@ class AccountMoveLine(models.Model):
     def _get_asset_analytic_values(self, vals, asset_vals):
         asset_vals['account_analytic_id'] = vals.get(
             'analytic_account_id', False)
+        asset_vals['analytic_tag_ids'] = vals.get(
+            'analytic_tag_ids', False)
 
     @api.model
     def _play_onchange_profile_id(self, vals):

--- a/account_asset_management/readme/CONTRIBUTORS.rst
+++ b/account_asset_management/readme/CONTRIBUTORS.rst
@@ -14,3 +14,4 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
     * Víctor Martínez
+    * João Marques

--- a/account_asset_management/tests/account_asset_test_data.xml
+++ b/account_asset_management/tests/account_asset_test_data.xml
@@ -78,6 +78,8 @@
       <field name="purchase_value" eval="12000.0"/>
       <field name="salvage_value" eval="2000.0"/>
       <field name="profile_id" ref="account_asset_profile_car_5Y"/>
+      <field name="account_analytic_id" ref="analytic.analytic_administratif" />
+      <field name="analytic_tag_ids" eval="[(4, ref('analytic.tag_contract'))]" />
     </record>
 
   </data>

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -186,7 +186,20 @@ class TestAssetManagement(SavepointCase):
         self.assertEqual(ict0.value_depreciated, 500)
         self.assertEqual(ict0.value_residual, 1000)
         vehicle0.validate()
-        vehicle0.depreciation_line_ids[1].create_move()
+        created_move_ids = vehicle0.depreciation_line_ids[1].create_move()
+        for move_id in created_move_ids:
+            move = self.env["account.move"].browse(move_id)
+            expense_line = move.line_ids.filtered(
+                lambda line: line.account_id == self.env.ref("account.a_expense")
+            )
+            self.assertEqual(
+                expense_line.analytic_account_id,
+                self.env.ref("analytic.analytic_administratif"),
+            )
+            self.assertEqual(
+                expense_line.analytic_tag_ids,
+                self.env.ref("analytic.tag_contract")
+            )
         vehicle0.refresh()
         self.assertEqual(vehicle0.state, 'open')
         self.assertEqual(vehicle0.value_depreciated, 2000)

--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -56,6 +56,7 @@
                 <field name="group_ids" widget="many2many_tags"/>
                 <field name="partner_id"/>
                 <field name="account_analytic_id" groups="analytic.group_analytic_accounting"/>
+                <field name="analytic_tag_ids" groups="analytic.group_analytic_accounting" widget="many2many_tags" />
               </group>
               <group colspan="4">
                 <group>

--- a/account_asset_management/views/account_asset_profile.xml
+++ b/account_asset_management/views/account_asset_profile.xml
@@ -40,6 +40,7 @@
             </group>
             <group groups="analytic.group_analytic_accounting" string="Analytic Information">
               <field name="account_analytic_id"/>
+              <field name="analytic_tag_ids" widget="many2many_tags"/>
             </group>
           </group>
           <separator string="Notes"/>

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -289,6 +289,7 @@ class AccountAssetRemove(models.TransientModel):
                     'name': asset.name,
                     'account_id': self.account_residual_value_id.id,
                     'analytic_account_id': asset.account_analytic_id.id,
+                    'analytic_tag_ids': [(4, tag.id) for tag in asset.analytic_tag_ids],
                     'debit': residual_value,
                     'credit': 0.0,
                     'partner_id': partner_id,
@@ -302,6 +303,9 @@ class AccountAssetRemove(models.TransientModel):
                         'name': asset.name,
                         'account_id': self.account_sale_id.id,
                         'analytic_account_id': asset.account_analytic_id.id,
+                        'analytic_tag_ids': [
+                            (4, tag.id) for tag in asset.analytic_tag_ids
+                        ],
                         'debit': sale_value,
                         'credit': 0.0,
                         'partner_id': partner_id,
@@ -316,6 +320,7 @@ class AccountAssetRemove(models.TransientModel):
                     'name': asset.name,
                     'account_id': account_id,
                     'analytic_account_id': asset.account_analytic_id.id,
+                    'analytic_tag_ids': [(4, tag.id) for tag in asset.analytic_tag_ids],
                     'debit': balance < 0 and -balance or 0.0,
                     'credit': balance > 0 and balance or 0.0,
                     'partner_id': partner_id,


### PR DESCRIPTION
Add analytic tags to `asset.profile` and `asset.asset` and propagate them between these models and to the created `account.move.line`
Add tests for propagation of analytic data from asset to account.move.line

@Tecnativa
TT28974

ping @pedrobaeza @victoralmau 