### PR TITLE
[IMP]account_asset_management: allow posting depreciation entries in draft

### DIFF
--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -161,6 +161,12 @@ class AccountAssetProfile(models.Model):
         "product item. So, there will be an asset by product item.",
     )
     active = fields.Boolean(default=True)
+    auto_post_depreciation = fields.Boolean(
+        string="Auto-Post Depreciation Entries",
+        help="If checked, the accounting entries generated for the asset "
+        "depreciation lines will be automatically posted.",
+        default=True,
+    )
 
     @api.model
     def _default_company_id(self):

--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -176,7 +176,8 @@
                             >
                                 <tree
                                     string="Asset Lines"
-                                    decoration-info="(move_check == False) and (init_entry == False)"
+                                    decoration-info="(move_state == False) and (init_entry == False)"
+                                    decoration-warning="(move_state == 'draft')"
                                     create="false"
                                 >
                                     <field name="type" />
@@ -186,21 +187,21 @@
                                     <field name="amount" />
                                     <field name="remaining_value" readonly="1" />
                                     <field name="init_entry" string="Init" />
-                                    <field name="move_check" />
+                                    <field name="move_state" />
                                     <field name="parent_state" invisible="1" />
                                     <button
                                         name="create_move"
                                         icon="fa-cog"
                                         string="Create Move"
                                         type="object"
-                                        attrs="{'invisible': ['|', '|', ('init_entry', '=', True), ('move_check', '!=', False), ('parent_state', '!=', 'open')]}"
+                                        attrs="{'invisible': ['|', '|', ('init_entry', '=', True), ('move_state', '!=', False), ('parent_state', '!=', 'open')]}"
                                     />
                                     <button
                                         name="open_move"
                                         icon="fa-folder-open-o"
                                         string="View Move"
                                         type="object"
-                                        attrs="{'invisible': [('move_check', '!=', True)]}"
+                                        attrs="{'invisible': [('move_state', 'not in', ('draft', 'posted'))]}"
                                     />
                                     <button
                                         name="unlink_move"
@@ -209,7 +210,16 @@
                                         type="object"
                                         confirm="Are you sure ?"
                                         groups="account.group_account_manager"
-                                        attrs="{'invisible': [('move_check', '!=', True)]}"
+                                        attrs="{'invisible': [('move_state', '!=', 'posted')]}"
+                                    />
+                                    <button
+                                        name="post_move"
+                                        icon="fa-check"
+                                        string="Post Move"
+                                        type="object"
+                                        confirm="Are you sure ?"
+                                        groups="account.group_account_manager"
+                                        attrs="{'invisible': [('move_state', '!=', 'draft')]}"
                                     />
                                 </tree>
                                 <form string="Asset Line">
@@ -224,19 +234,19 @@
                                             <field name="name" />
                                             <field
                                                 name="amount"
-                                                attrs="{'readonly': [('move_check', '=', True)]}"
+                                                attrs="{'readonly': [('move_state', '!=', False)]}"
                                             />
                                             <field
                                                 name="init_entry"
-                                                attrs="{'readonly': ['|', ('move_check', '=', True), ('type', '=', 'create')]}"
+                                                attrs="{'readonly': ['|', ('move_state', '!=', False), ('type', '=', 'create')]}"
                                             />
                                             <field name="move_id" />
-                                            <field name="move_check" />
+                                            <field name="move_state" />
                                         </group>
                                         <group>
                                             <field
                                                 name="line_date"
-                                                attrs="{'readonly': [('move_check', '=', True)]}"
+                                                attrs="{'readonly': [('move_state', '!=', False)]}"
                                             />
                                             <field
                                                 name="depreciated_value"

--- a/account_asset_management/views/account_asset_profile.xml
+++ b/account_asset_management/views/account_asset_profile.xml
@@ -51,6 +51,7 @@
                                 attrs="{'readonly':[('method_time','!=','year')]}"
                             />
                             <field name="open_asset" />
+                            <field name="auto_post_depreciation" />
                         </group>
                         <group
                             groups="analytic.group_analytic_accounting"

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -240,9 +240,7 @@ class AccountAssetRemove(models.TransientModel):
         def _dlines(asset):
             lines = asset.depreciation_line_ids
             dlines = lines.filtered(
-                lambda l: l.type == "depreciate"
-                and not l.init_entry
-                and not l.move_check
+                lambda l: l.type == "depreciate" and not l.init_entry and not l.move_id
             )
             dlines = dlines.sorted(key=lambda l: l.line_date)
             return dlines


### PR DESCRIPTION
Currently the default behaviour when creating depreciation entries is posting them directly.
However, in some cases it may be desired to have them created in draft in order to review them
first, letting the user post them afterwards.

This commit introduces a new option to allow deciding which behaviour is preferred at asset profile
level. Also, for asset line it adds a related field to the depreciation entry state.