### PR TITLE
[10.0][IMP] account_credit_control: fix constrain

### DIFF
--- a/account_credit_control/models/res_partner.py
+++ b/account_credit_control/models/res_partner.py
@@ -75,6 +75,9 @@ class ResPartner(models.Model):
         # updated not in the same time on ORM write
         # so we call check when all fields written to the record
         res = super(ResPartner, self).write(vals)
-        if vals.get("credit_policy_id") or vals.get("property_account_receivable_id"):
+        # onchange method in credit policy provides cleaning of credit_policy if account
+        # was changed and checking for both fields in vals provides check will be executed
+        # only on parent company and skip child partners
+        if vals.get("credit_policy_id") and vals.get("property_account_receivable_id"):
             self._check_credit_policy()
         return res

--- a/account_credit_control/tests/test_account_invoice.py
+++ b/account_credit_control/tests/test_account_invoice.py
@@ -49,18 +49,11 @@ class TestAccountInvoice(TransactionCase):
         policy.write({
             'account_ids': [(6, 0, [account.id])]
         })
-
-        # There is a bug with Odoo ...
-        # The field "credit_policy_id" is considered as an "old field" and
-        # the field property_account_receivable_id like a "new field"
-        # The ORM will create the record with old field
-        # and update the record with new fields.
-        # However constrains are applied after the first creation.
         partner = self.env['res.partner'].create({
             'name': 'Partner',
             'property_account_receivable_id': account.id,
+            'credit_policy_id': policy.id,
         })
-        partner.credit_policy_id = policy.id
 
         date_invoice = datetime.today() - relativedelta.relativedelta(years=1)
         invoice = self.env['account.invoice'].create({

--- a/account_credit_control/tests/test_res_partner.py
+++ b/account_credit_control/tests/test_res_partner.py
@@ -28,6 +28,7 @@ class TestCreditControlPolicyLevel(TransactionCase):
         with self.assertRaises(ValidationError):
             partner.write({
                 'credit_policy_id': policy.id,
+                'property_account_receivable_id': partner.property_account_receivable_id.id
             })
 
         policy.write({


### PR DESCRIPTION
there is special behavior with property fields and constrain check running when record not completely updated, so we cannot have constrain relying on these fields
so we just call constrain directly from the write method