### PR TITLE
[14.0][FIX] account_move_line_tax_editable: make tax field actually editable

### DIFF
--- a/account_move_line_tax_editable/i18n/es.po
+++ b/account_move_line_tax_editable/i18n/es.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_move_line_tax_editable
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_move_line_tax_editable
+#: model:ir.model.fields,field_description:account_move_line_tax_editable.field_account_move_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_move_line_tax_editable
+#: model:ir.model.fields,field_description:account_move_line_tax_editable.field_account_move_line__id
+msgid "ID"
+msgstr ""
+
+#. module: account_move_line_tax_editable
+#: model:ir.model.fields,field_description:account_move_line_tax_editable.field_account_move_line__is_tax_editable
+msgid "Is tax data editable?"
+msgstr ""
+
+#. module: account_move_line_tax_editable
+#: model:ir.model,name:account_move_line_tax_editable.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: account_move_line_tax_editable
+#: model:ir.model.fields,field_description:account_move_line_tax_editable.field_account_move_line____last_update
+msgid "Last Modified on"
+msgstr ""

--- a/account_move_line_tax_editable/models/account_move_line.py
+++ b/account_move_line_tax_editable/models/account_move_line.py
@@ -12,7 +12,36 @@ class AccountMoveLine(models.Model):
         string="Is tax data editable?", compute="_compute_is_tax_editable"
     )
 
+    tax_line_id = fields.Many2one(inverse="_inverse_tax_line_id")
+
     @api.depends("move_id.state")
     def _compute_is_tax_editable(self):
         for rec in self:
             rec.is_tax_editable = rec.move_id.state == "draft"
+
+    def _inverse_tax_line_id(self):
+        for rec in self:
+            repartition_type = rec.tax_repartition_line_id.repartition_type or "tax"
+            factor_percent = rec.tax_repartition_line_id.factor_percent or 100
+            has_account = bool(rec.tax_repartition_line_id.account_id)
+            if rec.move_id.move_type in ("out_refund", "in_refund"):
+                repartition_lines = rec.tax_line_id.refund_repartition_line_ids
+            else:
+                repartition_lines = rec.tax_line_id.invoice_repartition_line_ids
+            lines = repartition_lines.filtered(
+                lambda rl: rl.repartition_type == repartition_type
+                and rl.factor_percent == factor_percent
+            )
+            if len(lines) > 1:
+                lines = (
+                    lines.filtered(
+                        lambda rl: rl.repartition_type == "base"
+                        or has_account is bool(rl.account_id)
+                    )[:1]
+                    or lines[:1]
+                )
+            elif not lines:
+                lines = repartition_lines.filtered(
+                    lambda rl: rl.repartition_type == repartition_type
+                )[:1]
+            rec.tax_repartition_line_id = lines


### PR DESCRIPTION
- Issues:
Since v13 field tax_line_id is a computed and stored field, therefore when editing it and saving/publishing the changes were overwritten.

Also it wasn't showing the Taxes group in the Journal Items form view (only was shown if the field tax_line_id or tax_ids had a value), so it wasn't possible to change it from there.

- Solution:
A new field force_tax_line_id has been created that is displayed when the invoice is in draft state. Then, when saving or or publishing, tax_line_id value is updated in the compute function.

@LoisRForgeFlow 