### PR TITLE
[FIX] account_move_force_removal: buggy migration script

### DIFF
--- a/account_move_force_removal/migrations/15.0.1.0.1/post-migration.py
+++ b/account_move_force_removal/migrations/15.0.1.0.1/post-migration.py
@@ -1,3 +1,7 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
 def migrate(env, version):
     users_billing = env.ref("account.group_account_invoice").users
     group = env.ref("account_move_force_removal.group_account_move_force_removal")


### PR DESCRIPTION
Running the migration script fails with:

    AttributeError: 'psycopg2.extensions.cursor' object has no attribute 'ref'

@moduon