### PR TITLE
[14.0][ENH] account_asset_transfer: allow transfer asset without moves

### DIFF
--- a/account_asset_transfer/README.rst
+++ b/account_asset_transfer/README.rst
@@ -31,6 +31,10 @@ AUC is Asset under construction where some assets are in construction phase and
 cost needs to be captured for the time being. Once asset is fully completed then
 cost would be transferred to final asset
 
+**Note:**
+
+* If the asset don't have journal entries, asset transfer will use account settings from the asset/asset profile instead.
+
 **Table of contents**
 
 .. contents::
@@ -77,6 +81,7 @@ Contributors
 * `Ecosoft <http://ecosoft.co.th>`__:
 
   * Kitti U. <kittiu@ecosoft.co.th>
+  * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_asset_transfer/models/account_asset.py
+++ b/account_asset_transfer/models/account_asset.py
@@ -20,7 +20,6 @@ class AccountAsset(models.Model):
                 not asset.method_number
                 and asset.value_residual
                 and asset.state == "open"
-                and asset.account_move_line_ids
             )
 
     def _search_can_transfer(self, operator, value):
@@ -29,7 +28,6 @@ class AccountAsset(models.Model):
                 ("method_number", "=", 0),
                 ("value_residual", ">", 0),
                 ("state", "=", "open"),
-                ("account_move_line_ids", "!=", False),
             ]
         if operator == "!=":
             return [
@@ -39,7 +37,6 @@ class AccountAsset(models.Model):
                 ("method_number", ">", 0),
                 ("value_residual", "=", 0),
                 ("state", "!=", "open"),
-                ("account_move_line_ids", "=", False),
             ]
 
     def _check_can_transfer(self):

--- a/account_asset_transfer/readme/CONTRIBUTORS.rst
+++ b/account_asset_transfer/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * `Ecosoft <http://ecosoft.co.th>`__:
 
   * Kitti U. <kittiu@ecosoft.co.th>
+  * Pimolnat Suntian <pimolnats@ecosoft.co.th>

--- a/account_asset_transfer/readme/DESCRIPTION.rst
+++ b/account_asset_transfer/readme/DESCRIPTION.rst
@@ -3,3 +3,7 @@ This module allow transferring assets under construction (AUC) to normal assets.
 AUC is Asset under construction where some assets are in construction phase and
 cost needs to be captured for the time being. Once asset is fully completed then
 cost would be transferred to final asset
+
+**Note:**
+
+* If the asset don't have journal entries, asset transfer will use account settings from the asset/asset profile instead.

--- a/account_asset_transfer/static/description/index.html
+++ b/account_asset_transfer/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Asset Transfer from AUC to Asset</title>
 <style type="text/css">
 
