### PR TITLE
[13.0][account_asset_management]: fix group_assets sorting

### DIFF
--- a/account_asset_management/report/account_asset_report_xls.py
+++ b/account_asset_management/report/account_asset_report_xls.py
@@ -420,7 +420,9 @@ class AssetReportXlsx(models.AbstractModel):
             group_assets = assets.filtered(lambda r: group in r.group_ids)
         else:
             group_assets = assets
-        group_assets = group_assets.sorted(lambda r: (r.date_start or "", r.code))
+        group_assets = group_assets.sorted(
+            lambda r: (r.date_start or "", r.code or "", r.name)
+        )
         grouped_assets[group] = {"assets": group_assets}
         for child in group.child_ids:
             self._group_assets(assets, child, grouped_assets[group])


### PR DESCRIPTION
Error: 

> File "/opt/odoo/custom/src/account-financial-tools/account_asset_management/report/account_asset_report_xls.py", line 423, in _group_assets
>     group_assets = group_assets.sorted(lambda r: (r.date_start or "", r.code))
>   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5466, in sorted
>     return self.browse(item.id for item in sorted(self, key=key, reverse=reverse))
> TypeError: '<' not supported between instances of 'bool' and 'str'

Steps to reproduce it: Create two assets with same date_start, both of them without code.

As the code is not required we can't fallback on it when sorting the assets. Instead, fallback on the name.
