### PR TITLE
[14.0] account_cash_deposit: add support for loose coins in deposits

### DIFF
--- a/account_cash_deposit/models/account_cash_deposit.py
+++ b/account_cash_deposit/models/account_cash_deposit.py
@@ -39,7 +39,7 @@ class AccountCashDeposit(models.Model):
     )
     date = fields.Date(
         string="Date",
-        readonly=True,
+        states={"done": [("readonly", "=", True)]},
         tracking=True,
         copy=False,
         help="Used as date for the journal entry.",
@@ -281,7 +281,7 @@ class AccountCashDeposit(models.Model):
 
     def _prepare_account_move(self, vals):
         self.ensure_one()
-        date = vals["date"]
+        date = vals.get("date") or self.date
         op_type = self.operation_type
         total_amount_comp_cur = self.currency_id._convert(
             self.total_amount, self.company_id.currency_id, self.company_id, date
@@ -328,7 +328,7 @@ class AccountCashDeposit(models.Model):
         vals = {"state": "done"}
         if force_date:
             vals["date"] = force_date
-        else:
+        elif not self.date:
             vals["date"] = fields.Date.context_today(self)
         return vals
 

--- a/account_cash_deposit/tests/test_cash_deposit.py
+++ b/account_cash_deposit/tests/test_cash_deposit.py
@@ -93,6 +93,7 @@ class TestAccountCashDeposit(TransactionCase):
         self.assertEqual(order.move_id.ref, order.display_name)
 
     def test_cash_deposit(self):
+        coin_amount = 12.42
         deposit = (
             self.env["account.cash.deposit"]
             .with_context(default_operation_type="deposit")
@@ -102,6 +103,7 @@ class TestAccountCashDeposit(TransactionCase):
                     "currency_id": self.currency.id,
                     "cash_journal_id": self.cash_journal.id,
                     "bank_journal_id": self.bank_journal.id,
+                    "coin_amount": coin_amount,
                     "line_ids": [
                         (0, 0, {"cash_unit_id": self.cash_unit_note.id, "qty": 3}),
                         (0, 0, {"cash_unit_id": self.cash_unit_coinroll.id, "qty": 6}),
@@ -116,7 +118,7 @@ class TestAccountCashDeposit(TransactionCase):
         total = (
             3 * self.cash_unit_note.total_value
             + 6 * self.cash_unit_coinroll.total_value
-        )
+        ) + coin_amount
         self.assertFalse(
             deposit.currency_id.compare_amounts(deposit.total_amount, total)
         )

--- a/account_cash_deposit/views/account_cash_deposit.xml
+++ b/account_cash_deposit/views/account_cash_deposit.xml
@@ -68,6 +68,10 @@
                             />
                             <field name="cash_journal_id" />
                             <field name="bank_journal_id" />
+                            <field
+                                name="coin_amount"
+                                attrs="{'invisible': [('operation_type', '!=', 'deposit')]}"
+                            />
                         </group>
                         <group name="right">
                             <field name="total_amount" />


### PR DESCRIPTION
Adds a new field for loose coin amount for deposits: this field is useful if your bank has a coin counting machine that allows you to deposit coins without putting them in rolls.

Here is a video of a coin counting machine using for cash deposit at the bank:
https://www.youtube.com/watch?v=TXXfSVvKHdU