### PR TITLE
[FIX] account_journal_general_sequence: bottleneck at install

### DIFF
--- a/account_journal_general_sequence/README.rst
+++ b/account_journal_general_sequence/README.rst
@@ -36,6 +36,16 @@ that Odoo adds by default, and has different purpose.
 .. contents::
    :local:
 
+Installation
+============
+
+After installing this module, no entry numbers will be generated because that
+could have a very negative impact in installations that already had a lot of
+account moves.
+
+If you need to add numbers to preexisting account moves, please use the
+renumbering wizard as explained in the *Usage* section.
+
 Configuration
 =============
 

--- a/account_journal_general_sequence/__manifest__.py
+++ b/account_journal_general_sequence/__manifest__.py
@@ -9,6 +9,7 @@
     "author": "Moduon, Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "external_dependencies": {"python": ["freezegun"]},
+    "maintainers": ["yajo"],
     "depends": [
         "account",
     ],

--- a/account_journal_general_sequence/readme/INSTALL.rst
+++ b/account_journal_general_sequence/readme/INSTALL.rst
@@ -1,0 +1,6 @@
+After installing this module, no entry numbers will be generated because that
+could have a very negative impact in installations that already had a lot of
+account moves.
+
+If you need to add numbers to preexisting account moves, please use the
+renumbering wizard as explained in the *Usage* section.

--- a/account_journal_general_sequence/static/description/index.html
+++ b/account_journal_general_sequence/static/description/index.html
@@ -375,19 +375,28 @@ that Odoo adds by default, and has different purpose.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
-<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
+<li><a class="reference internal" href="#installation" id="id1">Installation</a></li>
+<li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id3">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="installation">
+<h1><a class="toc-backref" href="#id1">Installation</a></h1>
+<p>After installing this module, no entry numbers will be generated because that
+could have a very negative impact in installations that already had a lot of
+account moves.</p>
+<p>If you need to add numbers to preexisting account moves, please use the
+renumbering wizard as explained in the <em>Usage</em> section.</p>
+</div>
 <div class="section" id="configuration">
-<h1><a class="toc-backref" href="#id1">Configuration</a></h1>
+<h1><a class="toc-backref" href="#id2">Configuration</a></h1>
 <p>To configure journal sequences:</p>
 <ol class="arabic simple">
 <li>Have full accounting permissions.</li>
@@ -404,7 +413,7 @@ per journal, make sure they don’t produce colliding results.</li>
 </ul>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id2">Usage</a></h1>
+<h1><a class="toc-backref" href="#id3">Usage</a></h1>
 <p>To see journal entry numbers:</p>
 <ol class="arabic simple">
 <li>Go to <em>Invoicing &gt; Accounting &gt; Miscellaneous &gt; Journal Entries</em>.</li>
@@ -430,7 +439,7 @@ per journal, make sure they don’t produce colliding results.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-financial-tools/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -438,22 +447,22 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id6">Authors</a></h2>
 <ul class="simple">
 <li>Moduon</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
 <ul class="simple">
 <li>Jairo Llopis (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 <li>Rafael Blasco (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/account_journal_general_sequence/tests/test_numbering.py
+++ b/account_journal_general_sequence/tests/test_numbering.py
@@ -55,3 +55,19 @@ class RenumberCase(TestAccountReconciliationCommon):
         wiz = wiz_f.save()
         wiz.action_renumber()
         self.assertEqual(opening_invoice.entry_number, "2022/0000000000")
+
+    def test_install_no_entry_number(self):
+        """No entry numbers assigned on module installation."""
+        # Imitate installation environment
+        self.env = self.env(
+            context=dict(self.env.context, module="account_journal_general_sequence")
+        )
+        self.env["ir.module.module"].search(
+            [("name", "=", "account_journal_general_sequence")]
+        ).state = "to install"
+        # Do some action that would make the move get an entry number
+        invoice = self._create_invoice()
+        self.assertFalse(invoice.entry_number)
+        invoice.action_post()
+        # Ensure there's no entry number
+        self.assertFalse(invoice.entry_number)


### PR DESCRIPTION
On databases with big amounts of account moves, installation would freeze Odoo for some minutes.

We skip now entry number computation at install, to avoid such cases.

@moduon MT-676 fw-port-of https://github.com/OCA/account-financial-tools/pull/1420

Please @rafaelbn fast-track this one too.