### PR TITLE
[15.0][FIX] base_vat_optional_vies: Simple VAT error message, uncheck vies_passed field

### DIFF
--- a/base_vat_optional_vies/__manifest__.py
+++ b/base_vat_optional_vies/__manifest__.py
@@ -2,6 +2,7 @@
 # Copyright 2016 Tecnativa - Sergio Teruel
 # Copyright 2017 Tecnativa - David Vidal
 # Copyright 2019 FactorLibre - Rodrigo Bonilla
+# Copyright 2022 Moduon - Eduardo de Miguel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Optional validation of VAT via VIES",

--- a/base_vat_optional_vies/readme/CONTRIBUTORS.rst
+++ b/base_vat_optional_vies/readme/CONTRIBUTORS.rst
@@ -1,7 +1,8 @@
-* Rafael Blasco <rafael.blasco@tecnativa.com>
+* Rafael Blasco <rblasco@moduon.team>
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com>
 * David Vidal <david.vidal@tecnativa.com>
 * Rodrigo Bonilla <rodrigo.bonilla@factorlibre.com>
 * Alexandre Díaz <alexandre.diaz@tecnativa.com>
 * Harald Panten <harald.panten@sygel.es>
+* Eduardo de Miguel <edu@moduon.team>

--- a/base_vat_optional_vies/tests/test_res_partner.py
+++ b/base_vat_optional_vies/tests/test_res_partner.py
@@ -1,10 +1,12 @@
 # Copyright 2015 Tecnativa - Antonio Espinosa
 # Copyright 2016 Tecnativa - Sergio Teruel
 # Copyright 2017 Tecnativa - David Vidal
+# Copyright 2022 Moduon - Eduardo de Miguel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import mock
 
+from odoo.exceptions import ValidationError
 from odoo.tests import common
 
 
@@ -44,3 +46,17 @@ class TestResPartner(common.TransactionCase):
             self.partner.vat = "MXGODE561231GR8"
             self.partner.country_id = 156
             self.assertEqual(self.partner.vies_passed, False)
+
+    def test_validate_vies_passed_false_when_vat_set_to_false(self):
+        with mock.patch(self.vatnumber_path) as mock_vatnumber:
+            mock_vatnumber.check_vies.return_value = True
+            self.partner.vat = "ESB87530432"
+            self.partner.country_id = 20
+            self.assertEqual(self.partner.vies_passed, True)
+            self.partner.vat = False
+            self.assertEqual(self.partner.vies_passed, False)
+
+    def test_validate_wrong_vat_shows_simple_message(self):
+        with self.assertRaisesRegex(ValidationError, "does not seem to be valid"):
+            self.partner.vat = "ES11111111A"
+            self.partner.country_id = 20


### PR DESCRIPTION
This module prevents to show the raise error when VIES fails, so when an user is entering incorrectly a VAT, the error should display only the reason of the error. 
With this module, only VAT format error is shown.

Also, uncheck the vies passed when an user removes the VAT from the contact.

Once this is merged, I will backport to v14.

@rafaelbn @yajo please review

MT-747 MT-847 @moduon