### PR TITLE
[13.0][fix][account_asset_management] the asset can be removed irrespective of the Time Method used.

### DIFF
--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -25,7 +25,7 @@
                         string="Remove"
                         type="object"
                         groups="account.group_account_manager"
-                        attrs="{'invisible':['|', ('method_time', '!=', 'year'), ('state', 'not in', ['open', 'close'])]}"
+                        attrs="{'invisible':[('state', 'not in', ['open', 'close'])]}"
                         help="Asset removal."
                     />
                     <field


### PR DESCRIPTION
It does not make sense that you cannot remove an asset where the time method used
is not based on number of years or end date. If you choose, for example, to depreciate the asset
using the time method 'Number of depreciations' you will want to remove the asset when it has been
fully depreciated.

@luc-demeyer This code has not been changed since your initial commit of the module https://github.com/OCA/account-financial-tools/commit/76717b04705f19f19eef5d23db1f4c5176111ad4#diff-efe16d95ce441575538d16ec19ca5dad3701cb997628c1c3875006a9581b8995R81. I don't really understand the reason for it.

In my opinion since 7.0 no one has ever used a depreciation method other than 'year', and that's why no one found a reason to fix this.

