### PR TITLE
Impossible to set lock date before next month

### DIFF
--- a/account_lock_to_date/models/res_company.py
+++ b/account_lock_to_date/models/res_company.py
@@ -74,7 +74,7 @@ class ResCompany(models.Model):
 
             # The user attempts to set a lock date for advisors after
             # the first day of next month
-            if fiscalyear_lock_to_date < next_month:
+            if fiscalyear_lock_to_date > next_month:
                 raise ValidationError(
                     _('You cannot lock a period that is not finished yet. '
                       'Please make sure that the lock date for advisors is '


### PR DESCRIPTION
I swapped the comparison sign with the next_month date.
It is not logical to prohibit locking the entry BEFORE this date but AFTER.. as indicated in the comment.
The odoo code is correct in addons/account_lock/models/res_company.py