### PR TITLE
[FIX] account_invoice_constraint_chronology: modify past invoices

### DIFF
--- a/account_invoice_constraint_chronology/model/account_move.py
+++ b/account_invoice_constraint_chronology/model/account_move.py
@@ -67,12 +67,14 @@ class AccountMove(models.Model):
     def write(self, vals):
         if vals.get("state") != "posted":
             return super().write(vals)
-
+        previously_validated = self.filtered(lambda m: m.name and m.name != "/")
         newly_posted = self.filtered(lambda move: move.state != "posted")
         res = super().write(vals)
         for move in newly_posted & self.filtered("journal_id.check_chronology"):
             if self.search(move._get_older_conflicting_invoices_domain(), limit=1):
                 move._raise_older_conflicting_invoices()
+            if move in previously_validated:
+                continue
             if self.search(move._get_newer_conflicting_invoices_domain(), limit=1):
                 move._raise_newer_conflicting_invoices()
 

--- a/account_invoice_constraint_chronology/tests/test_account_invoice_constraint_chronology.py
+++ b/account_invoice_constraint_chronology/tests/test_account_invoice_constraint_chronology.py
@@ -129,3 +129,19 @@ class TestAccountInvoiceConstraintChronology(common.SavepointCase):
         refund = self.AccountMove.browse(refund["res_id"])
         with self.assertRaises(UserError):
             refund.action_post()
+
+    def test_modify_validated_past_invoice(self):
+        """We've got an invoice from yesterday that we need to modify but new ones
+        have been posted since. As the invoice already has a name, we should be able
+        to validate it"""
+        self.invoice_1.invoice_date = self.yesterday
+        self.invoice_1.action_post()
+        self.invoice_2.invoice_date = self.today
+        self.invoice_2.action_post()
+        self.invoice_1.button_cancel()
+        self.invoice_1.button_draft()
+        self.invoice_1.action_post()
+        self.invoice_1_5 = self.invoice_1.copy()
+        self.invoice_1_5.invoice_date = self.yesterday
+        with self.assertRaises(UserError):
+            self.invoice_1_5.action_post()


### PR DESCRIPTION
Addresses the issue as commented here:

- https://github.com/OCA/account-financial-tools/issues/1206
- https://github.com/OCA/account-financial-tools/pull/1152#issuecomment-847854629

Summary of the steps to reproduce the problem:

1. Set on the invoices journal the constraint chronology.
2. Validate an invoice for this journal today.
3. Your accountant says there's an error on an invoice from yesterday.
4. Cancel it an set it to draft. You don't even need to modify anything
5. Try to post the invoice.
6. You'll get a chronology error.

In v12 this was considered but it was lost on the migration to v13: 

https://github.com/OCA/account-financial-tools/blob/800c02474e5aa43cee592e93499d2a480be46d32/account_invoice_constraint_chronology/model/account_invoice.py#L50

https://github.com/OCA/account-financial-tools/blob/800c02474e5aa43cee592e93499d2a480be46d32/account_invoice_constraint_chronology/model/account_invoice.py#L70-L73

cc @Tecnativa TT34624

please review @carlosdauden @pedrobaeza 

ping to involved contributors @alexey-pelykh @stevech091 @sergioeix