### PR TITLE
[14.0][IMP] account_asset_management: set asset_profile_id on invoice creation

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -93,6 +93,8 @@ class AccountMove(models.Model):
                     raise UserError(
                         _("Asset name must be set in the label of the line.")
                     )
+                if aml.asset_id:
+                    continue
                 asset_form = Form(
                     self.env["account.asset"]
                     .with_company(move.company_id)
@@ -102,7 +104,9 @@ class AccountMove(models.Model):
                     setattr(asset_form, key, val)
                 asset = asset_form.save()
                 asset.analytic_tag_ids = aml.analytic_tag_ids
-                aml.with_context(allow_asset=True).asset_id = asset.id
+                aml.with_context(
+                    allow_asset=True, allow_asset_removal=True
+                ).asset_id = asset.id
             refs = [
                 "<a href=# data-oe-model=account.asset data-oe-id=%s>%s</a>"
                 % tuple(name_get)
@@ -157,6 +161,9 @@ class AccountMoveLine(models.Model):
     asset_profile_id = fields.Many2one(
         comodel_name="account.asset.profile",
         string="Asset Profile",
+        compute="_compute_asset_profile",
+        store=True,
+        readonly=False,
     )
     asset_id = fields.Many2one(
         comodel_name="account.asset",
@@ -164,11 +171,13 @@ class AccountMoveLine(models.Model):
         ondelete="restrict",
     )
 
-    @api.onchange("account_id")
-    def _onchange_account_id(self):
-        if self.account_id.asset_profile_id:
-            self.asset_profile_id = self.account_id.asset_profile_id
-        super()._onchange_account_id()
+    @api.depends("account_id", "asset_id")
+    def _compute_asset_profile(self):
+        for rec in self:
+            if rec.account_id.asset_profile_id and not rec.asset_id:
+                rec.asset_profile_id = rec.account_id.asset_profile_id
+            elif rec.asset_id:
+                rec.asset_profile_id = rec.asset_id.profile_id
 
     @api.onchange("asset_profile_id")
     def _onchange_asset_profile_id(self):


### PR DESCRIPTION
When creating an invoice from a PO with an account with asset_profile_id set, the field  wasn't propagated in the invoice_line.

@ForgeFlow