### PR TITLE
[14.0] Add module account_move_name_sequence

### DIFF
--- a/account_move_name_sequence/README.rst
+++ b/account_move_name_sequence/README.rst
@@ -1,0 +1,1 @@
+Will be auto-generated from the readme subdir

--- a/account_move_name_sequence/__init__.py
+++ b/account_move_name_sequence/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_move_name_sequence/__init__.py
+++ b/account_move_name_sequence/__init__.py
@@ -1,1 +1,2 @@
+from .post_install import create_journal_sequences
 from . import models

--- a/account_move_name_sequence/__manifest__.py
+++ b/account_move_name_sequence/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Account Move Number Sequence",
+    "version": "14.0.1.0.0",
+    "category": "Accounting",
+    "license": "AGPL-3",
+    "summary": "Generate journal entry number from sequence",
+    "author": "Akretion,Odoo Community Association (OCA)",
+    "maintainers": ["alexis-via"],
+    "website": "https://github.com/OCA/account-financial-tools",
+    "depends": ["account"],
+    "data": [
+        "views/account_journal.xml",
+        "security/ir.model.access.csv",
+    ],
+    "installable": True,
+}

--- a/account_move_name_sequence/__manifest__.py
+++ b/account_move_name_sequence/__manifest__.py
@@ -14,7 +14,9 @@
     "depends": ["account"],
     "data": [
         "views/account_journal.xml",
+        "views/account_move.xml",
         "security/ir.model.access.csv",
     ],
+    "post_init_hook": "create_journal_sequences",
     "installable": True,
 }

--- a/account_move_name_sequence/models/__init__.py
+++ b/account_move_name_sequence/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_journal
+from . import account_move

--- a/account_move_name_sequence/models/account_journal.py
+++ b/account_move_name_sequence/models/account_journal.py
@@ -1,0 +1,96 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    sequence_id = fields.Many2one(
+        "ir.sequence",
+        string="Entry Sequence",
+        copy=False,
+        check_company=True,
+        domain="[('company_id', '=', company_id)]",
+        help="This sequence will be used to generate the journal entry number.",
+    )
+    refund_sequence = fields.Boolean(
+        string="Dedicated Credit Note Sequence",
+        default=True,
+        help="If enabled, you will be able to setup a sequence dedicated for refunds.",
+    )
+    refund_sequence_id = fields.Many2one(
+        "ir.sequence",
+        string="Credit Note Entry Sequence",
+        copy=False,
+        check_company=True,
+        domain="[('company_id', '=', company_id)]",
+        help="This sequence will be used to generate the journal entry number for refunds.",
+    )
+
+    @api.constrains("refund_sequence_id", "sequence_id")
+    def _check_journal_sequence(self):
+        for journal in self:
+            if (
+                journal.refund_sequence_id
+                and journal.sequence_id
+                and journal.refund_sequence_id == journal.sequence_id
+            ):
+                raise ValidationError(
+                    _(
+                        "On journal '%s', the same sequence is used as "
+                        "Entry Sequence and Credit Note Entry Sequence."
+                    )
+                    % journal.display_name
+                )
+            if journal.sequence_id and not journal.sequence_id.company_id:
+                raise ValidationError(
+                    _(
+                        "The company is not set on sequence '%s' configured on "
+                        "journal '%s'."
+                    )
+                    % (journal.sequence_id.display_name, journal.display_name)
+                )
+            if journal.refund_sequence_id and not journal.refund_sequence_id.company_id:
+                raise ValidationError(
+                    _(
+                        "The company is not set on sequence '%s' configured as "
+                        "credit note sequence of journal '%s'."
+                    )
+                    % (journal.refund_sequence_id.display_name, journal.display_name)
+                )
+
+    @api.model
+    def create(self, vals):
+        if not vals.get("sequence_id"):
+            vals["sequence_id"] = self._create_sequence(vals).id
+        if (
+            vals.get("type") in ("sale", "purchase")
+            and vals.get("refund_sequence")
+            and not vals.get("refund_sequence_id")
+        ):
+            vals["refund_sequence_id"] = self._create_sequence(vals, refund=True).id
+        return super().create(vals)
+
+    @api.model
+    def _prepare_sequence(self, vals, refund=False):
+        code = vals.get("code") and vals["code"].upper() or ""
+        prefix = "%s%s/%%(range_year)s/" % (refund and "R" or "", code)
+        seq_vals = {
+            "name": "%s%s"
+            % (vals.get("name", _("Sequence")), refund and _("Refund") + " " or ""),
+            "company_id": vals.get("company_id") or self.env.company.id,
+            "implementation": "no_gap",
+            "prefix": prefix,
+            "padding": 4,
+            "use_date_range": True,
+        }
+        return seq_vals
+
+    @api.model
+    def _create_sequence(self, vals, refund=False):
+        seq_vals = self._prepare_sequence(vals, refund=refund)
+        return self.env["ir.sequence"].sudo().create(seq_vals)

