### PR TITLE
[14.0][FIX] account_sequence_option: maintain sequence of out-invoices when returning to draft and changing date.

### DIFF
--- a/account_sequence_option/__manifest__.py
+++ b/account_sequence_option/__manifest__.py
@@ -10,7 +10,10 @@
     "website": "https://github.com/OCA/account-financial-tools",
     "category": "Accounting",
     "depends": ["account", "base_sequence_option"],
-    "data": ["data/account_sequence_option.xml"],
+    "data": [
+        "data/account_sequence_option.xml",
+        "views/account_move_views.xml",
+    ],
     "demo": ["demo/account_demo_options.xml"],
     "maintainers": ["kittiu"],
     "license": "LGPL-3",

--- a/account_sequence_option/readme/CONTRIBUTORS.rst
+++ b/account_sequence_option/readme/CONTRIBUTORS.rst
@@ -1,1 +1,4 @@
 * Kitti U. <kittiu@ecosoft.co.th>
+* `Sygel <https://www.sygel.es>`_:
+
+  * Ángel García de la Chica Herrera

--- a/account_sequence_option/tests/test_account_sequence_option.py
+++ b/account_sequence_option/tests/test_account_sequence_option.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
+from datetime import timedelta
+
 from odoo import fields
 from odoo.tests.common import Form, TransactionCase, tagged
 
@@ -72,3 +74,14 @@ class TestAccountSequenceOption(TransactionCase):
         self.payment = self._create_payment("outbound", "supplier")
         self.payment.action_post()
         self.assertIn("VPAY", self.payment.name)
+        # 7. Create out invoice, post invoice, reset invoice to Draft
+        #       Change Date, post invoice.
+        self.invoice = self._create_invoice("out_invoice")
+        self.invoice.action_post()
+        old_name = self.invoice.name
+        self.invoice.button_draft()
+        self.invoice.write(
+            {"invoice_date": self.invoice.invoice_date - timedelta(days=1)}
+        )
+        self.invoice.action_post()
+        self.assertEqual(old_name, self.invoice.name)

--- a/account_sequence_option/views/account_move_views.xml
+++ b/account_sequence_option/views/account_move_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 Angel Garcia de la Chica Herrera <angel.garcia@sygel.es>
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="account_sequence_option_view_move_form" model="ir.ui.view">
+        <field name="name">account_sequence_option_view_move_form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='date']" position="after">
+                <field name="sequence_option" invisible="1" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
[FIX] When you have a posted output invoice, if you return it to draft and change the date, the invoice name is deleted and it asks again for another sequence number. This FIX prevents this from happening and keeps the name.
