### PR TITLE
[13.0] [FIX] account_netting: Post move to reconcile

### DIFF
--- a/account_netting/wizards/account_move_make_netting.py
+++ b/account_netting/wizards/account_move_make_netting.py
@@ -117,6 +117,7 @@ class AccountMoveMakeNetting(models.TransientModel):
         if move_lines:
             move.write({"line_ids": move_lines})
         # Make reconciliation
+        move.action_post()
         for move_line in move.line_ids:
             to_reconcile = move_line + self.move_line_ids.filtered(
                 lambda x: x.account_id == move_line.account_id

--- a/account_spread_cost_revenue/tests/test_account_invoice_spread.py
+++ b/account_spread_cost_revenue/tests/test_account_invoice_spread.py
@@ -642,7 +642,7 @@ class TestAccountInvoiceSpread(common.TransactionCase):
         payable_account = self.spread2.credit_account_id
         balance_sheet = self.spread2.debit_account_id
         self.assertTrue(balance_sheet.reconcile)
-
+        self.spread2.line_ids.mapped("move_id").action_post()
         spread_mls = self.spread2.line_ids.mapped("move_id.line_ids")
         self.assertTrue(spread_mls)
         for spread_ml in spread_mls:


### PR DESCRIPTION
Post move to reconcile (since https://github.com/odoo/odoo/pull/91306/commits/02fb119e3220378930c37228a94815f2377b244e)

Please @pedrobaeza and @carlosdauden  can you review it?

@Tecnativa