### PR TITLE
[14.0] account_permanent_lock_move: re-write the module

### DIFF
--- a/account_permanent_lock_move/README.rst
+++ b/account_permanent_lock_move/README.rst
@@ -1,0 +1,1 @@
+Will be auto-generated from readme subdir

--- a/account_permanent_lock_move/__init__.py
+++ b/account_permanent_lock_move/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_permanent_lock_move/__manifest__.py
+++ b/account_permanent_lock_move/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Account Permanent Lock Move",
+    "version": "14.0.1.0.0",
+    "category": "Accounting",
+    "license": "AGPL-3",
+    "summary": "Lock date for all users cannot be set backwards",
+    "author": "Akretion,Odoo Community Association (OCA)",
+    "maintainers": ["alexis-via"],
+    "website": "https://github.com/OCA/account-financial-tools",
+    "depends": ["account"],
+    "installable": True,
+}

--- a/account_permanent_lock_move/models/__init__.py
+++ b/account_permanent_lock_move/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_company

--- a/account_permanent_lock_move/models/res_company.py
+++ b/account_permanent_lock_move/models/res_company.py
@@ -1,0 +1,43 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+from odoo.tools.misc import format_date
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    # the native method _validate_fiscalyear_lock() is called at the beginning of
+    # write()
+    def _validate_fiscalyear_lock(self, values):
+        if "fiscalyear_lock_date" in values:
+            new_fy_lock_date = values["fiscalyear_lock_date"]
+            for company in self:
+                if company.fiscalyear_lock_date:
+                    if not new_fy_lock_date:
+                        raise UserError(
+                            _(
+                                "You cannot remove the 'Lock Date for All Users' "
+                                "on company '%s'."
+                            )
+                            % company.display_name
+                        )
+                    else:
+                        if isinstance(new_fy_lock_date, str):
+                            new_fy_lock_date = fields.Date.from_string(new_fy_lock_date)
+                    if new_fy_lock_date < company.fiscalyear_lock_date:
+                        raise UserError(
+                            _(
+                                "On company '%s', the current 'Lock Date for All Users' "
+                                "is %s: you cannot set it backwards to %s."
+                            )
+                            % (
+                                company.display_name,
+                                format_date(self.env, company.fiscalyear_lock_date),
+                                format_date(self.env, new_fy_lock_date),
+                            )
+                        )
+        super()._validate_fiscalyear_lock(values)

--- a/account_permanent_lock_move/readme/CONTRIBUTORS.rst
+++ b/account_permanent_lock_move/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Alexis de Lattre <alexis.delattre@akretion.com>

--- a/account_permanent_lock_move/readme/DESCRIPTION.rst
+++ b/account_permanent_lock_move/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+In the Accounting module of Odoo, when you want to close a period or a fiscal year, you update the *Lock Dates* to the last day of the period or fiscal year that you want to close.
+
+By default, you can write any value on the *Lock Date* fields. As a consequence, it is always possible to re-open any period or fiscal year by setting the Lock Dates backwards.
+
+With this module, the *Lock Date for All Users* (technical field name: *fiscalyear_lock_date*) cannot be updated backwards, it can only be updated forward. For example, if the *Lock Date for All Users* has been set to December 31st 2020, it cannot be set back to December 31st 2019. The *Lock Date for Non-Advisers* (technical field name: *period_lock_date*) can still be set backwards.

--- a/account_permanent_lock_move/tests/__init__.py
+++ b/account_permanent_lock_move/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_permanent_lock_move

--- a/account_permanent_lock_move/tests/test_permanent_lock_move.py
+++ b/account_permanent_lock_move/tests/test_permanent_lock_move.py
@@ -1,0 +1,32 @@
+# Copyright 2021 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import fields
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestPermanentLockDate(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.new_company = self.env["res.company"].create(
+            {"name": "My little test company"}
+        )
+
+    def test_set_fiscal_year_lock_date(self):
+        self.new_company.write({"fiscalyear_lock_date": "2020-12-31"})
+        with self.assertRaises(UserError):
+            self.new_company.write({"fiscalyear_lock_date": False})
+        with self.assertRaises(UserError):
+            self.new_company.write({"fiscalyear_lock_date": "2020-11-30"})
+        # Test there's no error if you write the same date
+        self.new_company.write({"fiscalyear_lock_date": "2020-12-31"})
+        # Test there's no error if you move forward
+        # also test there is no bug if the date is a datetime object
+        self.new_company.write(
+            {"fiscalyear_lock_date": fields.Date.from_string("2021-01-31")}
+        )

--- a/setup/account_permanent_lock_move/odoo/addons/account_permanent_lock_move
+++ b/setup/account_permanent_lock_move/odoo/addons/account_permanent_lock_move
@@ -1,0 +1,1 @@
+../../../../account_permanent_lock_move

--- a/setup/account_permanent_lock_move/setup.py
+++ b/setup/account_permanent_lock_move/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This is a completely new implementation of the module: it doesn't use a dedicated lock date 'permanent_lock_date' any more, it puts a constraint on the native field 'fiscalyear_lock_date': it cannot be unset or updated backwards.

Advantages:

1. no need to inherit create() and write() of account.move in account_permanent_lock_date => perf improvement and code simplification
2. no need to maintain the "glue" module account_permanent_lock_move_update
3. only 3 lock dates fields instead of 4 => easier to understand for accountants.