### PR TITLE
[13.0][FIX]account_asset_management: use column_invisible

### DIFF
--- a/account_asset_management/views/account_move.xml
+++ b/account_asset_management/views/account_move.xml
@@ -28,11 +28,11 @@
                 <field
                     name="asset_profile_id"
                     domain="[('company_id','=', parent.company_id)]"
-                    attrs="{'invisible': [('parent.type', 'not in', ('in_invoice', 'in_refund'))]}"
+                    attrs="{'column_invisible': [('parent.type', 'not in', ('in_invoice', 'in_refund'))]}"
                 />
                 <field
                     name="asset_id"
-                    attrs="{'invisible': [('parent.type', 'not in', ('out_invoice', 'out_refund'))]}"
+                    attrs="{'column_invisible': [('parent.type', 'not in', ('out_invoice', 'out_refund'))]}"
                     groups="account.group_account_manager"
                 />
             </xpath>


### PR DESCRIPTION
Use column_invisible for the fields added inside the tree of the invoice_line_ids, otherwise it is not evaluated correctly.