### PR TITLE
[14.0][FIX] account_move_line_purchase_info: migration and init hook

### DIFF
--- a/account_move_line_purchase_info/__init__.py
+++ b/account_move_line_purchase_info/__init__.py
@@ -1,3 +1,2 @@
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
 from . import models
+from .hooks import post_init_hook

--- a/account_move_line_purchase_info/__manifest__.py
+++ b/account_move_line_purchase_info/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 ForgeFlow S.L.
+# Copyright 2019-2022 ForgeFlow S.L.
 #   (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
@@ -13,4 +13,5 @@
     "license": "AGPL-3",
     "data": ["security/account_security.xml", "views/account_move_view.xml"],
     "installable": True,
+    "post_init_hook": "post_init_hook",
 }

--- a/account_move_line_purchase_info/hooks.py
+++ b/account_move_line_purchase_info/hooks.py
@@ -1,0 +1,20 @@
+# Copyright 2022 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def post_init_hook(cr, registry):
+
+    """INIT purchase_line_id in acount move line"""
+    # FOR stock moves
+    cr.execute(
+        """
+        UPDATE account_move_line aml SET purchase_line_id = sm.purchase_line_id
+        FROM account_move_line aml2
+        INNER JOIN account_move am
+        ON am.id = aml2.move_id
+        INNER JOIN stock_move sm ON
+        am.stock_move_id = sm.id
+        WHERE aml.id = aml2.id
+        AND sm.purchase_line_id IS NOT NULL;
+    """
+    )

--- a/account_move_line_purchase_info/migrations/14.0.1.0.3/pre-migration.py
+++ b/account_move_line_purchase_info/migrations/14.0.1.0.3/pre-migration.py
@@ -1,0 +1,21 @@
+# Copyright 2022 ForgeFlow, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Update account move lines with purchase order line")
+    cr.execute(
+        """
+        UPDATE account_move_line aml SET purchase_line_id = sm.purchase_line_id
+        FROM account_move_line aml2
+        INNER JOIN account_move am
+        ON am.id = aml2.move_id
+        INNER JOIN stock_move sm ON
+        am.stock_move_id = sm.id
+        WHERE aml.id = aml2.id
+        AND sm.purchase_line_id IS NOT NULL;
+    """
+    )


### PR DESCRIPTION
Add an init hook and a migration in order to make sure
that account move lines connected with stock moves get the
connecting purchase order line.

cc @AaronHForgeFlow @ChrisOForgeFlow 