### PR TITLE
[12.0][FIX] account_asset_management: fix error in parent to group migration

### DIFF
--- a/account_asset_management/migrations/12.0.2.0.0/post-migration.py
+++ b/account_asset_management/migrations/12.0.2.0.0/post-migration.py
@@ -28,7 +28,7 @@ def create_asset_groups(cr):
         LEFT JOIN account_asset_group aag2
             ON aag2.{origin_column} = va.{parent_column}
         WHERE {parent_column} {rest_sql}
-        RETURNING id
+        RETURNING {origin_column}
     """)
     isnull = sql.SQL("IS NULL")
     inids = sql.SQL("IN %(ids)s")


### PR DESCRIPTION
Return the `id` from the subselect by its column name in the main query. Fixes
incomplete and incorrect group assignment during the migration.