### PR TITLE
[14.0][FIX] Add sudo() on account.asset.line

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -36,6 +36,7 @@ class AccountMove(models.Model):
         for rec in self:
             assets = (
                 self.env["account.asset.line"]
+                .sudo()
                 .search([("move_id", "=", rec.id)])
                 .mapped("asset_id")
             )


### PR DESCRIPTION
This PR is fix for error **"You are not allowed to access 'Asset depreciation table line' (account.asset.line) records."**
![Selection_438](https://user-images.githubusercontent.com/24691983/142590479-4bd0659d-bef8-4b93-9965-bdba8844e804.png)

cc: @kittiu 

