### PR TITLE
[14.0][FIX] account_asset_management, error on remove for asset no depre

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -36,7 +36,7 @@ class AccountMove(models.Model):
         for rec in self:
             assets = (
                 self.env["account.asset.line"]
-                .search([("move_id", "=", self.id)])
+                .search([("move_id", "=", rec.id)])
                 .mapped("asset_id")
             )
             rec.asset_count = len(assets)

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -252,6 +252,8 @@ class AccountAssetRemove(models.TransientModel):
         if not dlines:
             asset.compute_depreciation_board()
             dlines = _dlines(asset)
+        if not dlines:
+            return asset.value_residual
         first_to_depreciate_dl = dlines[0]
 
         first_date = first_to_depreciate_dl.line_date


### PR DESCRIPTION
Create asset with profile, which has number of year = 0 (no depreciation asset).
Error will occur when try to to remove it.

![Selection_111](https://user-images.githubusercontent.com/1973598/132324293-9a092d6b-aa6f-4eb1-a956-f334b0e11274.png)