--- a/account_move_name_sequence/models/account_journal.py
+++ b/account_move_name_sequence/models/account_journal.py
@@ -13,6 +13,7 @@ class AccountJournal(models.Model):
         "ir.sequence",
         string="Entry Sequence",
         copy=False,
+        required=True,
         check_company=True,
         domain="[('company_id', '=', company_id)]",
         help="This sequence will be used to generate the journal entry number.",

--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -2,31 +2,44 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, fields, models
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def _compute_name(self):
-        for move in self.filtered(
-            lambda m: (m.name == "/" or not m.name)
-            and m.state == "posted"
-            and m.journal_id
-            and m.journal_id.sequence_id
-        ):
+    name = fields.Char(compute="_compute_name_by_sequence")
+    # highest_name, sequence_prefix and sequence_number are not needed any more
+    # -> compute=False to improve perf
+    highest_name = fields.Char(compute=False)
+    sequence_prefix = fields.Char(compute=False)
+    sequence_number = fields.Integer(compute=False)
+
+    @api.depends("state", "journal_id", "date")
+    def _compute_name_by_sequence(self):
+        for move in self:
+            name = move.name or "/"
+            # I can't use posted_before in this IF because
+            # posted_before is set to True in _post() at the same
+            # time as state is set to "posted"
             if (
-                move.move_type in ("out_refund", "in_refund")
-                and move.journal_id.type in ("sale", "purchase")
-                and move.journal_id.refund_sequence
-                and move.journal_id.refund_sequence_id
+                move.state == "posted"
+                and (not move.name or move.name == "/")
+                and move.journal_id
+                and move.journal_id.sequence_id
             ):
-                seq = move.journal_id.refund_sequence_id
-            else:
-                seq = move.journal_id.sequence_id
-            move.name = seq.next_by_id(sequence_date=move.date)
-        super()._compute_name()
-        for move in self.filtered(
-            lambda m: m.name and m.name != "/" and m.state != "posted"
-        ):
-            move.name = "/"
+                if (
+                    move.move_type in ("out_refund", "in_refund")
+                    and move.journal_id.type in ("sale", "purchase")
+                    and move.journal_id.refund_sequence
+                    and move.journal_id.refund_sequence_id
+                ):
+                    seq = move.journal_id.refund_sequence_id
+                else:
+                    seq = move.journal_id.sequence_id
+                name = seq.next_by_id(sequence_date=move.date)
+            move.name = name
+
+    # We must by-pass this constraint of sequence.mixin
+    def _constrains_date_sequence(self):
+        return True

--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -1,0 +1,32 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _compute_name(self):
+        for move in self.filtered(
+            lambda m: (m.name == "/" or not m.name)
+            and m.state == "posted"
+            and m.journal_id
+            and m.journal_id.sequence_id
+        ):
+            if (
+                move.move_type in ("out_refund", "in_refund")
+                and move.journal_id.type in ("sale", "purchase")
+                and move.journal_id.refund_sequence
+                and move.journal_id.refund_sequence_id
+            ):
+                seq = move.journal_id.refund_sequence_id
+            else:
+                seq = move.journal_id.sequence_id
+            move.name = seq.next_by_id(sequence_date=move.date)
+        super()._compute_name()
+        for move in self.filtered(
+            lambda m: m.name and m.name != "/" and m.state != "posted"
+        ):
+            move.name = "/"

