### PR TITLE
[13.0][account_asset_management][imp] Carry forward depreciations from closed periods

### DIFF
--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -156,6 +156,7 @@
                                         name="prorata"
                                         attrs="{'readonly': [('method_time', '!=', 'year')]}"
                                     />
+                                    <field name="carry_forward_missed_depreciations" />
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
In some cases you will create an asset with a start date that falls in one or more periods that are now closed. In those cases you may want the depreciations that should happen during closed periods to accumulate to the first depreciation line of the first open period.

For example, we create an asset with date 01/01/2021 and the periods are now locked until 31/05/2021. All depreciations between 01/01/2021 and 31/05/2021 that could not be posted should be moved forward to the first depreciation line that does not fall within a closed period, in this case 30/06/2021.

![image](https://user-images.githubusercontent.com/7683926/121549556-41f72180-ca0e-11eb-97c7-bd2f9ae8b218.png)

![image](https://user-images.githubusercontent.com/7683926/121549617-4de2e380-ca0e-11eb-96d6-6b8e97f475e0.png)

We found this case in a migration from Odoo 10, where the previous asset management system was generating depreciation at the start of the month. When we migrate to Odoo 13 the system now generates depreciations at month end, which may fall within an already locked date. In this situation the depreciation between 01/05/2021 and 31/05/2021 was being 'trapped' in an init depreciation line, with us being unable to post this depreciation.

