### PR TITLE
[13.0][IMP] account_maturity_date_default: Define the maturity date of the entries when updating the journal entry date.

### DIFF
--- a/account_maturity_date_default/models/__init__.py
+++ b/account_maturity_date_default/models/__init__.py
@@ -1,1 +1,2 @@
+from . import account_move
 from . import account_move_line

--- a/account_maturity_date_default/models/account_move.py
+++ b/account_maturity_date_default/models/account_move.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def write(self, vals):
+        res = super().write(vals)
+        if vals.get("date"):
+            self.mapped("line_ids").filtered(
+                lambda x: (
+                    not x.date_maturity
+                    and x.account_internal_type in {"receivable", "payable"}
+                )
+            ).write({"date_maturity": vals["date"]})
+        return res

--- a/account_maturity_date_default/tests/test_account_move.py
+++ b/account_maturity_date_default/tests/test_account_move.py
@@ -56,6 +56,17 @@ class TestAccountMove(common.SavepointCase):
         invoice = move_form.save()
         return invoice
 
+    def test_invoice_move_update(self):
+        invoice = self._create_invoice()
+        invoice.line_ids.write({"date_maturity": False})
+        invoice.write({"date": "1999-12-31"})
+        invoice_line = invoice.line_ids.filtered(
+            lambda x: x.account_id.internal_type == "receivable"
+        )
+        self.assertEqual(
+            invoice_line.date_maturity, fields.Date.from_string("1999-12-31")
+        )
+
     def test_invoice_reconciliation(self):
         invoice = self._create_invoice()
         invoice.action_post()


### PR DESCRIPTION
Define the maturity date of the entries when updating the journal entry date.

Please @joao-p-marques and  @pedrobaeza can you review it?

@Tecnativa TT31617