### PR TITLE
[13.0][account_asset_management]: add user error when creating asset from bill

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -74,6 +74,10 @@ class AccountMove(models.Model):
         for move in self:
             for aml in move.line_ids.filtered("asset_profile_id"):
                 depreciation_base = aml.debit or -aml.credit
+                if not aml.name:
+                    raise UserError(
+                        _("Asset name must be set in the label of the line.")
+                    )
                 vals = {
                     "name": aml.name,
                     "code": move.name,


### PR DESCRIPTION
When creating an asset from a vendor bill, the account move line name (label) is used to set the asset name, which is a required field. However, the label is not required for account move lines, so users may face problems if they forget to set it.

This PR simply adds a User Error to provide insight when users face this situation.