### PR TITLE
[13.0][IMP] account_move_purchase_info: make purchase fields optional in journal entries too

### DIFF
--- a/account_move_line_purchase_info/views/account_move_view.xml
+++ b/account_move_line_purchase_info/views/account_move_view.xml
@@ -81,10 +81,12 @@
                 <field
                     name="purchase_line_id"
                     context="{'po_line_info': True}"
+                    optional="hide"
                     groups="account_move_line_purchase_info.group_account_move_purchase_info"
                 />
                 <field
                     name="purchase_id"
+                    optional="show"
                     groups="account_move_line_purchase_info.group_account_move_purchase_info"
                 />
             </xpath>


### PR DESCRIPTION
Too many fields there.Similar as https://github.com/OCA/account-financial-tools/pull/1219 but for the journal entry form view

@ForgeFlow 