### PR TITLE
[12.0][FIX] account_asset_management: Avoid the error when clicking on "Delete" button if there is a residual value and all the depreciation lines are posted.

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -526,9 +526,18 @@ class AccountAsset(models.Model):
             # recompute in case of deviation
             depreciated_value_posted = depreciated_value = 0.0
             if posted_lines:
+                total_table_lines = sum([len(entry["lines"]) for entry in table])
+                move_check_lines = asset.depreciation_line_ids.filtered("move_check")
                 last_depreciation_date = last_line.line_date
                 last_date_in_table = table[-1]['lines'][-1]['date']
-                if last_date_in_table <= last_depreciation_date:
+                # If the number of lines in the table is the same as the depreciation
+                # lines, we will not show an error even if the dates are the same.
+                if (
+                    (last_date_in_table < last_depreciation_date) or (
+                        last_date_in_table == last_depreciation_date
+                        and total_table_lines != len(move_check_lines)
+                    )
+                ):
                     raise UserError(
                         _("The duration of the asset conflicts with the "
                           "posted depreciation table entry dates."))
@@ -563,6 +572,17 @@ class AccountAsset(models.Model):
                 amount_diff = round(
                     residual_amount_table - residual_amount, digits)
                 if amount_diff:
+                    # We will auto-create a new line because the number of lines in
+                    # the tables are the same as the posted depreciations and there
+                    # is still a residual value. Only in this case we will need to
+                    # add a new line to the table with the amount of the difference.
+                    if len(move_check_lines) == total_table_lines:
+                        table[table_i_start]['lines'].append(
+                            table[table_i_start]['lines'][line_i_start-1]
+                        )
+                        line = table[table_i_start]['lines'][line_i_start]
+                        line['days'] = 0
+                        line['amount'] = amount_diff
                     # compensate in first depreciation entry
                     # after last posting
                     line = table[table_i_start]['lines'][line_i_start]

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -708,3 +708,35 @@ class TestAssetManagement(SavepointCase):
         # In the last month of the fiscal year we compensate for the small
         # deviations if that is necessary.
         self.assertAlmostEqual(asset.depreciation_line_ids[12].amount, 166.63, places=2)
+
+    def test_17_asset_removal_with_value_residual(self):
+        """Asset removal with value residual"""
+        asset = self.asset_model.create({
+            'name': 'test asset removal',
+            'profile_id': self.ref('account_asset_management.'
+                                   'account_asset_profile_car_5Y'),
+            'purchase_value': 1000,
+            'salvage_value': 0,
+            'date_start': '2019-01-01',
+            'method_time': 'number',
+            'method_number': 10,
+            'method_period': 'month',
+            'prorata': False,
+        })
+        asset.compute_depreciation_board()
+        asset.validate()
+        lines = asset.depreciation_line_ids.filtered(lambda x: not x.init_entry)
+        self.assertEqual(len(lines), 10)
+        last_line = lines[-1]
+        last_line['amount'] = last_line['amount'] - 0.10
+        for asset_line in lines:
+            asset_line.create_move()
+        self.assertEqual(asset.value_residual, 0.10)
+        asset.compute_depreciation_board()
+        lines = asset.depreciation_line_ids.filtered(lambda x: not x.init_entry)
+        self.assertEqual(len(lines), 11)
+        last_line = lines[-1]
+        self.assertEqual(last_line.amount, 0.10)
+        last_line.create_move()
+        self.assertEqual(asset.value_residual, 0)
+        self.assertEqual(asset.state, "close")


### PR DESCRIPTION
Avoid the error when clicking on `Delete` button if there is a residual value and all the depreciation lines are posted.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT32861