### PR TITLE
[FIX] account_chart_update: issue with xmlid

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -656,7 +656,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             ('res_id', '=', template.id),
         ])
         new_xml_id = "%d_%s" % (self.company_id.id, template_xmlid.name)
-        return not ir_model_data.search([
+        return template_xmlid and not ir_model_data.search([
             ('res_id', '=', real_obj.id),
             ('model', '=', real_obj._name),
             ('module', '=', template_xmlid.module),


### PR DESCRIPTION
If you try to update the xmlid and the template object has been manually created, an error is raised:
```
Traceback (most recent call last):
File "/home/operador/pyworkspace/oca/account-financial-tools/account_chart_update/wizard/wizard_chart_update.py", line 886, in _update_accounts
self.recreate_xml_id(template, account)
File "/home/operador/pyworkspace/oca/account-financial-tools/account_chart_update/wizard/wizard_chart_update.py", line 801, in recreate_xml_id
template_xmlid.copy({
File "/home/operador/pyworkspace/odoo/odoo/models.py", line 4333, in copy
self.ensure_one()
File "/home/operador/pyworkspace/odoo/odoo/models.py", line 4768, in ensure_one
raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: ir.model.data()
```

This solves the issue

@pedrobaeza 