### PR TITLE
[14.0][FIX] base_vat_optional_vies: fix tests

### DIFF
--- a/base_vat_optional_vies/tests/test_res_partner.py
+++ b/base_vat_optional_vies/tests/test_res_partner.py
@@ -12,14 +12,20 @@ class TestResPartner(common.TransactionCase):
         super(TestResPartner, self).setUp()
         self.company = self.env.user.company_id
         self.company.vat_check_vies = True
-        self.partner = self.env["res.partner"].create({"name": "Test partner"})
+        self.partner = self.env["res.partner"].create(
+            {
+                "name": "Test partner",
+                "country_id": self.env.ref("base.es").id,
+                "company_type": "company",
+            }
+        )
+        self.partner.onchange_company_type()
         self.vatnumber_path = "odoo.addons.base_vat.models.res_partner.check_vies"
 
     def test_validate_vat_vies(self):
         with mock.patch(self.vatnumber_path) as mock_vatnumber:
             mock_vatnumber.check_vies.return_value = True
             self.partner.vat = "ESB87530432"
-            self.partner.country_id = 20
             self.assertEqual(self.partner.vies_passed, True)
 
     def test_exception_vat_vies(self):
@@ -39,5 +45,5 @@ class TestResPartner(common.TransactionCase):
             self.company.vat_check_vies = False
             mock_vatnumber.check_vies.return_value = False
             self.partner.vat = "MXGODE561231GR8"
-            self.partner.country_id = 156
+            self.partner.country_id = self.env.ref("base.mx")
             self.assertEqual(self.partner.vies_passed, False)


### PR DESCRIPTION
Related to 13.0: https://github.com/OCA/account-financial-tools/pull/1279

Force EU country and compay type in test partner

After OCA/OCB@4518968#diff-1ef5fe83935572c9b9b9e6eec69a44551023f3b92fe38bed4f765a24e16694b4 and OCA/OCB@198a4dd the associated partner needs to be in a EU country and be of type company for the vies check to work.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT32861