### PR TITLE
[14.0][FIX] account_asset_management, error create bill by purchase user

### DIFF
--- a/account_asset_management/views/account_move.xml
+++ b/account_asset_management/views/account_move.xml
@@ -4,6 +4,7 @@
         <field name="name">account.move.form.account.asset.management</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
+        <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]" />
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                 <button


### PR DESCRIPTION
This error wasn't detected if user have invoicing access rights.

But if for the purchase user (without invoicing rights), click create Bill from Purchase Order, error will occur

![Selection_055](https://user-images.githubusercontent.com/1973598/136366008-fa20942c-8589-4b19-8030-152ede2ecb97.png)

Fixed by adding group = Billing to view.