### PR TITLE
[14.0][FIX] account_asset_management: Fix error from group_ids in asset when set profile_id + Fix _name_search

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -313,8 +313,9 @@ class AccountAsset(models.Model):
 
     @api.depends("profile_id")
     def _compute_group_ids(self):
-        for asset in self.filtered("profile_id"):
-            asset.group_ids = asset.profile_id.group_ids
+        for asset in self:
+            if asset.profile_id:
+                asset.group_ids = asset.profile_id.group_ids
 
     @api.depends("profile_id")
     def _compute_method(self):

--- a/account_asset_management/models/account_asset_group.py
+++ b/account_asset_management/models/account_asset_group.py
@@ -1,5 +1,6 @@
 # Copyright 2009-2020 Noviat
 # Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -72,7 +73,6 @@ class AccountAssetGroup(models.Model):
             ]
             if operator in expression.NEGATIVE_TERM_OPERATORS:
                 domain = ["&", "!"] + domain[1:]
-        rec_ids = self._search(
+        return self._search(
             expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid
         )
-        return self.browse(rec_ids).name_get()

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -640,18 +640,18 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         )
         # Groups are displayed by code (if any) plus name
         self.assertEqual(
-            self.env["account.asset.group"]._name_search("FA"),
+            self.env["account.asset.group"].name_search("FA"),
             [(group_fa.id, "FA Fixed Assets")],
         )
         # Groups with code are shown by code in list views
         self.assertEqual(
             self.env["account.asset.group"]
             .with_context(params={"view_type": "list"})
-            ._name_search("FA"),
+            .name_search("FA"),
             [(group_fa.id, "FA")],
         )
         self.assertEqual(
-            self.env["account.asset.group"]._name_search("TFA"),
+            self.env["account.asset.group"].name_search("TFA"),
             [(group_tfa.id, "TFA Tangible Fixed Assets")],
         )
         group_tfa.code = False
@@ -665,4 +665,4 @@ class TestAssetManagement(AccountTestInvoicingCommon):
             group_tfa.with_context(params={"view_type": "list"}).name_get(),
             [(group_tfa.id, "Tangible Fixed A...")],
         )
-        self.assertFalse(self.env["account.asset.group"]._name_search("stessA dexiF"))
+        self.assertFalse(self.env["account.asset.group"].name_search("stessA dexiF"))


### PR DESCRIPTION
Fix error from `group_ids` in asset when set `profile_id`. (FWP from 13.0 https://github.com/OCA/account-financial-tools/pull/1170)
Fix error according to `_name_search` in group when try to set groups in profile.

Steps to reproduce:
- Create Asset group.
- Create Asset profile and try to set group previously created.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT29490