### PR TITLE
[14.0][FIX] account_asset_management: depreciation computation

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -982,7 +982,9 @@ class AccountAsset(models.Model):
         day_amount = 0.0
         if self.days_calc:
             days = (depreciation_stop_date - depreciation_start_date).days + 1
-            day_amount = self.depreciation_base / days
+            purchase_value = self.purchase_value or 0.0
+            salvage_value = self.salvage_value or 0.0
+            day_amount = (purchase_value - salvage_value) / days
 
         for i, entry in enumerate(table):
             if self.method_time == "year":

--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -520,7 +520,12 @@ class AccountAsset(models.Model):
 
     def validate(self):
         for asset in self:
-            if asset.company_currency_id.is_zero(asset.value_residual):
+            if (
+                asset.company_currency_id.compare_amounts(
+                    asset.value_residual, asset.salvage_value
+                )
+                == 0
+            ):
                 asset.state = "close"
             else:
                 asset.state = "open"

--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -280,7 +280,12 @@ class AccountAssetLine(models.Model):
             asset_ids.add(asset.id)
         # we re-evaluate the assets to determine if we can close them
         for asset in self.env["account.asset"].browse(list(asset_ids)):
-            if asset.company_currency_id.is_zero(asset.value_residual):
+            if (
+                asset.company_currency_id.compare_amounts(
+                    asset.value_residual, asset.salvage_value
+                )
+                == 0
+            ):
                 asset.state = "close"
         return created_move_ids
 


### PR DESCRIPTION
This pull request fixes depreciation computation because the amount per day was incorrectly calculated therefore the last depreciation line is an overestimated depreciation adjustment instead. The amount per day should be calculated as the difference between purchase value and salvage value divided by the number of days.

- Change the amount by days = (Purchase Value - Salvage Value) / Number of days of depreciation

**Asset Setting**
![Selection_143](https://user-images.githubusercontent.com/51266019/151143364-9c53fedc-bded-4465-adb1-8de1f55d6dcd.png)

**Before Fix**
![before](https://user-images.githubusercontent.com/51266019/151282865-36846f20-f6ae-47b8-baa8-7490266bb8b5.png)

**After Fix**
![after](https://user-images.githubusercontent.com/51266019/151282897-8453c6b3-803e-4199-8d41-aad25cc83464.png)