--- a/account_move_name_sequence/post_install.py
+++ b/account_move_name_sequence/post_install.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def create_journal_sequences(cr, registry):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        journals = env["account.journal"].with_context(active_test=False).search([])
+        for journal in journals:
+            vals = {}
+            journal_vals = {
+                "code": journal.code,
+                "name": journal.name,
+                "company_id": journal.company_id.id,
+            }
+            seq_vals = journal._prepare_sequence(journal_vals)
+            vals["sequence_id"] = env["ir.sequence"].create(seq_vals).id
+            if journal.type in ("sale", "purchase") and journal.refund_sequence:
+                rseq_vals = journal._prepare_sequence(journal_vals, refund=True)
+                vals["refund_sequence_id"] = env["ir.sequence"].create(rseq_vals).id
+            journal.write(vals)
+    return

--- a/account_move_name_sequence/readme/CONFIGURE.rst
+++ b/account_move_name_sequence/readme/CONFIGURE.rst
@@ -1,3 +1,5 @@
 On the form view of an account journal, in the first tab, there is a many2one link to the sequence. When you create a new journal, you can keep this field empty and a new sequence will be automatically created when you save the journal.
 
 On sale and purchase journals, you have an additionnal option to have another sequence dedicated to refunds.
+
+Upon module installation, all existing journals will be updated with a journal entry sequence (and also a credit note sequence for sale and purchase journals). You should update the configuration of the sequences to fit your needs. You can uncheck the option *Dedicated Credit Note Sequence* on existing sale and purchase journals if you don't want it. For the journals which already have journal entries, you should update the sequence configuration to avoid a discontinuity in the numbering for the next journal entry.

--- a/account_move_name_sequence/readme/CONFIGURE.rst
+++ b/account_move_name_sequence/readme/CONFIGURE.rst
@@ -1,0 +1,3 @@
+On the form view of an account journal, in the first tab, there is a many2one link to the sequence. When you create a new journal, you can keep this field empty and a new sequence will be automatically created when you save the journal.
+
+On sale and purchase journals, you have an additionnal option to have another sequence dedicated to refunds.

--- a/account_move_name_sequence/readme/CONTRIBUTORS.rst
+++ b/account_move_name_sequence/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Alexis de Lattre <alexis.delattre@akretion.com>

--- a/account_move_name_sequence/readme/DESCRIPTION.rst
+++ b/account_move_name_sequence/readme/DESCRIPTION.rst
@@ -1,0 +1,14 @@
+In Odoo version 13.0 and previous versions, the number of journal entries was generated from a sequence configured on the journal.
+
+In Odoo version 14.0, the number of journal entries can be manually set by the user. Then, the number attributed for next journal entries in the same journal is computed by a complex piece of code that guesses the format of the journal entry number from the number of the journal entry which was manually entered by the user. It has several drawbacks:
+
+* the available options for the sequence are limited,
+* it is not possible to configure the sequence in advance before the deployment in production,
+* as it is error-prone, they added a *Resequence* wizard to re-generate the journal entry numbers, which can be considered as illegal in many countries,
+* the `piece of code <https://github.com/odoo/odoo/blob/14.0/addons/account/models/sequence_mixin.py>`_ that handle this is not easy to understand and quite difficult to debug.
+
+For those like me who think that the implementation before Odoo v14.0 was much better, for the accountants who think it should not be possible to manually enter the sequence of a customer invoice, for the auditor who consider that resequencing journal entries is prohibited by law, this module may be a solution to get out of the nightmare.
+
+The field names used in this module to configure the sequence on the journal are exactly the same as in Odoo version 13.0 and previous versions. That way, if you migrate to Odoo version 14.0 and you install this module immediately after the migration, you should keep the previous behavior and the same sequences will continue to be used.
+
+The module removes access to the *Resequence* wizard on journal entries.

--- a/account_move_name_sequence/security/ir.model.access.csv
+++ b/account_move_name_sequence/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+account.access_account_resequence,Remove rights on account.resequence.wizard,account.model_account_resequence_wizard,account.group_account_manager,0,0,0,0

--- a/account_move_name_sequence/tests/__init__.py
+++ b/account_move_name_sequence/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_move_name_seq

--- a/account_move_name_sequence/tests/test_account_move_name_seq.py
+++ b/account_move_name_sequence/tests/test_account_move_name_seq.py
@@ -78,6 +78,9 @@ class TestAccountMoveNameSequence(TransactionCase):
             ]
         )
         self.assertEqual(drange_count, 1)
