### PR TITLE
[14.0][IMP] account_asset_management: Add chatter + activities to assets.

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -32,6 +32,7 @@ class DummyFy(object):
 
 class AccountAsset(models.Model):
     _name = "account.asset"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "Asset"
     _order = "date_start desc, code, name"
     _check_company_auto = True

--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -277,6 +277,11 @@
                         </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/account-financial-tools/pull/1334

Add chatter + activities to assets.

Please @chienandalu and @pedrobaeza can you review it?

@Tecnativa TT34459