### PR TITLE
[FIX] account_journal_lock_date: remove false alerts 

### DIFF
--- a/account_journal_lock_date/models/account_move.py
+++ b/account_journal_lock_date/models/account_move.py
@@ -12,11 +12,6 @@ class AccountMove(models.Model):
 
     _inherit = "account.move"
 
-    def write(self, values):
-        res = super().write(values)
-        self._check_fiscalyear_lock_date()
-        return res
-
     def _check_fiscalyear_lock_date(self):
         res = super()._check_fiscalyear_lock_date()
         if self.env.context.get("bypass_journal_lock_date"):


### PR DESCRIPTION
The overload of the `_check_fiscalyear_lock_date` function is enough, we don't need overload write function of `account.move`. Otherwise we get false alert for normal action: reconciliation, consult PDF viewer (enterprise edition) ...

For information, this bug was detected on the enterprise edition 14.0.