### PR TITLE
[FIX] account_asset_management: Use API functions for date handling

### DIFF
--- a/account_asset_management/models/account_fiscal_year.py
+++ b/account_asset_management/models/account_fiscal_year.py
@@ -2,12 +2,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
-import time
-from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, models
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
+from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -17,15 +14,15 @@ class AccountFiscalYear(models.Model):
 
     @api.model
     def create(self, vals):
-        date_from = datetime.strptime(vals.get('date_from'), '%Y-%m-%d')
-        date_to = datetime.strptime(vals.get('date_to'), '%Y-%m-%d')
+        date_from = fields.Date.to_date(vals.get('date_from'))
+        date_to = fields.Date.to_date(vals.get('date_to'))
         if not date_to == date_from + relativedelta(years=1, days=-1):
             recompute_vals = {
                 'reason': 'creation of fiscalyear %s' % vals.get('name'),
                 'company_id':
                     vals.get('company_id') or
                     self.env.user.company_id.id,
-                'date_trigger': time.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
+                'date_trigger': fields.Datetime.now(),
                 'state': 'open',
             }
             self.env['account.asset.recompute.trigger'].sudo().create(
@@ -40,8 +37,7 @@ class AccountFiscalYear(models.Model):
                     'reason':
                         'duration change of fiscalyear %s' % fy.name,
                     'company_id': fy.company_id.id,
-                    'date_trigger':
-                        time.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
+                    'date_trigger': fields.Datetime.now(),
                     'state': 'open',
                 }
                 self.env['account.asset.recompute.trigger'].sudo().\


### PR DESCRIPTION
as `date` objects are valid input for date fields since v12, we can't assume strings. This should be cherry picked to higher versions too