### PR TITLE
[IMP] account_chart_update: adds tags in repartition lines search

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -449,6 +449,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                     ("repartition_type", "=", repartition_type),
                     ("account_id", "=", account_id),
                 ]
+                + [("tag_ids", "=", tag_id) for tag_id in tpl.tag_ids.ids]
             )
             if not existing:
                 # create a new mapping


### PR DESCRIPTION
For now, this module does not react to changes in the repartition line templates for the `tag_ids` field.

Because `tag_ids` is many2many field, using domain `("tag_ids", "=", tpl.tag_ids.ids)` doesn't work properly as SQL will always use `IN` operator instead of `=` in for many2many cases.
This is why the change compiles the domain using `for` loop to format it with AND's