### PR TITLE
[13.0][account_asset_management][imp] allow manual entry/editing of depreciation board

### DIFF
--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -129,6 +129,12 @@ class AccountAssetLine(models.Model):
             )
 
     def write(self, vals):
+        if "previous_id" in vals:
+            vals2 = {"previous_id": vals["previous_id"]}
+            super().write(vals2)
+            del vals["previous_id"]
+        if not vals:
+            return super().write(vals)
         for dl in self:
             line_date = vals.get("line_date") or dl.line_date
             asset_lines = dl.asset_id.depreciation_line_ids

--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -136,7 +136,10 @@ class AccountAssetLine(models.Model):
         if not vals:
             return super().write(vals)
         for dl in self:
-            line_date = vals.get("line_date") or dl.line_date
+            line_date = vals.get("line_date") or ""
+            if line_date:
+                line_date = fields.Date.from_string(line_date)
+            line_date = line_date or dl.line_date
             asset_lines = dl.asset_id.depreciation_line_ids
             if list(vals.keys()) == ["move_id"] and not vals["move_id"]:
                 # allow to remove an accounting entry via the

--- a/account_asset_management/tests/test_asset_management_xls.py
+++ b/account_asset_management/tests/test_asset_management_xls.py
@@ -31,7 +31,9 @@ class TestAssetManagementXls(SavepointCase):
         cls.wiz_model = cls.env["wiz.account.asset.report"]
         cls.company = cls.env.ref("base.main_company")
         # Ensure we have something to report on
-        cls.env.ref("account_asset_management." "account_asset_asset_ict0").validate()
+        ict0 = cls.env.ref("account_asset_management.account_asset_asset_ict0")
+        ict0.compute_depreciation_board()
+        ict0.validate()
         asset_group_id = cls.wiz_model._default_asset_group_id()
         fy_dates = cls.company.compute_fiscalyear_dates(fields.date.today())
 

--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -109,6 +109,8 @@
                             <group colspan="4" col="4">
                                 <field name="profile_id" />
                                 <field name="group_ids" widget="many2many_tags" />
+                                <field name="manual_lines" widget="boolean_toggle" />
+                                <field name="editable_lines" widget="boolean_toggle" />
                                 <field name="partner_id" />
                                 <field
                                     name="account_analytic_id"
@@ -120,7 +122,11 @@
                                     widget="many2many_tags"
                                 />
                             </group>
-                            <group colspan="4">
+                            <group
+                                name='depreciation_auto'
+                                colspan="4"
+                                attrs="{'invisible':[('manual_lines', '=', True)]}"
+                            >
                                 <group>
                                     <separator
                                         string="Depreciation Dates"
@@ -167,18 +173,19 @@
                                     name="compute_depreciation_board"
                                     string="Compute"
                                     icon="fa-gears"
-                                    attrs="{'invisible': [('state', 'in', ['close', 'removed'])]}"
+                                    attrs="{'invisible': ['|', ('state', 'in', ['close', 'removed']), ('manual_lines', '=', True)]}"
                                 />
                             </div>
                             <field
                                 name="depreciation_line_ids"
+                                readonly="1"
+                                attrs="{'invisible':[('editable_lines', '=', True)]}"
                                 mode="tree"
                                 options="{'reload_on_button': true}"
                             >
                                 <tree
                                     string="Asset Lines"
                                     decoration-info="(move_check == False) and (init_entry == False)"
-                                    create="false"
                                 >
                                     <field name="type" />
                                     <field name="line_date" />
@@ -213,7 +220,7 @@
                                         attrs="{'invisible': [('move_check', '!=', True)]}"
                                     />
                                 </tree>
-                                <form string="Asset Line">
+                                <form string="Asset Line" edit="false">
                                     <group>
                                         <group>
                                             <field name="parent_state" invisible="1" />
@@ -250,6 +257,51 @@
                                         </group>
                                     </group>
                                 </form>
+                            </field>
+                            <field
+                                name="depreciation_line_manual_ids"
+                                attrs="{'invisible':[('editable_lines', '!=', True)]}"
+                                can_create="true"
+                                mode="tree"
+                                options="{'reload_on_button': true}"
+                            >
+                                <tree
+                                    string="Asset Lines"
+                                    decoration-info="(move_check == False) and (init_entry == False)"
+                                    editable="bottom"
+                                >
+                                    <field name="type" />
+                                    <field name="line_date" />
+                                    <field name="depreciated_value" readonly="1" />
+                                    <field name="amount" />
+                                    <field name="remaining_value" readonly="1" />
+                                    <field name="init_entry" string="Init" />
+                                    <field name="move_check" />
+                                    <field name="parent_state" invisible="1" />
+                                    <button
+                                        name="create_move"
+                                        icon="fa-cog"
+                                        string="Create Move"
+                                        type="object"
+                                        attrs="{'invisible': ['|', '|', ('init_entry', '=', True), ('move_check', '!=', False), ('parent_state', '!=', 'open')]}"
+                                    />
+                                    <button
+                                        name="open_move"
+                                        icon="fa-folder-open-o"
+                                        string="View Move"
+                                        type="object"
+                                        attrs="{'invisible': [('move_check', '!=', True)]}"
+                                    />
+                                    <button
+                                        name="unlink_move"
+                                        icon="fa-times"
+                                        string="Delete Move"
+                                        type="object"
+                                        confirm="Are you sure ?"
+                                        groups="account.group_account_manager"
+                                        attrs="{'invisible': [('move_check', '!=', True)]}"
+                                    />
+                                </tree>
                             </field>
                         </page>
                         <page string="History">


### PR DESCRIPTION
Some companies may need to manage a custom depreciation board because the depreciation schedule is too custom,
or because it may have evolved over time and cannot follow a single method.
In those cases it's better to manage a manual depreciation schedule.

This PR allows to:
* Enter manually the depreciation board.
* Compute the depreciation board based on rules, but allow editing of lines.


Attention:
This PR removes several stored attributes from computed fields in the `account.asset.line` in order to make sure that the calculations are always accurate whenever the edits lines in the depreciation board.

![image](https://user-images.githubusercontent.com/7683926/71367061-242cc700-25a4-11ea-88c8-620a90aa5625.png)

