### PR TITLE
[15.0][IMP] account_move_force_removal: add a new user group.

### DIFF
--- a/account_move_force_removal/__manifest__.py
+++ b/account_move_force_removal/__manifest__.py
@@ -4,10 +4,11 @@
 {
     "name": "Account Move Force Removal",
     "summary": """Allow force removal account moves""",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.0.1",
     "category": "Account",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/account-financial-tools",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "depends": ["account"],
+    "data": ["security/account_move_force_removal_security.xml"],
 }

--- a/account_move_force_removal/migrations/15.0.1.0.1/post-migration.py
+++ b/account_move_force_removal/migrations/15.0.1.0.1/post-migration.py
@@ -1,0 +1,4 @@
+def migrate(env, version):
+    users_billing = env.ref("account.group_account_invoice").users
+    group = env.ref("account_move_force_removal.group_account_move_force_removal")
+    group.users = [(4, user.id) for user in users_billing]

--- a/account_move_force_removal/models/account_move.py
+++ b/account_move_force_removal/models/account_move.py
@@ -8,6 +8,10 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     def unlink(self):
-        cancelled_moves = self.filtered(lambda m: m.state == "cancel")
-        super(AccountMove, cancelled_moves.with_context(force_delete=True)).unlink()
+        cancelled_moves = self.env["account.move"]
+        if self.env.user.has_group(
+            "account_move_force_removal.group_account_move_force_removal"
+        ):
+            cancelled_moves = self.filtered(lambda m: m.state == "cancel")
+            super(AccountMove, cancelled_moves.with_context(force_delete=True)).unlink()
         return super(AccountMove, self - cancelled_moves).unlink()

--- a/account_move_force_removal/security/account_move_force_removal_security.xml
+++ b/account_move_force_removal/security/account_move_force_removal_security.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 Ángel García de la Chica Herrera <angel.garcia@sygel.es>
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).  -->
+<odoo>
+    <record id="group_account_move_force_removal" model="res.groups">
+        <field name="name">Allow to delete invoices/journal entries</field>
+        <field name="category_id" ref="base.module_category_accounting" />
+        <field name="users" eval="[(4, ref('base.user_admin'))]" />
+    </record>
+</odoo>

--- a/account_move_force_removal/tests/test_move.py
+++ b/account_move_force_removal/tests/test_move.py
@@ -2,10 +2,11 @@
 # License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo.exceptions import UserError
-from odoo.tests import Form
+from odoo.tests import Form, tagged
 from odoo.tests.common import TransactionCase
 
 
+@tagged("post_install", "-at_install")
 class TestMove(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -25,6 +26,7 @@ class TestMove(TransactionCase):
             {"name": "Test product", "type": "service"}
         )
         cls.company = cls.env.company
+        cls.company.currency_id.active = True
         account_type = cls.env.ref("account.data_account_type_other_income")
         cls.income_account = cls.env["account.account"].search(
             [
@@ -50,14 +52,36 @@ class TestMove(TransactionCase):
         invoice = invoice.save()
         invoice.action_post()
         cls.invoice = invoice
+        cls.invoice2 = cls.invoice.copy()
+        cls.invoice2.action_post()
+        cls.invoice3 = cls.invoice.copy()
+        cls.invoice3.action_post()
 
     def test_remove_invoice_error(self):
-        # Delete invoice while name isn't /
+        # Delete invoice while name isn't / and
+        # user not in group_account_move_force_removal
         with self.assertRaises(UserError):
             self.invoice.unlink()
-
-    def test_ok_invoice_error(self):
-        # Delete invoice (previously draft + camcel)
+        # Delete invoice (previously draft + cancel) and
+        # user not in group_account_move_force_removal
         self.invoice.button_draft()
         self.invoice.button_cancel()
+        with self.assertRaises(UserError):
+            self.invoice.unlink()
+        # Delete invoice while name isn't / and
+        # user in group_account_move_force_removal
+        self.env.user.groups_id += self.env.ref(
+            "account_move_force_removal.group_account_move_force_removal"
+        )
+        with self.assertRaises(UserError):
+            self.invoice3.unlink()
+
+    def test_ok_invoice_error(self):
+        # Delete invoice (previously draft + cancel) and
+        # user in group_account_move_force_removal
+        self.invoice.button_draft()
+        self.invoice.button_cancel()
+        self.env.user.groups_id += self.env.ref(
+            "account_move_force_removal.group_account_move_force_removal"
+        )
         self.invoice.unlink()


### PR DESCRIPTION
This improvement creates a new user group called 'Allow delete account move' so that only users belonging to this group can delete invoices in cancelled status. It also extends the tests to contemplate the new use case.