### PR TITLE
[13.0][ADD]:  account_move_line_purchase_info: script post_install for update references on new column purchase_line_id from stock.move

### DIFF
--- a/account_move_line_purchase_info/__init__.py
+++ b/account_move_line_purchase_info/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from .hooks import post_init_hook

--- a/account_move_line_purchase_info/__manifest__.py
+++ b/account_move_line_purchase_info/__manifest__.py
@@ -13,4 +13,5 @@
     "license": "AGPL-3",
     "data": ["security/account_security.xml", "views/account_move_view.xml"],
     "installable": True,
+    "post_init_hook": "post_init_hook",
 }

--- a/account_move_line_purchase_info/hooks.py
+++ b/account_move_line_purchase_info/hooks.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Carlos Lopez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def post_init_hook(cr, registry):
+
+    """ INIT purchase references in acount move line """
+    # FOR stock moves
+    cr.execute(
+        """
+        UPDATE account_move_line aml
+            SET purchase_line_id = sm.purchase_line_id, purchase_id = pol.order_id
+        FROM stock_move sm
+            INNER JOIN purchase_order_line pol ON pol.id = sm.purchase_line_id
+            INNER JOIN account_move am ON am.stock_move_id  = sm.id
+        WHERE am.id = aml.move_id AND sm.purchase_line_id IS NOT NULL;
+    """
+    )


### PR DESCRIPTION
When install module on database with data, new column is NULL, purpose is FILL column with data

Inspired by https://github.com/OCA/account-financial-tools/blob/13.0/account_move_line_sale_info/hooks.py