### PR TITLE
[14.0][IMP] account_menu: make anglo-saxon toggle visible

### DIFF
--- a/account_menu/README.rst
+++ b/account_menu/README.rst
@@ -38,6 +38,10 @@ This module adds all missing menu entries for the **Account** module.
 * Tax Templates
 * Fiscal Position Templates
 
+Additionally, this module also enables the option to enable or disable
+Anglo-Saxon accounting in the Chart of Account Template form view and
+in the Invoicing Settings.
+
 **Table of contents**
 
 .. contents::
@@ -52,6 +56,12 @@ To see all the menus, make sure:
   "Technical Settings / Show Full Accounting Features"
 
 * The page is running in debug mode
+
+Known issues / Roadmap
+======================
+
+* Suggest to rename to something like `account_usability` in 15.0, given that
+  there are now non-menu usability improvements in this module.
 
 Bug Tracker
 ===========

--- a/account_menu/__manifest__.py
+++ b/account_menu/__manifest__.py
@@ -13,6 +13,7 @@
     "depends": ["account"],
     "data": [
         "views/menu.xml",
+        "views/res_config_settings_views.xml",
         "views/view_account_account_template.xml",
         "views/view_account_bank_statement.xml",
         "views/view_account_chart_template.xml",

--- a/account_menu/models/__init__.py
+++ b/account_menu/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_group
 from . import account_tag
 from . import account_tax_group
+from . import res_config_settings

--- a/account_menu/models/res_config_settings.py
+++ b/account_menu/models/res_config_settings.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Opener B.V. <stefan@opener.amsterdam>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    anglo_saxon_accounting = fields.Boolean(
+        related="company_id.anglo_saxon_accounting",
+        readonly=False,
+        string="Use anglo-saxon accounting",
+        help=(
+            "Record the cost of a good as an expense when this good is "
+            "invoiced to a final customer."
+        ),
+    )

--- a/account_menu/readme/DESCRIPTION.rst
+++ b/account_menu/readme/DESCRIPTION.rst
@@ -10,3 +10,7 @@ This module adds all missing menu entries for the **Account** module.
 * Account Templates
 * Tax Templates
 * Fiscal Position Templates
+
+Additionally, this module also enables the option to enable or disable
+Anglo-Saxon accounting in the Chart of Account Template form view and
+in the Invoicing Settings.

--- a/account_menu/readme/ROADMAP.rst
+++ b/account_menu/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+* Suggest to rename to something like `account_usability` in 15.0, given that
+  there are now non-menu usability improvements in this module.

--- a/account_menu/static/description/index.html
+++ b/account_menu/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Account - Missing Menus</title>
 <style type="text/css">
 
@@ -381,15 +381,19 @@ ul.auto-toc {
 <li>Tax Templates</li>
 <li>Fiscal Position Templates</li>
 </ul>
+<p>Additionally, this module also enables the option to enable or disable
+Anglo-Saxon accounting in the Chart of Account Template form view and
+in the Invoicing Settings.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -403,8 +407,15 @@ ul.auto-toc {
 <li>The page is running in debug mode</li>
 </ul>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>Suggest to rename to something like <cite>account_usability</cite> in 15.0, given that
+there are now non-menu usability improvements in this module.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-financial-tools/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -412,16 +423,16 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>GRAP</li>
 <li>Akretion</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li>Sylvain LE GAL &lt;<a class="reference external" href="https://twitter.com/legalsylvain">https://twitter.com/legalsylvain</a>&gt;</li>
 <li>Raf Ven &lt;<a class="reference external" href="mailto:raf.ven&#64;dynapps.be">raf.ven&#64;dynapps.be</a>&gt;</li>
@@ -429,7 +440,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/account_menu/views/res_config_settings_views.xml
+++ b/account_menu/views/res_config_settings_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div data-key="account" position="inside">
+                <h2>Anglo-Saxon Accounting</h2>
+                <div
+                    class="row mt16 o_settings_container"
+                    name="anglo_saxon_setting_container"
+                >
+                    <div class="col-12 col-lg-6 o_setting_box" id="anglo_saxon">
+                        <div class="o_setting_left_pane">
+                            <field name="anglo_saxon_accounting" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label
+                                string="Anglo-Saxon Accounting"
+                                for="anglo_saxon_accounting"
+                            />
+                            <div class="text-muted">
+                                Record the cost of a good as an expense when this good is
+                                invoiced to a final customer (instead of recording the cost as soon
+                                as the product is received in stock).
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/account_menu/views/view_account_chart_template.xml
+++ b/account_menu/views/view_account_chart_template.xml
@@ -5,6 +5,16 @@ Copyright (C) 2019 - Today: GRAP (http://www.grap.coop)
 License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 <odoo>
+    <record id="view_account_chart_template_form" model="ir.ui.view">
+        <field name="model">account.chart.template</field>
+        <field name="inherit_id" ref="account.view_account_chart_template_form" />
+        <field name="arch" type="xml">
+            <field name="complete_tax_set" position="after">
+                <field name="use_anglo_saxon" />
+            </field>
+        </field>
+    </record>
+
     <menuitem
         id="menu_account_chart_template"
         action="account.action_account_chart_template_form"


### PR DESCRIPTION
By default, the Anglo-Saxon toggle is not accessible anywhere in the UI. This change adds it to the chart template and to the Invoicing settings to proxy the boolean field on the company.

Strictly speaking, not a menu so I hope this is allowed to be included in this module `account_menu`. It seemed appropriate because this module is indispensible to solve all kinds of usability problems in the Accounting department of the Community Edition, and this modules makes the chart template views accessible in the first place.
