### PR TITLE
Use fully qualified self references in the demo data

### DIFF
--- a/account_sequence_option/demo/account_demo_options.xml
+++ b/account_sequence_option/demo/account_demo_options.xml
@@ -6,36 +6,42 @@
         <field name="name">Customer Invoice</field>
         <field name="padding" eval="5" />
         <field name="prefix">CINV/</field>
+        <field name="use_date_range">false</field>
     </record>
 
     <record id="seq_customer_refund_1" model="ir.sequence">
         <field name="name">Customer Refund</field>
         <field name="padding" eval="5" />
         <field name="prefix">CREF/</field>
+        <field name="use_date_range">false</field>
     </record>
 
     <record id="seq_vendor_bill_1" model="ir.sequence">
         <field name="name">Vendor Bill</field>
         <field name="padding" eval="5" />
         <field name="prefix">VBIL/</field>
+        <field name="use_date_range">false</field>
     </record>
 
     <record id="seq_vendor_refund_1" model="ir.sequence">
         <field name="name">Vendor Refund</field>
         <field name="padding" eval="5" />
         <field name="prefix">VREF/</field>
+        <field name="use_date_range">false</field>
     </record>
 
     <record id="seq_customer_payment_1" model="ir.sequence">
         <field name="name">Customer Payment</field>
         <field name="padding" eval="5" />
         <field name="prefix">CPAY/</field>
+        <field name="use_date_range">false</field>
     </record>
 
     <record id="seq_vendor_payment_1" model="ir.sequence">
         <field name="name">Vendor Payment</field>
         <field name="padding" eval="5" />
         <field name="prefix">VPAY/</field>
+        <field name="use_date_range">false</field>
     </record>
 
     <!-- Demo Options-->
@@ -48,7 +54,6 @@
             name="sequence_id"
             ref="account_sequence_option.seq_customer_invoice_1"
         />
-        <field name="use_date_range">false</field>
     </record>
 
     <record id="account_sequence_option.account_customer_refund_1" model="ir.sequence.option.line">
@@ -56,7 +61,6 @@
         <field name="name">Customer Refund</field>
         <field name="filter_domain">[("move_type", "=", "out_refund")]</field>
         <field name="sequence_id" ref="account_sequence_option.seq_customer_refund_1" />
-        <field name="use_date_range">false</field>
     </record>
 
     <record id="account_sequence_option.account_vendor_bill_1" model="ir.sequence.option.line">
@@ -64,7 +68,6 @@
         <field name="name">Vendor Bill</field>
         <field name="filter_domain">[("move_type", "=", "in_invoice")]</field>
         <field name="sequence_id" ref="account_sequence_option.seq_vendor_bill_1" />
-        <field name="use_date_range">false</field>
     </record>
 
     <record id="account_sequence_option.account_vendor_refund_1" model="ir.sequence.option.line">
@@ -72,7 +75,6 @@
         <field name="name">Vendor Refund</field>
         <field name="filter_domain">[("move_type", "=", "in_refund")]</field>
         <field name="sequence_id" ref="account_sequence_option.seq_vendor_refund_1" />
-        <field name="use_date_range">false</field>
     </record>
 
     <record id="account_sequence_option.account_customer_payment_1" model="ir.sequence.option.line">
@@ -85,7 +87,6 @@
             name="sequence_id"
             ref="account_sequence_option.seq_customer_payment_1"
         />
-        <field name="use_date_range">false</field>
     </record>
 
     <record id="account_sequence_option.account_vendor_payment_1" model="ir.sequence.option.line">
@@ -95,7 +96,6 @@
             name="filter_domain"
         >[("move_type", "=", "entry"), ("payment_id.payment_type", "=", "outbound")]</field>
         <field name="sequence_id" ref="account_sequence_option.seq_vendor_payment_1" />
-        <field name="use_date_range">false</field>
     </record>
 
 </odoo>

--- a/account_sequence_option/demo/account_demo_options.xml
+++ b/account_sequence_option/demo/account_demo_options.xml
@@ -46,35 +46,35 @@
 
     <!-- Demo Options-->
 
-    <record id="account_sequence_option.account_customer_invoice_1" model="ir.sequence.option.line">
+    <record id="account_customer_invoice_1" model="ir.sequence.option.line">
         <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Customer Invoice</field>
         <field name="filter_domain">[("move_type", "=", "out_invoice")]</field>
         <field name="sequence_id" ref="seq_customer_invoice_1" />
     </record>
 
