### PR TITLE
[14.0][FIX] account_move_line_sale_info: adjust migration script

### DIFF
--- a/account_move_line_sale_info/hooks.py
+++ b/account_move_line_sale_info/hooks.py
@@ -12,7 +12,20 @@ def post_init_hook(cr, registry):
         FROM account_move_line aml2
         INNER JOIN stock_move sm ON
         aml2.stock_move_id = sm.id
-        WHERE aml.id = aml2.id;
+        WHERE aml.id = aml2.id
+        AND sm.sale_line_id IS NOT NULL;
+    """
+    )
+    cr.execute(
+        """
+        UPDATE account_move_line aml SET sale_line_id = sm.sale_line_id
+        FROM account_move_line aml2
+        INNER JOIN account_move am
+        ON am.id = aml2.move_id
+        INNER JOIN stock_move sm ON
+        am.stock_move_id = sm.id
+        WHERE aml.id = aml2.id
+        AND sm.sale_line_id IS NOT NULL;
     """
     )
     # FOR invoices

--- a/account_move_line_sale_info/migrations/14.0.1.0.2/pre-migration.py
+++ b/account_move_line_sale_info/migrations/14.0.1.0.2/pre-migration.py
@@ -1,0 +1,21 @@
+# Copyright 2022 ForgeFlow, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Update account move lines with sale order line")
+    cr.execute(
+        """
+        UPDATE account_move_line aml SET sale_line_id = sm.sale_line_id
+        FROM account_move_line aml2
+        INNER JOIN account_move am
+        ON am.id = aml2.move_id
+        INNER JOIN stock_move sm ON
+        am.stock_move_id = sm.id
+        WHERE aml.id = aml2.id
+        AND sm.sale_line_id IS NOT NULL;
+    """
+    )


### PR DESCRIPTION
In v14 the account.move has the stock_move_id in standard, so we should make use of it.

@AaronHForgeFlow 