+        move.button_draft()
+        move.action_post()
+        self.assertEqual(move.name, move_name)
 
     def test_in_refund(self):
         in_refund_invoice = self.env["account.move"].create(
@@ -104,4 +107,7 @@ class TestAccountMoveNameSequence(TransactionCase):
         seq = self.purchase_journal.refund_sequence_id
         move_name = "%s%s" % (seq.prefix, "1".zfill(seq.padding))
         move_name = move_name.replace("%(range_year)s", str(self.date.year))
+        self.assertEqual(in_refund_invoice.name, move_name)
+        in_refund_invoice.button_draft()
+        in_refund_invoice.action_post()
         self.assertEqual(in_refund_invoice.name, move_name)

--- a/account_move_name_sequence/tests/test_account_move_name_seq.py
+++ b/account_move_name_sequence/tests/test_account_move_name_seq.py
@@ -1,0 +1,107 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from datetime import datetime
+
+from odoo import fields
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestAccountMoveNameSequence(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.company = self.env.ref("base.main_company")
+        self.misc_journal = self.env["account.journal"].create(
+            {
+                "name": "Test Journal Move name seq",
+                "code": "ADLM",
+                "type": "general",
+                "company_id": self.company.id,
+            }
+        )
+        self.purchase_journal = self.env["account.journal"].create(
+            {
+                "name": "Test Purchase Journal Move name seq",
+                "code": "ADLP",
+                "type": "purchase",
+                "company_id": self.company.id,
+                "refund_sequence": True,
+            }
+        )
+        self.accounts = self.env["account.account"].search(
+            [("company_id", "=", self.company.id)], limit=2
+        )
+        self.account1 = self.accounts[0]
+        self.account2 = self.accounts[1]
+        self.date = datetime.now()
+
+    def test_seq_creation(self):
+        self.assertTrue(self.misc_journal.sequence_id)
+        seq = self.misc_journal.sequence_id
+        self.assertEqual(seq.company_id, self.company)
+        self.assertEqual(seq.implementation, "no_gap")
+        self.assertEqual(seq.padding, 4)
+        self.assertTrue(seq.use_date_range)
+        self.assertTrue(self.purchase_journal.sequence_id)
+        self.assertTrue(self.purchase_journal.refund_sequence_id)
+        seq = self.purchase_journal.refund_sequence_id
+        self.assertEqual(seq.company_id, self.company)
+        self.assertEqual(seq.implementation, "no_gap")
+        self.assertEqual(seq.padding, 4)
+        self.assertTrue(seq.use_date_range)
+
+    def test_misc_move_name(self):
+        move = self.env["account.move"].create(
+            {
+                "date": self.date,
+                "journal_id": self.misc_journal.id,
+                "line_ids": [
+                    (0, 0, {"account_id": self.account1.id, "debit": 10}),
+                    (0, 0, {"account_id": self.account2.id, "credit": 10}),
+                ],
+            }
+        )
+        self.assertEqual(move.name, "/")
+        move.action_post()
+        seq = self.misc_journal.sequence_id
+        move_name = "%s%s" % (seq.prefix, "1".zfill(seq.padding))
+        move_name = move_name.replace("%(range_year)s", str(self.date.year))
+        self.assertEqual(move.name, move_name)
+        self.assertTrue(seq.date_range_ids)
+        drange_count = self.env["ir.sequence.date_range"].search_count(
+            [
+                ("sequence_id", "=", seq.id),
+                ("date_from", "=", fields.Date.add(self.date, month=1, day=1)),
+            ]
+        )
+        self.assertEqual(drange_count, 1)
+
+    def test_in_refund(self):
+        in_refund_invoice = self.env["account.move"].create(
+            {
+                "journal_id": self.purchase_journal.id,
+                "invoice_date": self.date,
+                "partner_id": self.env.ref("base.res_partner_3").id,
+                "move_type": "in_refund",
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "account_id": self.account1.id,
+                            "price_unit": 42.0,
+                            "quantity": 12,
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertEqual(in_refund_invoice.name, "/")
+        in_refund_invoice.action_post()
+        seq = self.purchase_journal.refund_sequence_id
+        move_name = "%s%s" % (seq.prefix, "1".zfill(seq.padding))
+        move_name = move_name.replace("%(range_year)s", str(self.date.year))
+        self.assertEqual(in_refund_invoice.name, move_name)

--- a/account_move_name_sequence/views/account_journal.xml
+++ b/account_move_name_sequence/views/account_journal.xml
@@ -6,29 +6,25 @@
 -->
 <odoo>
 
-                  <record id="view_account_journal_form" model="ir.ui.view">
-                          <field name="model">account.journal</field>
-                          <field
-            name="inherit_id"
-            ref="account.view_account_journal_form"
-        />
-                          <field name="arch" type="xml">
-                                  <field name="currency_id" position="after">
-                                          <field
+    <record id="view_account_journal_form" model="ir.ui.view">
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="arch" type="xml">
+            <field name="refund_sequence" position="before">
+                <field
                     name="sequence_id"
+                    required="0"
                     context="{'default_name': name, 'default_company_id': company_id, 'default_implementation': 'no_gap', 'default_padding': 4, 'default_use_date_range': True, 'default_prefix': code + '/%%(range_year)s/'}"
                 />
-                                          <field
-                    name="refund_sequence"
-                    attrs="{'invisible': [('type', 'not in', ('sale', 'purchase'))]}"
-                />
-                                          <field
+            </field>
+            <field name="refund_sequence" position="after">
+                <field
                     name="refund_sequence_id"
                     attrs="{'invisible': ['|', ('type', 'not in', ('sale', 'purchase')), ('refund_sequence', '=', False)]}"
                     context="{'default_name': name, 'default_company_id': company_id, 'default_implementation': 'no_gap', 'default_padding': 4, 'default_use_date_range': True, 'default_prefix': 'R' + code + '/%%(range_year)s/'}"
                 />
-                                  </field>
-                          </field>
-                  </record>
+            </field>
+        </field>
+    </record>
 
-          </odoo>
+</odoo>

--- a/account_move_name_sequence/views/account_journal.xml
+++ b/account_move_name_sequence/views/account_journal.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2021 Akretion France (http://www.akretion.com/)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+                  <record id="view_account_journal_form" model="ir.ui.view">
+                          <field name="model">account.journal</field>
+                          <field
+            name="inherit_id"
+            ref="account.view_account_journal_form"
+        />
+                          <field name="arch" type="xml">
+                                  <field name="currency_id" position="after">
+                                          <field
+                    name="sequence_id"
+                    context="{'default_name': name, 'default_company_id': company_id, 'default_implementation': 'no_gap', 'default_padding': 4, 'default_use_date_range': True, 'default_prefix': code + '/%%(range_year)s/'}"
+                />
+                                          <field
+                    name="refund_sequence"
+                    attrs="{'invisible': [('type', 'not in', ('sale', 'purchase'))]}"
+                />
+                                          <field
+                    name="refund_sequence_id"
+                    attrs="{'invisible': ['|', ('type', 'not in', ('sale', 'purchase')), ('refund_sequence', '=', False)]}"
+                    context="{'default_name': name, 'default_company_id': company_id, 'default_implementation': 'no_gap', 'default_padding': 4, 'default_use_date_range': True, 'default_prefix': 'R' + code + '/%%(range_year)s/'}"
+                />
+                                  </field>
+                          </field>
+                  </record>
+
+          </odoo>

--- a/account_move_name_sequence/views/account_move.xml
+++ b/account_move_name_sequence/views/account_move.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2021 Akretion France (http://www.akretion.com/)
+  @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+                <xpath
+                expr="//div[hasclass('oe_title')]/h1[hasclass('mt0')]"
+                position="attributes"
+            >
+                        <attribute
+                    name="attrs"
+                >{'invisible': [('name', '=', '/')]}</attribute>
+                </xpath>
+                <xpath
+                expr="//div[hasclass('oe_title')]//field[@name='name']"
+                position="attributes"
+            >
+                        <attribute name="attrs">{'readonly': 1}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='highest_name']/.." position="attributes">
+                <attribute name="attrs">{'invisible': 1}</attribute>
+                </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/account_move_name_sequence/odoo/addons/account_move_name_sequence
+++ b/setup/account_move_name_sequence/odoo/addons/account_move_name_sequence
@@ -1,0 +1,1 @@
+../../../../account_move_name_sequence

--- a/setup/account_move_name_sequence/setup.py
+++ b/setup/account_move_name_sequence/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module restores the good old behavior where journal entry numbers were generated from a sequence configured on the journal.

It uses the same datamodel as previous odoo versions, to facilitate the migration to odoo v14.

It is an alternative to PR https://github.com/OCA/account-invoicing/pull/932/files but with a different approach: here, we just try to restore the same behavior as previous odoo versions, we don't try to add new (great) features.

I plan to add tests soon.