@@ -372,6 +372,10 @@ ul.auto-toc {
 <p>AUC is Asset under construction where some assets are in construction phase and
 cost needs to be captured for the time being. Once asset is fully completed then
 cost would be transferred to final asset</p>
+<p><strong>Note:</strong></p>
+<ul class="simple">
+<li>If the asset don’t have journal entries, asset transfer will use account settings from the asset/asset profile instead.</li>
+</ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -423,6 +427,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li><a class="reference external" href="http://ecosoft.co.th">Ecosoft</a>:<ul>
 <li>Kitti U. &lt;<a class="reference external" href="mailto:kittiu&#64;ecosoft.co.th">kittiu&#64;ecosoft.co.th</a>&gt;</li>
+<li>Pimolnat Suntian &lt;<a class="reference external" href="mailto:pimolnats&#64;ecosoft.co.th">pimolnats&#64;ecosoft.co.th</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/account_asset_transfer/tests/test_account_asset_transfer.py
+++ b/account_asset_transfer/tests/test_account_asset_transfer.py
@@ -18,7 +18,7 @@ class TestAccountAssetTransfer(TestAssetManagement):
     def setUpClass(cls):
         super().setUpClass()
         # Profile Under Construction
-        cls.profile_uac = cls.asset_profile_model.create(
+        cls.profile_auc = cls.asset_profile_model.create(
             {
                 "account_expense_depreciation_id": cls.company_data[
                     "default_account_expense"
@@ -54,10 +54,10 @@ class TestAccountAssetTransfer(TestAssetManagement):
             }
         )
 
-    def test_01_asset_transfer_uac_to_asset(self):
-        """Create UAC and then transfer to normal asset class,
+    def test_01_asset_transfer_auc_to_asset(self):
+        """Create AUC and then transfer to normal asset class,
         I expect a new journal entry will be created"""
-        # Create 3 UAC assets from an invoice
+        # Create 3 AUC assets from an invoice
         move_form = Form(
             self.env["account.move"].with_context(
                 default_move_type="in_invoice", check_move_validity=False
@@ -68,22 +68,32 @@ class TestAccountAssetTransfer(TestAssetManagement):
         with move_form.invoice_line_ids.new() as line_form:
             line_form.name = "Wall"
             line_form.price_unit = 2000.00
-            line_form.asset_profile_id = self.profile_uac
+            line_form.asset_profile_id = self.profile_auc
         with move_form.invoice_line_ids.new() as line_form:
             line_form.name = "Roof"
             line_form.price_unit = 10000.00
-            line_form.asset_profile_id = self.profile_uac
+            line_form.asset_profile_id = self.profile_auc
         with move_form.invoice_line_ids.new() as line_form:
             line_form.name = "Floor"
             line_form.price_unit = 10000.00
-            line_form.asset_profile_id = self.profile_uac
-        self.invoice_uac = move_form.save()
-        self.invoice_uac.invoice_line_ids.write(
-            {"asset_profile_id": self.profile_uac.id}
+            line_form.asset_profile_id = self.profile_auc
+        self.invoice_auc = move_form.save()
+        self.invoice_auc.invoice_line_ids.write(
+            {"asset_profile_id": self.profile_auc.id}
         )
-        self.invoice_uac.action_post()
-        # Test can can_review status
-        assets = self.invoice_uac.invoice_line_ids.mapped("asset_id")
+        self.invoice_auc.action_post()
+        # Create AUC asset without move
+        asset_auc = self.env["account.asset"].create(
+            {
+                "name": "Door",
+                "profile_id": self.profile_auc.id,
+                "purchase_value": 1000,
+                "date_start": fields.Date.context_today(self.env.user),
+            }
+        )
+        # Test can_transfer status
+        assets = self.invoice_auc.invoice_line_ids.mapped("asset_id")
+        assets += asset_auc
         self.assertFalse(list(set(assets.mapped("can_transfer")))[0])
         assets.validate()
         assets.invalidate_cache()
@@ -100,7 +110,7 @@ class TestAccountAssetTransfer(TestAssetManagement):
         with transfer_form.to_asset_ids.new() as to_asset:
             to_asset.asset_name = "Asset 1"
             to_asset.asset_profile_id = self.profile_asset
-            to_asset.asset_value = 2000
+            to_asset.asset_value = 3000
         with transfer_form.to_asset_ids.new() as to_asset:
             to_asset.asset_name = "Asset 2"
             to_asset.asset_profile_id = self.profile_asset
@@ -111,4 +121,4 @@ class TestAccountAssetTransfer(TestAssetManagement):
         assets = transfer_move.invoice_line_ids.mapped("asset_id")
         # 2 new assets created, and value equal to original assets
         new_assets = assets.filtered(lambda l: l.state == "draft")
-        self.assertEqual(sum(new_assets.mapped("purchase_value")), 22000)
+        self.assertEqual(sum(new_assets.mapped("purchase_value")), 23000)

--- a/account_asset_transfer/views/account_asset.xml
+++ b/account_asset_transfer/views/account_asset.xml
@@ -19,6 +19,16 @@
                     help="Transfer asset from AUC to Asset"
                 />
             </button>
+            <xpath expr="//header[last()]" position="after">
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    style="margin-bottom:0px;"
+                    attrs="{'invisible': ['|', ('can_transfer', '=', 'False'), ('account_move_line_ids', '!=', [])]}"
+                >
+                    There are no journal entries on current asset(s), asset transfer will use account settings from the asset/asset profile instead.
+                </div>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
This PR use to allow the transfer of assets that don't have journal entries. But show the yellow banner for warning the current asset doesn't have journal entries, asset transfer will use account settings from the asset/asset profile instead.

![Selection_078](https://user-images.githubusercontent.com/51266019/173274293-26ce677a-b4bb-4dfa-9cf5-6e566aaf8c3c.png)
