### PR TITLE
[13.0][FIX] account_move_line_sale_info: do not copy sale references

### DIFF
--- a/account_move_line_sale_info/models/account_move.py
+++ b/account_move_line_sale_info/models/account_move.py
@@ -56,6 +56,7 @@ class AccountMoveLine(models.Model):
         string="Sale Order Line",
         ondelete="set null",
         index=True,
+        copy=False,
     )
 
     sale_order_id = fields.Many2one(
@@ -65,4 +66,5 @@ class AccountMoveLine(models.Model):
         ondelete="set null",
         store=True,
         index=True,
+        copy=False,
     )


### PR DESCRIPTION
@ForgeFlow