-    <record id="account_sequence_option.account_customer_refund_1" model="ir.sequence.option.line">
+    <record id="account_customer_refund_1" model="ir.sequence.option.line">
         <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Customer Refund</field>
         <field name="filter_domain">[("move_type", "=", "out_refund")]</field>
         <field name="sequence_id" ref="seq_customer_refund_1" />
     </record>
 
-    <record id="account_sequence_option.account_vendor_bill_1" model="ir.sequence.option.line">
+    <record id="account_vendor_bill_1" model="ir.sequence.option.line">
         <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Vendor Bill</field>
         <field name="filter_domain">[("move_type", "=", "in_invoice")]</field>
         <field name="sequence_id" ref="seq_vendor_bill_1" />
     </record>
 
-    <record id="account_sequence_option.account_vendor_refund_1" model="ir.sequence.option.line">
+    <record id="account_vendor_refund_1" model="ir.sequence.option.line">
         <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Vendor Refund</field>
         <field name="filter_domain">[("move_type", "=", "in_refund")]</field>
         <field name="sequence_id" ref="seq_vendor_refund_1" />
     </record>
 
-    <record id="account_sequence_option.account_customer_payment_1" model="ir.sequence.option.line">
+    <record id="account_customer_payment_1" model="ir.sequence.option.line">
         <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Customer Payment</field>
         <field
@@ -83,7 +83,7 @@
         <field name="sequence_id" ref="seq_customer_payment_1" />
     </record>
 
-    <record id="account_sequence_option.account_vendor_payment_1" model="ir.sequence.option.line">
+    <record id="account_vendor_payment_1" model="ir.sequence.option.line">
         <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Vendor Payment</field>
         <field

--- a/account_sequence_option/demo/account_demo_options.xml
+++ b/account_sequence_option/demo/account_demo_options.xml
@@ -40,39 +40,43 @@
 
     <!-- Demo Options-->
 
-    <record id="account_customer_invoice_1" model="ir.sequence.option.line">
-        <field name="base_id" ref="account_sequence" />
+    <record id="account_sequence_option.account_customer_invoice_1" model="ir.sequence.option.line">
+        <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Customer Invoice</field>
         <field name="filter_domain">[("move_type", "=", "out_invoice")]</field>
         <field
             name="sequence_id"
             ref="account_sequence_option.seq_customer_invoice_1"
         />
+        <field name="use_date_range">false</field>
     </record>
 
-    <record id="account_customer_refund_1" model="ir.sequence.option.line">
-        <field name="base_id" ref="account_sequence" />
+    <record id="account_sequence_option.account_customer_refund_1" model="ir.sequence.option.line">
+        <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Customer Refund</field>
         <field name="filter_domain">[("move_type", "=", "out_refund")]</field>
         <field name="sequence_id" ref="account_sequence_option.seq_customer_refund_1" />
+        <field name="use_date_range">false</field>
     </record>
 
-    <record id="account_vendor_bill_1" model="ir.sequence.option.line">
-        <field name="base_id" ref="account_sequence" />
+    <record id="account_sequence_option.account_vendor_bill_1" model="ir.sequence.option.line">
+        <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Vendor Bill</field>
         <field name="filter_domain">[("move_type", "=", "in_invoice")]</field>
         <field name="sequence_id" ref="account_sequence_option.seq_vendor_bill_1" />
+        <field name="use_date_range">false</field>
     </record>
 
-    <record id="account_vendor_refund_1" model="ir.sequence.option.line">
-        <field name="base_id" ref="account_sequence" />
+    <record id="account_sequence_option.account_vendor_refund_1" model="ir.sequence.option.line">
+        <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Vendor Refund</field>
         <field name="filter_domain">[("move_type", "=", "in_refund")]</field>
         <field name="sequence_id" ref="account_sequence_option.seq_vendor_refund_1" />
+        <field name="use_date_range">false</field>
     </record>
 
-    <record id="account_customer_payment_1" model="ir.sequence.option.line">
-        <field name="base_id" ref="account_sequence" />
+    <record id="account_sequence_option.account_customer_payment_1" model="ir.sequence.option.line">
+        <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Customer Payment</field>
         <field
             name="filter_domain"
@@ -81,15 +85,17 @@
             name="sequence_id"
             ref="account_sequence_option.seq_customer_payment_1"
         />
+        <field name="use_date_range">false</field>
     </record>
 
-    <record id="account_vendor_payment_1" model="ir.sequence.option.line">
-        <field name="base_id" ref="account_sequence" />
+    <record id="account_sequence_option.account_vendor_payment_1" model="ir.sequence.option.line">
+        <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Vendor Payment</field>
         <field
             name="filter_domain"
         >[("move_type", "=", "entry"), ("payment_id.payment_type", "=", "outbound")]</field>
         <field name="sequence_id" ref="account_sequence_option.seq_vendor_payment_1" />
