### PR TITLE
[13.0][FIX] account_asset_management: Fix error from group_ids in asset when set profile_id

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -316,8 +316,12 @@ class AccountAsset(models.Model):
 
     @api.depends("profile_id")
     def _compute_group_ids(self):
-        for asset in self.filtered("profile_id"):
-            asset.group_ids = asset.profile_id.group_ids
+        for asset in self:
+            if asset.profile_id:
+                asset.group_ids = asset.profile_id.group_ids
+            else:
+                # HACK: Not needed in v14 due to odoo/odoo#64359
+                asset.group_ids = asset.group_ids
 
     @api.depends("profile_id")
     def _compute_method(self):


### PR DESCRIPTION
Fix error from `group_ids` in asset when set `profile_id`.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT29490