### PR TITLE
[12.0][IMP][MIG] account_asset_management: delete obsolete xmlids

### DIFF
--- a/account_asset_management/migrations/12.0.1.0.0/post-migration.py
+++ b/account_asset_management/migrations/12.0.1.0.0/post-migration.py
@@ -163,3 +163,6 @@ def migrate(env, version):
     handle_account_asset_disposal_migration(env)
     set_asset_line_previous(env)
     add_asset_initial_entry(env)
+    openupgrade.delete_records_safely_by_xml_id(
+        env, ["account_asset_management.account_asset_category_multi_company_rule",
+              "account_asset_management.account_asset_asset_multi_company_rule"])


### PR DESCRIPTION
These are the noupdate=True xmlids from account_asset, they have to be removed.