### PR TITLE
[13.0][FIX] account_document_reversal: pass active_ids and active_model cor…

### DIFF
--- a/account_document_reversal/models/account_move.py
+++ b/account_document_reversal/models/account_move.py
@@ -70,10 +70,10 @@ class AccountMove(models.Model):
         self.mapped("line_ids").filtered(
             lambda x: x.account_id.reconcile
         ).remove_move_reconcile()
-        Reversal = self.env["account.move.reversal"]
-        res = Reversal.with_context(
+        Reversal = self.env["account.move.reversal"].with_context(
             active_ids=self.ids, active_model="account.move"
-        ).default_get([])
+        )
+        res = Reversal.default_get([])
         res.update(
             {"journal_id": journal_id, "refund_method": "cancel", "move_type": "entry"}
         )


### PR DESCRIPTION
…rectly

* before this commit, If try reversal from `account.payment` when `create `is call, `active_model `and `active_ids ` are of `account.payment`  instead of `account.move`. this commit avoid confussed and errors if any custom module try do browse from account.move with ID of other table

![image](https://user-images.githubusercontent.com/7775116/155621266-f9882cb9-a624-45bc-bbbd-76d44a6c8781.png)
