### PR TITLE
[14.0][FIX] account_asset_management, error create bill by purchase user

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -30,7 +30,7 @@ FIELDS_AFFECTS_ASSET_MOVE_LINE = {
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    asset_count = fields.Integer(compute="_compute_asset_count")
+    asset_count = fields.Integer(compute="_compute_asset_count", compute_sudo=True)
 
     def _compute_asset_count(self):
         for rec in self:


### PR DESCRIPTION
This error wasn't detected if user have invoicing access rights.

But if for the purchase user (without invoicing rights), click create Bill from Purchase Order, error will occur

![Selection_055](https://user-images.githubusercontent.com/1973598/136366008-fa20942c-8589-4b19-8030-152ede2ecb97.png)

Fixed by using compute_sudo=True