### PR TITLE
[13.0][IMP] account_asset_management: remove asset with existing JE

### DIFF
--- a/account_asset_management/wizard/account_asset_remove.xml
+++ b/account_asset_management/wizard/account_asset_remove.xml
@@ -7,9 +7,13 @@
             <form string="Remove Asset">
                 <group colspan="4" col="4">
                     <field name="company_id" groups="base.group_multi_company" />
-                    <field name="date_remove" />
+                    <field
+                        name="date_remove"
+                        attrs="{'required': [('removal_account_move_id', '=', False)]}"
+                    />
                     <field name="force_date" />
                     <field name="sale_value" />
+                    <field name="removal_account_move_id" />
                     <field
                         name="account_sale_id"
                         attrs="{'invisible': [('sale_value', '=', 0.0)], 'required': [('sale_value', '>', 0.0)]}"
@@ -19,11 +23,11 @@
                     <newline />
                     <field
                         name="account_plus_value_id"
-                        attrs="{'invisible': [('posting_regime', '=', 'residual_value')], 'required': [('posting_regime', '!=', 'residual_value')]}"
+                        attrs="{'invisible': [('posting_regime', '=', 'residual_value')], 'required': [('posting_regime', '!=', 'residual_value'), ('removal_account_move_id', '=', False)]}"
                     />
                     <field
                         name="account_min_value_id"
-                        attrs="{'invisible': [('posting_regime', '=', 'residual_value')], 'required': [('posting_regime', '!=', 'residual_value')]}"
+                        attrs="{'invisible': [('posting_regime', '=', 'residual_value')], 'required': [('posting_regime', '!=', 'residual_value'), ('removal_account_move_id', '=', False)]}"
                     />
                     <field
                         name="account_residual_value_id"


### PR DESCRIPTION
If a manual journal entry was created to remove the asset users should be able to remove the asset based on them.

To test this feature just create a JE and then, when remove the asset select the JE as "Removal Journal Entry" field:
![image](https://user-images.githubusercontent.com/19620251/158193042-c9e93fc6-12c2-473b-a2cd-82afed0679f9.png)

@ForgeFlow