### PR TITLE
[13.0][FIX] account_asset_management: migration fixup

### DIFF
--- a/account_asset_management/migrations/13.0.1.0.0/post-migration.py
+++ b/account_asset_management/migrations/13.0.1.0.0/post-migration.py
@@ -8,7 +8,8 @@ def handle_account_invoice_move_migration(env):
         env.cr,
         """
         UPDATE account_move_line aml
-        SET asset_profile_id = ail.asset_profile_id, asset_id = ail.asset_id
+        SET asset_profile_id = COALESCE(ail.asset_profile_id, aml.asset_profile_id),
+            asset_id = COALESCE(ail.asset_id, aml.asset_id)
         FROM account_invoice_line ail
         WHERE aml.old_invoice_line_id = ail.id AND
             (ail.asset_profile_id IS NOT NULL OR ail.asset_id IS NOT NULL)"""


### PR DESCRIPTION
Suppose you have filled in v12:

- account.invoice.line: asset_id
- account.move.line: asset_profile_id

Without this fix, the field asset_id becomes NULL. I know this is an extremely remote case, but let's be sure everything is handled correctly.