### PR TITLE
[14.0][FIX] account_asset_management + account_asset_transfer + account_journal_lock_date: Add post_install tag in tests to prevent test errors

### DIFF
--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -8,11 +8,13 @@ import time
 from datetime import date, datetime
 
 from odoo import fields
+from odoo.tests import tagged
 from odoo.tests.common import Form
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
+@tagged("post_install", "-at_install")
 class TestAssetManagement(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):

--- a/account_asset_management/tests/test_asset_management_xls.py
+++ b/account_asset_management/tests/test_asset_management_xls.py
@@ -3,10 +3,12 @@
 import time
 
 from odoo import fields
+from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
+@tagged("post_install", "-at_install")
 class TestAssetManagementXls(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):

--- a/account_asset_transfer/tests/test_account_asset_transfer.py
+++ b/account_asset_transfer/tests/test_account_asset_transfer.py
@@ -4,6 +4,7 @@
 
 from odoo import fields
 from odoo.exceptions import UserError
+from odoo.tests import tagged
 from odoo.tests.common import Form
 
 from odoo.addons.account_asset_management.tests.test_account_asset_management import (
@@ -11,6 +12,7 @@ from odoo.addons.account_asset_management.tests.test_account_asset_management im
 )
 
 
+@tagged("post_install", "-at_install")
 class TestAccountAssetTransfer(TestAssetManagement):
     @classmethod
     def setUpClass(cls):

--- a/account_journal_lock_date/tests/test_journal_lock_date.py
+++ b/account_journal_lock_date/tests/test_journal_lock_date.py
@@ -4,10 +4,12 @@
 from datetime import date, timedelta
 
 from odoo.exceptions import UserError
+from odoo.tests import tagged
 
 from odoo.addons.account.tests import common
 
 
+@tagged("post_install", "-at_install")
 class TestJournalLockDate(common.AccountTestInvoicingCommon):
     def setUp(self):
         super(TestJournalLockDate, self).setUp()


### PR DESCRIPTION
Add `post_install` tag in tests to prevent test errors since https://github.com/odoo/odoo/commit/81aac30dd2278e43a43cf8fd6cef31e1e8c60f3f

Please @pedrobaeza can you review it?

@Tecnativa TT33774