### PR TITLE
[REF] account_move_name_sequence: Use Odoo native methods + Typos

### DIFF
--- a/account_move_name_sequence/__manifest__.py
+++ b/account_move_name_sequence/__manifest__.py
@@ -2,6 +2,7 @@
 # Copyright 2022 Vauxoo (https://www.vauxoo.com/)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # @author: Moisés López <moylop260@vauxoo.com>
+# @author: Francisco Luna <fluna@vauxoo.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
@@ -11,9 +12,11 @@
     "license": "AGPL-3",
     "summary": "Generate journal entry number from sequence",
     "author": "Akretion,Vauxoo,Odoo Community Association (OCA)",
-    "maintainers": ["alexis-via", "moylop260"],
+    "maintainers": ["alexis-via", "moylop260", "frahikLV"],
     "website": "https://github.com/OCA/account-financial-tools",
-    "depends": ["account"],
+    "depends": [
+        "account",
+    ],
     "data": [
         "views/account_journal.xml",
         "views/account_move.xml",

--- a/account_move_name_sequence/models/account_journal.py
+++ b/account_move_name_sequence/models/account_journal.py
@@ -6,8 +6,6 @@
 
 import logging
 
-from dateutil.relativedelta import relativedelta
-
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -222,7 +220,7 @@ class AccountJournal(models.Model):
                             year = "20" + year
                     if month:
                         date_from = fields.Date.to_date("%s-%s-1" % (year, month))
-                        date_to = date_from + relativedelta(day=31)
+                        date_to = fields.Date.end_of(date_from, "month")
                     else:
                         date_from = fields.Date.to_date("%s-1-1" % year)
                         date_to = fields.Date.to_date("%s-12-31" % year)

--- a/account_move_name_sequence/readme/CONFIGURE.rst
+++ b/account_move_name_sequence/readme/CONFIGURE.rst
@@ -1,5 +1,5 @@
 On the form view of an account journal, in the first tab, there is a many2one link to the sequence. When you create a new journal, you can keep this field empty and a new sequence will be automatically created when you save the journal.
 
-On sale and purchase journals, you have an additionnal option to have another sequence dedicated to refunds.
+On sale and purchase journals, you have an additional option to have another sequence dedicated to refunds.
 
 Upon module installation, all existing journals will be updated with a journal entry sequence (and also a credit note sequence for sale and purchase journals). You should update the configuration of the sequences to fit your needs. You can uncheck the option *Dedicated Credit Note Sequence* on existing sale and purchase journals if you don't want it. For the journals which already have journal entries, you should update the sequence configuration to avoid a discontinuity in the numbering for the next journal entry.

--- a/account_move_name_sequence/readme/CONTRIBUTORS.rst
+++ b/account_move_name_sequence/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Alexis de Lattre <alexis.delattre@akretion.com>
 * Moisés López <moylop260@vauxoo.com>
+* Francisco Luna <fluna@vauxoo.com>

--- a/account_move_name_sequence/views/account_journal.xml
+++ b/account_move_name_sequence/views/account_journal.xml
@@ -2,6 +2,8 @@
 <!--
   Copyright 2021 Akretion France (http://www.akretion.com/)
   @author: Alexis de Lattre <alexis.delattre@akretion.com>
+  @author: Moisés López <moylop260@vauxoo.com>
+  @author: Francisco Luna <fluna@vauxoo.com>
   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <odoo>

--- a/account_move_name_sequence/views/account_move.xml
+++ b/account_move_name_sequence/views/account_move.xml
@@ -10,23 +10,21 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-                <xpath
+            <xpath
                 expr="//div[hasclass('oe_title')]/h1[hasclass('mt0')]"
                 position="attributes"
             >
-                        <attribute
-                    name="attrs"
-                >{'invisible': [('name', '=', '/')]}</attribute>
-                </xpath>
-                <xpath
+                <attribute name="attrs">{'invisible': [('name', '=', '/')]}</attribute>
+            </xpath>
+            <xpath
                 expr="//div[hasclass('oe_title')]//field[@name='name']"
                 position="attributes"
             >
-                        <attribute name="attrs">{'readonly': 1}</attribute>
-                </xpath>
-                <xpath expr="//field[@name='highest_name']/.." position="attributes">
+                <attribute name="attrs">{'readonly': 1}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='highest_name']/.." position="attributes">
                 <attribute name="attrs">{'invisible': 1}</attribute>
-                </xpath>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
This RM has been created because of the migration to V15 https://github.com/OCA/account-financial-tools/pull/1410

Some changes are made in the use of native Odoo methods and typos correction to keep the code as similar as possible with the V15 migrated module.

Reviewers:
@moylop260 
@luisg123v