+        <field name="use_date_range">false</field>
     </record>
 
 </odoo>

--- a/account_sequence_option/demo/account_demo_options.xml
+++ b/account_sequence_option/demo/account_demo_options.xml
@@ -50,31 +50,28 @@
         <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Customer Invoice</field>
         <field name="filter_domain">[("move_type", "=", "out_invoice")]</field>
-        <field
-            name="sequence_id"
-            ref="account_sequence_option.seq_customer_invoice_1"
-        />
+        <field name="sequence_id" ref="seq_customer_invoice_1" />
     </record>
 
     <record id="account_sequence_option.account_customer_refund_1" model="ir.sequence.option.line">
         <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Customer Refund</field>
         <field name="filter_domain">[("move_type", "=", "out_refund")]</field>
-        <field name="sequence_id" ref="account_sequence_option.seq_customer_refund_1" />
+        <field name="sequence_id" ref="seq_customer_refund_1" />
     </record>
 
     <record id="account_sequence_option.account_vendor_bill_1" model="ir.sequence.option.line">
         <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Vendor Bill</field>
         <field name="filter_domain">[("move_type", "=", "in_invoice")]</field>
-        <field name="sequence_id" ref="account_sequence_option.seq_vendor_bill_1" />
+        <field name="sequence_id" ref="seq_vendor_bill_1" />
     </record>
 
     <record id="account_sequence_option.account_vendor_refund_1" model="ir.sequence.option.line">
         <field name="base_id" ref="account_sequence_option.account_sequence" />
         <field name="name">Vendor Refund</field>
         <field name="filter_domain">[("move_type", "=", "in_refund")]</field>
-        <field name="sequence_id" ref="account_sequence_option.seq_vendor_refund_1" />
+        <field name="sequence_id" ref="seq_vendor_refund_1" />
     </record>
 
     <record id="account_sequence_option.account_customer_payment_1" model="ir.sequence.option.line">
@@ -83,10 +80,7 @@
         <field
             name="filter_domain"
         >[("move_type", "=", "entry"), ("payment_id.payment_type", "=", "inbound")]</field>
-        <field
-            name="sequence_id"
-            ref="account_sequence_option.seq_customer_payment_1"
-        />
+        <field name="sequence_id" ref="seq_customer_payment_1" />
     </record>
 
     <record id="account_sequence_option.account_vendor_payment_1" model="ir.sequence.option.line">
@@ -95,7 +89,7 @@
         <field
             name="filter_domain"
         >[("move_type", "=", "entry"), ("payment_id.payment_type", "=", "outbound")]</field>
-        <field name="sequence_id" ref="account_sequence_option.seq_vendor_payment_1" />
+        <field name="sequence_id" ref="seq_vendor_payment_1" />
     </record>
 
 </odoo>

--- a/account_sequence_option/readme/DESCRIPTION.rst
+++ b/account_sequence_option/readme/DESCRIPTION.rst
@@ -1,2 +1,26 @@
 This module extends module ir_sequence_option and allow you to
 provide optional sequences for account.move documents, i.e., invoice, bill, journal entry.
+
+To use this module, enable developer mode, and check "Use sequence options"
+under Settings -> Technical -> Manage Sequence Options.
+
+If you want to define your sequences in XML, feel free to use
+demo/account_demo_options.xml as a base for your own sequence definitions.
+
+The demo sequences use a continuous numbering scheme, without the current year
+in the generated name. To use a scheme that does include the year, set
+`use_date_range` to `true`, and use `%(range_year)s` the represent the year.
+For example, to generate an invoice scheme that will generate "2022F00001" in
+2022, try:
+
+```
+    <record id="seq_customer_invoice_1" model="ir.sequence">
+        <field name="name">Customer Invoice</field>
+        <field name="padding" eval="5" />
+        <field name="prefix">%(range_year)sF</field>
+        <field name="use_date_range">true</field>
+    </record>
+```
+
+Odoo 14 will generate the date ranges automagically when the first invoice (or
+vendor bill, etc) of a year is posted.


### PR DESCRIPTION
This pull request updates the demo data with fully qualified self-references, to allow the file to be used as a template for a custom module more easily (I had a hard time figuring out which of the references to prefix with the module name). It also makes the default use_date_range=false explicit.

The README gained a quick blurb on how to use this module for invoice sequence customisation, and what to expect when enabling use_date_range, and a reminder that this module must be activated manually after installation.