### PR TITLE
[13.0][IMP] account_asset_management: Add analytic tags and propagate

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -266,6 +266,13 @@ class AccountAsset(models.Model):
         readonly=False,
         store=True,
     )
+    analytic_tag_ids = fields.Many2many(
+        comodel_name="account.analytic.tag",
+        string="Analytic tags",
+        compute="_compute_analytic_tag_ids",
+        readonly=False,
+        store=True,
+    )
 
     @api.model
     def _default_company_id(self):
@@ -366,6 +373,11 @@ class AccountAsset(models.Model):
     def _compute_account_analytic_id(self):
         for asset in self:
             asset.account_analytic_id = asset.profile_id.account_analytic_id
+
+    @api.depends("profile_id")
+    def _compute_analytic_tag_ids(self):
+        for asset in self:
+            asset.analytic_tag_ids = asset.profile_id.analytic_tag_ids
 
     @api.constrains("method", "method_time")
     def _check_method(self):

--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -222,9 +222,11 @@ class AccountAssetLine(models.Model):
         return move_data
 
     def _setup_move_line_data(self, depreciation_date, account, ml_type, move):
+        """Prepare data to be propagated to account.move.line"""
         asset = self.asset_id
         amount = self.amount
         analytic_id = False
+        analytic_tags = self.env["account.analytic.tag"]
         if ml_type == "depreciation":
             debit = amount < 0 and -amount or 0.0
             credit = amount > 0 and amount or 0.0
@@ -232,6 +234,7 @@ class AccountAssetLine(models.Model):
             debit = amount > 0 and amount or 0.0
             credit = amount < 0 and -amount or 0.0
             analytic_id = asset.account_analytic_id.id
+            analytic_tags = asset.analytic_tag_ids
         move_line_data = {
             "name": asset.name,
             "ref": self.name,
@@ -242,6 +245,7 @@ class AccountAssetLine(models.Model):
             "journal_id": asset.profile_id.journal_id.id,
             "partner_id": asset.partner_id.id,
             "analytic_account_id": analytic_id,
+            "analytic_tag_ids": [(4, tag.id) for tag in analytic_tags],
             "date": depreciation_date,
             "asset_id": asset.id,
         }

--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -16,6 +16,9 @@ class AccountAssetProfile(models.Model):
     account_analytic_id = fields.Many2one(
         comodel_name="account.analytic.account", string="Analytic account"
     )
+    analytic_tag_ids = fields.Many2many(
+        comodel_name="account.analytic.tag", string="Analytic tags"
+    )
     account_asset_id = fields.Many2one(
         comodel_name="account.account",
         domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",

--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -82,6 +82,7 @@ class AccountMove(models.Model):
                     "partner_id": aml.partner_id.id,
                     "date_start": move.date,
                     "account_analytic_id": aml.analytic_account_id.id,
+                    "analytic_tag_ids": aml.analytic_tag_ids.id,
                 }
                 if self.env.context.get("company_id"):
                     vals["company_id"] = self.env.context["company_id"]

--- a/account_asset_management/readme/CONTRIBUTORS.rst
+++ b/account_asset_management/readme/CONTRIBUTORS.rst
@@ -14,3 +14,4 @@
   * Ernesto Tejeda
   * Pedro M. Baeza
   * Víctor Martínez
+  * João Marques

--- a/account_asset_management/tests/account_asset_test_data.xml
+++ b/account_asset_management/tests/account_asset_test_data.xml
@@ -73,6 +73,8 @@
             <field name="purchase_value" eval="12000.0" />
             <field name="salvage_value" eval="2000.0" />
             <field name="profile_id" ref="account_asset_profile_car_5Y" />
+            <field name="account_analytic_id" ref="analytic.analytic_administratif" />
+            <field name="analytic_tag_ids" eval="[(4, ref('analytic.tag_contract'))]" />
         </record>
     </data>
 </odoo>

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -196,7 +196,19 @@ class TestAssetManagement(SavepointCase):
         self.assertEqual(ict0.value_depreciated, 500)
         self.assertEqual(ict0.value_residual, 1000)
         vehicle0.validate()
-        vehicle0.depreciation_line_ids[1].create_move()
+        created_move_ids = vehicle0.depreciation_line_ids[1].create_move()
+        for move_id in created_move_ids:
+            move = self.env["account.move"].browse(move_id)
+            expense_line = move.line_ids.filtered(
+                lambda line: line.account_id == self.env.ref("account.a_expense")
+            )
+            self.assertEqual(
+                expense_line.analytic_account_id,
+                self.env.ref("analytic.analytic_administratif"),
+            )
+            self.assertEqual(
+                expense_line.analytic_tag_ids, self.env.ref("analytic.tag_contract")
+            )
         vehicle0.refresh()
         self.assertEqual(vehicle0.state, "open")
         self.assertEqual(vehicle0.value_depreciated, 2000)

--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -114,6 +114,11 @@
                                     name="account_analytic_id"
                                     groups="analytic.group_analytic_accounting"
                                 />
+                                <field
+                                    name="analytic_tag_ids"
+                                    groups="analytic.group_analytic_accounting"
+                                    widget="many2many_tags"
+                                />
                             </group>
                             <group colspan="4">
                                 <group>

--- a/account_asset_management/views/account_asset_profile.xml
+++ b/account_asset_management/views/account_asset_profile.xml
@@ -57,6 +57,7 @@
                             string="Analytic Information"
                         >
                             <field name="account_analytic_id" />
+                            <field name="analytic_tag_ids" widget="many2many_tags" />
                         </group>
                     </group>
                     <separator string="Notes" />

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -322,6 +322,7 @@ class AccountAssetRemove(models.TransientModel):
                     "name": asset.name,
                     "account_id": self.account_residual_value_id.id,
                     "analytic_account_id": asset.account_analytic_id.id,
+                    "analytic_tag_ids": [(4, tag.id) for tag in asset.analytic_tag_ids],
                     "debit": residual_value,
                     "credit": 0.0,
                     "partner_id": partner_id,
@@ -335,6 +336,9 @@ class AccountAssetRemove(models.TransientModel):
                         "name": asset.name,
                         "account_id": self.account_sale_id.id,
                         "analytic_account_id": asset.account_analytic_id.id,
+                        "analytic_tag_ids": [
+                            (4, tag.id) for tag in asset.analytic_tag_ids
+                        ],
                         "debit": sale_value,
                         "credit": 0.0,
                         "partner_id": partner_id,
@@ -351,6 +355,7 @@ class AccountAssetRemove(models.TransientModel):
                     "name": asset.name,
                     "account_id": account_id,
                     "analytic_account_id": asset.account_analytic_id.id,
+                    "analytic_tag_ids": [(4, tag.id) for tag in asset.analytic_tag_ids],
                     "debit": balance < 0 and -balance or 0.0,
                     "credit": balance > 0 and balance or 0.0,
                     "partner_id": partner_id,


### PR DESCRIPTION
Forward-port of https://github.com/OCA/account-financial-tools/pull/1149

@ernestotejeda I noticed that, in order to view the move lines generated from an asset, I need to have the "Show full accounting features" option enabled for my user. Is that normal?

@Tecnativa
TT28974

@pedrobaeza @victoralmau can you review please?