### PR TITLE
[14.0][FIX] account_asset_management: calculate day mistake, remove asset

### DIFF
--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -524,8 +524,8 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         wiz.remove()
         asset.refresh()
         self.assertEqual(len(asset.depreciation_line_ids), 3)
-        self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 83.33, places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 4916.67, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 81.46, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 4918.54, places=2)
 
     def test_09_asset_from_invoice(self):
         all_asset = self.env["account.asset"].search([])

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -273,9 +273,14 @@ class AccountAssetRemove(models.TransientModel):
             )
             last_depr_date = create_dl.line_date
 
-        period_number_days = (first_date - last_depr_date).days + 1
+        # Never create move.
+        same_month = (
+            last_depr_date.month == first_to_depreciate_dl.line_date.month and 1 or 0
+        )
+
+        period_number_days = (first_date - last_depr_date).days + same_month
         new_line_date = date_remove + relativedelta(days=-1)
-        to_depreciate_days = (new_line_date - last_depr_date).days + 1
+        to_depreciate_days = (new_line_date - last_depr_date).days + same_month
         to_depreciate_amount = round(
             float(to_depreciate_days)
             / float(period_number_days)


### PR DESCRIPTION
Fix calculate day with case create some move already.

e.g.
Purchase Value = 36,500 and not salvage value
Asset Start Date = 01/01/2022

Run 1 asset line
and We will remove this asset after create move (03/02/2022)

----------------------

**it calculate days and amount mistake** (should be 200 -> 100 * 2 before date remove)
![Selection_004](https://user-images.githubusercontent.com/20896369/150323578-8d3446fe-a587-4bb9-aade-7599bf70cc11.png)

Fix it!
![Selection_003](https://user-images.githubusercontent.com/20896369/150324079-bef18009-c1c6-4ffe-a988-c918c30ec106.png)


Reference: https://github.com/OCA/account-financial-tools/pull/1184

cc: @rconjour @ps-tubtim 