### PR TITLE
[FIX] account_move_name_sequence: Fix required journal fields in view

### DIFF
--- a/account_move_name_sequence/views/account_journal.xml
+++ b/account_move_name_sequence/views/account_journal.xml
@@ -13,15 +13,15 @@
             <field name="refund_sequence" position="before">
                 <field
                     name="sequence_id"
-                    required="0"
+                    required="1"
                     context="{'default_name': name, 'default_company_id': company_id, 'default_implementation': 'no_gap', 'default_padding': 4, 'default_use_date_range': True, 'default_prefix': (code or 'UNKNOWN') + '/%%(range_year)s/'}"
                 />
             </field>
             <field name="refund_sequence" position="after">
                 <field
                     name="refund_sequence_id"
-                    attrs="{'invisible': ['|', ('type', 'not in', ('sale', 'purchase')), ('refund_sequence', '=', False)]}"
-                    required="1"
+                    attrs="{'invisible': ['|', ('type', 'not in', ('sale', 'purchase')), ('refund_sequence', '=', False)],
+                            'required': [('type', 'in', ('sale', 'purchase')), ('refund_sequence', '=', True)]}"
                     context="{'default_name': name, 'default_company_id': company_id, 'default_implementation': 'no_gap', 'default_padding': 4, 'default_use_date_range': True, 'default_prefix': 'R' + (code or 'UNKNOWN') + '/%%(range_year)s/'}"
                 />
             </field>


### PR DESCRIPTION
The required flag was wrong for sequence_id and refund_sequence_id

So, it was not possible to store any change in journal for journal different to sale and purchase