### PR TITLE
[FIX] account_asset_management: avoid access error to asset features

### DIFF
--- a/account_asset_management/views/account_move.xml
+++ b/account_asset_management/views/account_move.xml
@@ -3,6 +3,10 @@
     <record id="view_move_form" model="ir.ui.view">
         <field name="name">account.move.form.account.asset.management</field>
         <field name="model">account.move</field>
+        <field
+            name="groups_id"
+            eval="[(4, ref('account.group_account_invoice')), (4, ref('account.group_account_user'))]"
+        />
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">


### PR DESCRIPTION
When you have the permission `sales_team.group_sale_salesman` or higher, you can create an invoice from a sales order and view it. However, that doesn't grant permission for asset management. Thus, when loading this view, users got an access error.

Restrict this view only for account users, so they can actually see all they need.

@Tecnativa TT30228