### PR TITLE
[14.0][BKP] base_vat_optional_vies: Simple VAT error message, uncheck vies_passed field

### DIFF
--- a/base_vat_optional_vies/__manifest__.py
+++ b/base_vat_optional_vies/__manifest__.py
@@ -2,6 +2,7 @@
 # Copyright 2016 Tecnativa - Sergio Teruel
 # Copyright 2017 Tecnativa - David Vidal
 # Copyright 2019 FactorLibre - Rodrigo Bonilla
+# Copyright 2022 Moduon - Eduardo de Miguel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Optional validation of VAT via VIES",

--- a/base_vat_optional_vies/models/res_partner.py
+++ b/base_vat_optional_vies/models/res_partner.py
@@ -3,7 +3,9 @@
 # Copyright 2019 FactorLibre - Rodrigo Bonilla
 # Copyright 2022 Moduon - Eduardo de Miguel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+
+from odoo.addons.base_vat.models.res_partner import _ref_vat
 
 
 class ResPartner(models.Model):
@@ -36,7 +38,20 @@ class ResPartner(models.Model):
 
     @api.constrains("vat", "country_id")
     def check_vat(self):
+        self.update({"vies_passed": False})
         for partner in self:
             partner = partner.with_context(vat_partner=partner)
             super(ResPartner, partner).check_vat()
         return True
+
+    def _construct_constraint_msg(self, country_code):
+        self.ensure_one()
+        return "\n" + _(
+            "The VAT number [%(vat)s] for partner [%(name)s] does not seem to be valid. "
+            "\nNote: the expected format is %(format)s",
+            vat=self.vat,
+            name=self.name,
+            format=_ref_vat.get(
+                country_code, "'CC##' (CC=Country Code, ##=VAT Number)"
+            ),
+        )

--- a/base_vat_optional_vies/readme/CONTRIBUTORS.rst
+++ b/base_vat_optional_vies/readme/CONTRIBUTORS.rst
@@ -1,7 +1,8 @@
-* Rafael Blasco <rafael.blasco@tecnativa.com>
+* Rafael Blasco <rblasco@moduon.team>
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com>
 * David Vidal <david.vidal@tecnativa.com>
 * Rodrigo Bonilla <rodrigo.bonilla@factorlibre.com>
 * Alexandre Díaz <alexandre.diaz@tecnativa.com>
 * Harald Panten <harald.panten@sygel.es>
+* Eduardo de Miguel <edu@moduon.team>

--- a/base_vat_optional_vies/tests/test_res_partner.py
+++ b/base_vat_optional_vies/tests/test_res_partner.py
@@ -23,7 +23,7 @@ class TestResPartner(common.TransactionCase):
         with mock.patch(self.vatnumber_path) as mock_vatnumber:
             mock_vatnumber.check_vies.return_value = True
             self.partner.vat = "ESB87530432"
-            self.partner.country_id = 20
+            self.partner.country_id = self.env.ref("base.be")
             self.assertEqual(self.partner.vies_passed, True)
 
     def test_exception_vat_vies(self):
@@ -43,14 +43,14 @@ class TestResPartner(common.TransactionCase):
             self.company.vat_check_vies = False
             mock_vatnumber.check_vies.return_value = False
             self.partner.vat = "MXGODE561231GR8"
-            self.partner.country_id = 156
+            self.partner.country_id = self.env.ref("base.mx")
             self.assertEqual(self.partner.vies_passed, False)
 
     def test_validate_vies_passed_false_when_vat_set_to_false(self):
         with mock.patch(self.vatnumber_path) as mock_vatnumber:
             mock_vatnumber.check_vies.return_value = True
             self.partner.vat = "ESB87530432"
-            self.partner.country_id = 20
+            self.partner.country_id = self.env.ref("base.be")
             self.assertEqual(self.partner.vies_passed, True)
             self.partner.vat = False
             self.assertEqual(self.partner.vies_passed, False)
@@ -58,4 +58,3 @@ class TestResPartner(common.TransactionCase):
     def test_validate_wrong_vat_shows_simple_message(self):
         with self.assertRaisesRegex(ValidationError, "does not seem to be valid"):
             self.partner.vat = "ES11111111A"
-            self.partner.country_id = 20

--- a/base_vat_optional_vies/tests/test_res_partner.py
+++ b/base_vat_optional_vies/tests/test_res_partner.py
@@ -1,9 +1,11 @@
 # Copyright 2015 Tecnativa - Antonio Espinosa
 # Copyright 2016 Tecnativa - Sergio Teruel
 # Copyright 2017 Tecnativa - David Vidal
+# Copyright 2022 Moduon - Eduardo de Miguel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 import mock
 
+from odoo.exceptions import ValidationError
 from odoo.tests import common
 
 
@@ -43,3 +45,17 @@ class TestResPartner(common.TransactionCase):
             self.partner.vat = "MXGODE561231GR8"
             self.partner.country_id = 156
             self.assertEqual(self.partner.vies_passed, False)
+
+    def test_validate_vies_passed_false_when_vat_set_to_false(self):
+        with mock.patch(self.vatnumber_path) as mock_vatnumber:
+            mock_vatnumber.check_vies.return_value = True
+            self.partner.vat = "ESB87530432"
+            self.partner.country_id = 20
+            self.assertEqual(self.partner.vies_passed, True)
+            self.partner.vat = False
+            self.assertEqual(self.partner.vies_passed, False)
+
+    def test_validate_wrong_vat_shows_simple_message(self):
+        with self.assertRaisesRegex(ValidationError, "does not seem to be valid"):
+            self.partner.vat = "ES11111111A"
+            self.partner.country_id = 20


### PR DESCRIPTION
Backport of https://github.com/OCA/account-financial-tools/pull/1424 with cherry-pick + changes to let tests pass.

Tasks done:
- Changed `_build_vat_error_message` to `_construct_constraint_msg`
- Changed error message to fit the original Odoo message.

@yajo @rafaelbn @AaronHForgeFlow @Luisotto review if you want :)

MT-747  MT-847 @moduon
