### PR TITLE
[12.0][FIX] account_asset_management: method_time migration was incomplete

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -157,10 +157,8 @@ class AccountAsset(models.Model):
              "number of depreciation lines.\n"
              "  * Number of Years: Specify the number of years "
              "for the depreciation.\n"
-             # "  * Number of Depreciations: Fix the number of "
-             # "depreciation lines and the time between 2 depreciations.\n"
-             # "  * Ending Date: Choose the time between 2 depreciations "
-             # "and the date the depreciations won't go beyond."
+             "  * Number of Depreciations: Fix the number of "
+             "depreciation lines and the time between 2 depreciations.\n"
     )
     days_calc = fields.Boolean(
         string='Calculate by days',
@@ -258,10 +256,10 @@ class AccountAsset(models.Model):
                       "Year."))
 
     @api.multi
-    @api.constrains('date_start', 'method_end', 'method_time')
+    @api.constrains('date_start', 'method_end', 'method_number', 'method_time')
     def _check_dates(self):
         for asset in self:
-            if asset.method_time == 'end':
+            if asset.method_time == 'year' and not asset.method_number:
                 if asset.method_end <= asset.date_start:
                     raise UserError(
                         _("The Start Date must precede the Ending Date."))

--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -99,7 +99,10 @@ class AccountAssetProfile(models.Model):
         help="Choose the method to use to compute the dates and "
              "number of depreciation lines.\n"
              "  * Number of Years: Specify the number of years "
-             "for the depreciation.\n")
+             "for the depreciation.\n"
+             "  * Number of Depreciations: Fix the number of "
+             "depreciation lines and the time between 2 depreciations.\n"
+    )
     days_calc = fields.Boolean(
         string='Calculate by days',
         default=False,
@@ -164,6 +167,7 @@ class AccountAssetProfile(models.Model):
         """
         return [
             ('year', _('Number of Years or end date')),
+            ('number', _('Number of Depreciations')),
         ]
 
     @api.multi

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -679,3 +679,32 @@ class TestAssetManagement(SavepointCase):
             [(group_tfa.id, 'Tangible Fixed A...')])
         self.assertFalse(
             self.env['account.asset.group']._name_search('stessA dexiF'))
+
+    def test_16_use_number_of_depreciations(self):
+        # When you run a depreciation with method = 'number'
+        profile = self.env.ref("account_asset_management.account_asset_profile_car_5Y")
+        profile.method_time = "number"
+        asset = self.asset_model.create(
+            {
+                "name": "test asset",
+                "profile_id": profile.id,
+                "purchase_value": 10000,
+                "salvage_value": 0,
+                "date_start": time.strftime("2019-01-01"),
+                "method_time": "year",
+                "method_number": 5,
+                "method_period": "month",
+                "prorata": False,
+                "days_calc": False,
+                "use_leap_years": False,
+            }
+        )
+        asset.compute_depreciation_board()
+        asset.refresh()
+        for _i in range(1, 11):
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[1].amount, 166.67, places=2
+            )
+        # In the last month of the fiscal year we compensate for the small
+        # deviations if that is necessary.
+        self.assertAlmostEqual(asset.depreciation_line_ids[12].amount, 166.63, places=2)


### PR DESCRIPTION
This kind of fixes two things:

1) If method_time was 'end', this is full converted to 'year'.

2) Sometimes method_time 'number' cannot be converted to 'year', then 'number' should still be preserved as a method.