### PR TITLE
Remove date ranges of type fiscal year

### DIFF
--- a/account_fiscal_year/migrations/14.0.1.0.0/post-remove_fiscalyear_date_range.py
+++ b/account_fiscal_year/migrations/14.0.1.0.0/post-remove_fiscalyear_date_range.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Remove date ranges of type fiscal year
+    fiscal_year_type = env.ref(
+        "account_fiscal_year.fiscalyear", raise_if_not_found=False
+    )
+    if fiscal_year_type:
+        openupgrade.logged_query(
+            env.cr,
+            """
+            DELETE FROM date_range
+            WHERE type_id = %s
+            """,
+            (fiscal_year_type.id,),
+        )


### PR DESCRIPTION
Otherwise during migration to `14.0`, the following error might occur:
```
2021-03-29 12:49:59,001 83803 ERROR odoo14-migrated odoo.sql_db: bad query: DELETE FROM date_range_type WHERE id IN (1)
ERROR: update or delete on table "date_range_type" violates foreign key constraint "date_range_type_id_fkey" on table "date_range"
DETAIL:  Key (id)=(1) is still referenced from table "date_range".
2021-03-29 12:49:59,004 83803 WARNING odoo14-migrated odoo.modules.loading: Transient module states were reset
```
When, after the update of the whole DB, no more existing XMLIDS (like `account_fiscal_year.fiscalyear`) are purged.