### PR TITLE
[13.0][FIX] account_move_line_tax_editable: make tax field actually editable (backport)

### DIFF
--- a/account_move_line_tax_editable/i18n/es.po
+++ b/account_move_line_tax_editable/i18n/es.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_move_line_tax_editable
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_move_line_tax_editable
+#: model:ir.model.fields,field_description:account_move_line_tax_editable.field_account_move_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_move_line_tax_editable
+#: model:ir.model.fields,field_description:account_move_line_tax_editable.field_account_move_line__id
+msgid "ID"
+msgstr ""
+
+#. module: account_move_line_tax_editable
+#: model:ir.model.fields,field_description:account_move_line_tax_editable.field_account_move_line__is_tax_editable
+msgid "Is tax data editable?"
+msgstr ""
+
+#. module: account_move_line_tax_editable
+#: model:ir.model,name:account_move_line_tax_editable.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: account_move_line_tax_editable
+#: model:ir.model.fields,field_description:account_move_line_tax_editable.field_account_move_line____last_update
+msgid "Last Modified on"
+msgstr ""

--- a/account_move_line_tax_editable/models/account_move_line.py
+++ b/account_move_line_tax_editable/models/account_move_line.py
@@ -12,7 +12,36 @@ class AccountMoveLine(models.Model):
         string="Is tax data editable?", compute="_compute_is_tax_editable"
     )
 
+    tax_line_id = fields.Many2one(inverse="_inverse_tax_line_id")
+
     @api.depends("move_id.state")
     def _compute_is_tax_editable(self):
         for rec in self:
             rec.is_tax_editable = rec.move_id.state == "draft"
+
+    def _inverse_tax_line_id(self):
+        for rec in self:
+            repartition_type = rec.tax_repartition_line_id.repartition_type or "tax"
+            factor_percent = rec.tax_repartition_line_id.factor_percent or 100
+            has_account = bool(rec.tax_repartition_line_id.account_id)
+            if rec.move_id.type in ("out_refund", "in_refund"):
+                repartition_lines = rec.tax_line_id.refund_repartition_line_ids
+            else:
+                repartition_lines = rec.tax_line_id.invoice_repartition_line_ids
+            lines = repartition_lines.filtered(
+                lambda rl: rl.repartition_type == repartition_type
+                and rl.factor_percent == factor_percent
+            )
+            if len(lines) > 1:
+                lines = (
+                    lines.filtered(
+                        lambda rl: rl.repartition_type == "base"
+                        or has_account is bool(rl.account_id)
+                    )[:1]
+                    or lines[:1]
+                )
+            elif not lines:
+                lines = repartition_lines.filtered(
+                    lambda rl: rl.repartition_type == repartition_type
+                )[:1]
+            rec.tax_repartition_line_id = lines

--- a/account_move_line_tax_editable/tests/test_account_move_line_tax_editable.py
+++ b/account_move_line_tax_editable/tests/test_account_move_line_tax_editable.py
@@ -41,7 +41,7 @@ class TestAccountMoveLineTaxEditable(common.SavepointCase):
                     0,
                     0,
                     {
-                        "name": "move test",
+                        "name": "move test line 1",
                         "debit": 0.0,
                         "credit": 1000.0,
                         "account_id": account300.id,
@@ -51,7 +51,7 @@ class TestAccountMoveLineTaxEditable(common.SavepointCase):
                     0,
                     0,
                     {
-                        "name": "move test",
+                        "name": "move test line 2",
                         "debit": 1000.0,
                         "credit": 0.0,
                         "account_id": account100.id,
@@ -60,8 +60,25 @@ class TestAccountMoveLineTaxEditable(common.SavepointCase):
             ],
         }
         cls.move = cls.env["account.move"].create(move_vals)
+        cls.tax15 = cls.env["account.tax"].create({"name": "Test tax 15", "amount": 15})
 
     def test_compute_is_tax_editable(self):
         self.assertEqual(self.move.line_ids.mapped("is_tax_editable"), [True, True])
         self.move.post()
         self.assertEqual(self.move.line_ids.mapped("is_tax_editable"), [False, False])
+
+    def test_tax_edited(self):
+        line1 = self.move.line_ids[0]
+        line1.tax_line_id = self.tax15.id
+        line2 = self.move.line_ids[1]
+        self.move.action_post()
+        self.assertEqual(line1.tax_line_id.id, self.tax15.id)
+        self.assertEqual(line2.tax_line_id.id, False)
+        self.assertEqual(line1.tax_repartition_line_id.tax_id.id, self.tax15.id)
+
+    def test_tax_not_edited(self):
+        """In this case we set the tax_repartition_line_id field, simulating that the
+        move came from an invoice with tax applied. Thus, tax_line_id should be computed"""
+        line1 = self.move.line_ids[1]
+        line1.tax_repartition_line_id = self.tax15.invoice_repartition_line_ids[1]
+        self.assertEqual(line1.tax_line_id.id, self.tax15.id)


### PR DESCRIPTION
Backport of https://github.com/OCA/account-financial-tools/pull/1352.