### PR TITLE
[13.0][FIX] account_asset_management: make asset company match move's

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -88,13 +88,11 @@ class AccountMove(models.Model):
                     "date_start": move.date,
                     "account_analytic_id": aml.analytic_account_id,
                 }
-                if self.env.context.get("company_id"):
-                    vals["company_id"] = self.env["res.company"].browse(
-                        self.env.context["company_id"]
-                    )
                 asset_form = Form(
                     self.env["account.asset"].with_context(
-                        create_asset_from_move_line=True, move_id=move.id
+                        create_asset_from_move_line=True,
+                        force_company=move.company_id.id,
+                        move_id=move.id,
                     )
                 )
                 for key, val in vals.items():


### PR DESCRIPTION
To start, the context `company_id` is no longer used in v13. Instead, we use `force_company`.

OTOH, it doesn't make much sense because in case you have several companies enabled in your context, not necessarily your main one is gonna be the one that should be used for the asset. Instead, it should be the move company always, or consistency rules will fail.

@Tecnativa TT31311