### PR TITLE
[13.0][IMP] account_move_sale_info: make sale fields optional in journal entries

### DIFF
--- a/account_move_line_sale_info/views/account_move_view.xml
+++ b/account_move_line_sale_info/views/account_move_view.xml
@@ -81,10 +81,12 @@
                 <field
                     name="sale_line_id"
                     context="{'so_line_info': True}"
+                    optional="hide"
                     groups="account_move_line_sale_info.group_account_move_sale_info"
                 />
                 <field
                     name="sale_order_id"
+                    optional="show"
                     groups="account_move_line_sale_info.group_account_move_sale_info"
                 />
             </xpath>


### PR DESCRIPTION
Too many fields there.Similar as #1220 but for the journal entry form view

@ForgeFlow