### PR TITLE
[15.0][FIX] account_chart_update: do not browse rep_line in _update_taxes_pending_for_accounts

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -1071,9 +1071,10 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 tax.write(vals)
                 done |= tax
 
-        for k, v in todo_dict["account_dict"]["account.tax.repartition.line"].items():
+        for rep_line, v in todo_dict["account_dict"][
+            "account.tax.repartition.line"
+        ].items():
             if v["account_id"]:
-                rep_line = self.env["account.tax.repartition.line"].browse(k)
                 acc_id = self.find_account_by_templates(
                     self.env["account.account.template"].browse(v["account_id"].id)
                 )


### PR DESCRIPTION
todo_dict["account_dict"]["account.tax.repartition.line"].items() in function _update_taxes_pending_for_accounts (model wizard.update.charts.accounts) returns an account.tax.repartition.line record as the first element, so trying to browse it as if it was an id generates an error.