### PR TITLE
[FIX] account_asset_management: Check method end is defined in order to raise Exception

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -406,6 +406,7 @@ class AccountAsset(models.Model):
         if self.filtered(
             lambda a: a.method_time == "year"
             and not a.method_number
+            and a.method_end
             and a.method_end <= a.date_start
         ):
             raise UserError(_("The Start Date must precede the Ending Date."))


### PR DESCRIPTION
The field was not required, so we should need to check it