### PR TITLE
[FIX] [14.0] base_vat_optional_vies: Simple VAT check after VIES check fails

### DIFF
--- a/base_vat_optional_vies/models/res_partner.py
+++ b/base_vat_optional_vies/models/res_partner.py
@@ -1,6 +1,7 @@
 # Copyright 2015 Tecnativa - Antonio Espinosa
 # Copyright 2017 Tecnativa - David Vidal
 # Copyright 2019 FactorLibre - Rodrigo Bonilla
+# Copyright 2022 Moduon - Eduardo de Miguel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo import api, fields, models
 
@@ -29,6 +30,8 @@ class ResPartner(models.Model):
             # call simple_vat_check and thus the flag will be removed
             partner.update({"vies_passed": True})
         res = super(ResPartner, self).vies_vat_check(country_code, vat_number)
+        if not res:
+            return self.simple_vat_check(country_code, vat_number)
         return res
 
     @api.constrains("vat", "country_id")


### PR DESCRIPTION
When VIES check fails, perform a simple VAT check.

On v13:
https://github.com/OCA/account-financial-tools/blob/13.0/base_vat_optional_vies/models/res_partner.py#L30-L31

On v14:
https://github.com/OCA/account-financial-tools/blob/14.0/base_vat_optional_vies/models/res_partner.py#L22

On v15:
https://github.com/OCA/account-financial-tools/blob/15.0/base_vat_optional_vies/models/res_partner.py#L32-L38

As you can see, **we miss to launch the simple vat check** on v14.
Before this PR, this module is useless because Odoo is still blocking the partner creation/write.
No need to forward-port because on v13 and v15 it's ok.

Please review if you want @HaraldPanten @rafaelbn @yajo 

MT-800 @moduon