### PR TITLE
[REF] account_move_name_sequence: Moves with name '/' can not be posted

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -15,6 +15,15 @@ class AccountMove(models.Model):
     sequence_prefix = fields.Char(compute=False)
     sequence_number = fields.Integer(compute=False)
 
+    _sql_constraints = [
+        (
+            "name_state_diagonal",
+            "CHECK(COALESCE(name, '') NOT IN ('/', '') OR state!='posted')",
+            'A move can not be posted with name "/" or empty value\n'
+            "Check the journal sequence, please",
+        ),
+    ]
+
     @api.depends("state", "journal_id", "date")
     def _compute_name_by_sequence(self):
         for move in self:


### PR DESCRIPTION
After remove required=True for journal.sequence_id field it is possible to post an invoice with misconfigured journal with empty sequence

So, this constraint will raise an error for this kind of cases since that using '/' could raise the unique constraint for all other moves