### PR TITLE
[12.0][FIX] account_asset_management: report on assets without code

### DIFF
--- a/account_asset_management/report/account_asset_report_xls.py
+++ b/account_asset_management/report/account_asset_report_xls.py
@@ -441,7 +441,8 @@ class AssetReportXlsx(models.AbstractModel):
         else:
             group_assets = assets
         group_assets = group_assets.sorted(
-            lambda r: (r.date_start or '', r.code))
+            lambda r: (r.date_start or "", r.code or "", r.name)
+        )
         grouped_assets[group] = {'assets': group_assets}
         for child in group.child_ids:
             self._group_assets(assets, child, grouped_assets[group])

--- a/account_asset_management/tests/test_asset_management_xls.py
+++ b/account_asset_management/tests/test_asset_management_xls.py
@@ -23,8 +23,11 @@ class TestAssetManagementXls(SavepointCase):
         cls._load('account_asset_management', 'tests',
                   'account_asset_test_data.xml')
         # Ensure we have something to report on
-        cls.env.ref('account_asset_management.'
-                    'account_asset_asset_ict0').validate()
+        asset = cls.env.ref(
+            'account_asset_management.account_asset_asset_ict0')
+        asset.validate()
+        asset2 = asset.copy({"code": False})
+        asset2.validate()
         module = __name__.split('addons.')[1].split('.')[0]
         cls.xls_report_name = '{}.asset_report_xls'.format(module)
         cls.wiz_model = cls.env['wiz.account.asset.report']


### PR DESCRIPTION
Fixes
```
 Traceback (most recent call last):
 `   File "/home/odoo/account-financial-tools/account_asset_management/tests/test_asset_management_xls.py", line 60, in test_01_action_xls
 `     model.create_xlsx_report(
 `   File "/home/odoo/reporting-engine/report_xlsx/report/report_xlsx.py", line 47, in create_xlsx_report
 `     self.generate_xlsx_report(workbook, data, objs)
 `   File "/home/odoo/reporting-engine/report_xlsx_helper/report/report_xlsx_abstract.py", line 18, in generate_xlsx_report
 `     for ws_params in self._get_ws_params(workbook, data, objects):
 `   File "/home/odoo/account-financial-tools/account_asset_management/report/account_asset_report_xls.py", line 27, in _get_ws_params
 `     self._grouped_assets = self._get_assets(wiz)
 `   File "/home/odoo/account-financial-tools/account_asset_management/report/account_asset_report_xls.py", line 421, in _get_assets
 `     self._group_assets(self._assets, parent_group, grouped_assets)
 `   File "/home/odoo/account-financial-tools/account_asset_management/report/account_asset_report_xls.py", line 447, in _group_assets
 `     self._group_assets(assets, child, grouped_assets[group])
 `   File "/home/odoo/account-financial-tools/account_asset_management/report/account_asset_report_xls.py", line 443, in _group_assets
 `     group_assets = group_assets.sorted(
 `   File "/home/odoo/odoo/odoo/models.py", line 4961, in sorted
 `     return self.browse(item.id for item in sorted(self, key=key, reverse=reverse))
 ` TypeError: '<' not supported between instances of 'bool' and 'str'
 ```