### PR TITLE
[14.0][FIX] account_asset_management: set invoice date

### DIFF
--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -7,6 +7,7 @@ import calendar
 import time
 from datetime import date, datetime
 
+from odoo import fields
 from odoo.tests.common import Form
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -31,6 +32,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
                 default_move_type="in_invoice", check_move_validity=False
             )
         )
+        move_form.invoice_date = fields.Date.context_today(cls.env.user)
         move_form.partner_id = cls.partner
         with move_form.invoice_line_ids.new() as line_form:
             line_form.name = "test"
@@ -43,6 +45,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
                 default_move_type="in_invoice", check_move_validity=False
             )
         )
+        move_form.invoice_date = fields.Date.context_today(cls.env.user)
         move_form.partner_id = cls.partner
         with move_form.invoice_line_ids.new() as line_form:
             line_form.name = "test 2"
@@ -104,6 +107,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
                 default_move_type="in_invoice", check_move_validity=False
             )
         )
+        move_form.invoice_date = fields.Date.context_today(self.env.user)
         move_form.partner_id = self.partner
         with move_form.invoice_line_ids.new() as line_form:
             line_form.name = "Line 1"


### PR DESCRIPTION
Adapt to https://github.com/odoo/odoo/commit/fcaa54939e, which prevents
setting a default invoice date for purchase documents

Thanks to @JordiMForgeFlow for pointing out that upstream change.