### PR TITLE
[14.0][ADD] account_asset_management, option to set group_ids on bill

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -102,6 +102,7 @@ class AccountMove(models.Model):
                     setattr(asset_form, key, val)
                 asset = asset_form.save()
                 asset.analytic_tag_ids = aml.analytic_tag_ids
+                asset.group_ids = aml.asset_group_ids
                 aml.with_context(allow_asset=True).asset_id = asset.id
             refs = [
                 "<a href=# data-oe-model=account.asset data-oe-id=%s>%s</a>"
@@ -158,6 +159,13 @@ class AccountMoveLine(models.Model):
         comodel_name="account.asset.profile",
         string="Asset Profile",
     )
+    asset_group_ids = fields.Many2many(
+        comodel_name="account.asset.group",
+        relation="account_move_line_asset_group_rel",
+        column1="asset_id",
+        column2="group_id",
+        string="Asset Groups",
+    )
     asset_id = fields.Many2one(
         comodel_name="account.asset",
         string="Asset",
@@ -172,7 +180,8 @@ class AccountMoveLine(models.Model):
 
     @api.onchange("asset_profile_id")
     def _onchange_asset_profile_id(self):
-        if self.asset_profile_id.account_asset_id:
+        if self.asset_profile_id:
+            self.asset_group_ids = self.asset_profile_id.group_ids
             self.account_id = self.asset_profile_id.account_asset_id
 
     @api.model_create_multi

--- a/account_asset_management/views/account_move.xml
+++ b/account_asset_management/views/account_move.xml
@@ -31,6 +31,13 @@
                     optional="show"
                 />
                 <field
+                    name="asset_group_ids"
+                    widget="many2many_tags"
+                    attrs="{'column_invisible': [('parent.move_type', 'not in', ('in_invoice', 'in_refund'))]}"
+                    groups="account.group_account_manager"
+                    optional="hide"
+                />
+                <field
                     name="asset_id"
                     attrs="{'column_invisible': [('parent.move_type', 'not in', ('out_invoice', 'out_refund'))]}"
                     groups="account.group_account_manager"
@@ -44,6 +51,12 @@
                 <field
                     name="asset_profile_id"
                     domain="[('company_id','=', parent.company_id)]"
+                />
+                <field
+                    name="asset_group_ids"
+                    widget="many2many_tags"
+                    domain="[('company_id','=', parent.company_id)]"
+                    optional="hide"
                 />
                 <field name="asset_id" groups="account.group_account_manager" />
             </xpath>

--- a/account_asset_management/views/account_move_line.xml
+++ b/account_asset_management/views/account_move_line.xml
@@ -10,6 +10,7 @@
                     name="asset_profile_id"
                     domain="[('company_id','=', parent.company_id)]"
                 />
+                <field name="asset_group_ids" widget="many2many_tags" optional="hide" />
                 <field name="asset_id" />
             </field>
         </field>


### PR DESCRIPTION
This enhancement allow option to assign asset_group_ids since Vendor Bill.

![image](https://user-images.githubusercontent.com/1973598/134906088-33964bc5-db1e-4015-ba64-a948bd38971f.png)


---

Then, the asset is created with selected group_ids

![image](https://user-images.githubusercontent.com/1973598/134906411-5a0a886a-b128-48f6-aadb-a6fe50a73f44.png)
