### PR TITLE
[11.0][FIX] account_move_template: Duplicate implicit target name authors a…

### DIFF
--- a/account_move_template/README.rst
+++ b/account_move_template/README.rst
@@ -71,7 +71,7 @@ Credits
 =======
 
 Authors
-~~~~~~~
+-------
 
 * Agile Business Group
 * Aurium Technologies
@@ -79,19 +79,12 @@ Authors
 * Eficent
 
 Contributors
-~~~~~~~~~~~~
-
-Authors
--------
+------------
 
 * Davide Corio <davide.corio@agilebg.com>
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 * Paolo Chiara <p.chiara@isa.it>
 * Franco Tampieri <franco.tampieri@agilebg.com>
-
-Contributors
-------------
-
 * Jalal ZAHID <j.zahid@auriumtechnologies.com>  (port to v10)
 * Alex Comba <alex.comba@agilebg.com> (Port to V8)
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>


### PR DESCRIPTION
…nd contributors

Issue detected on PR https://github.com/OCA/account-financial-tools/pull/1280

```
account_move_template/README.rst:85: [E7901(rst-syntax-error), ]  Duplicate implicit target name: "authors".
account_move_template/README.rst:93: [E7901(rst-syntax-error), ]  Duplicate implicit target name: "contributors".
```