### PR TITLE
[14.0][IMP] account_asset_management: filter profile asset report

### DIFF
--- a/account_asset_management/report/account_asset_report_xls.py
+++ b/account_asset_management/report/account_asset_report_xls.py
@@ -421,6 +421,8 @@ class AssetReportXlsx(models.AbstractModel):
 
             groups = _child_get(parent_group)
             dom.append(("group_ids", "in", [x.id for x in groups]))
+        if wiz.asset_profile_ids:
+            dom.append(("profile_id", "in", wiz.asset_profile_ids.ids))
 
         if not wiz.draft:
             dom.append(("state", "!=", "draft"))

--- a/account_asset_management/wizard/wiz_account_asset_report.py
+++ b/account_asset_management/wizard/wiz_account_asset_report.py
@@ -16,6 +16,10 @@ class WizAccountAssetReport(models.TransientModel):
         string="Asset Group",
         default=lambda self: self._default_asset_group_id(),
     )
+    asset_profile_ids = fields.Many2many(
+        comodel_name="account.asset.profile",
+        string="Asset Profiles",
+    )
     date_from = fields.Date(string="Start Date", required=True)
     date_to = fields.Date(string="End Date", required=True)
     draft = fields.Boolean(string="Include draft assets")

--- a/account_asset_management/wizard/wiz_account_asset_report.xml
+++ b/account_asset_management/wizard/wiz_account_asset_report.xml
@@ -10,6 +10,11 @@
                         name="asset_group_id"
                         options="{'no_create_edit': True, 'no_create': True}"
                     />
+                    <field
+                        name="asset_profile_ids"
+                        widget="many2many_tags"
+                        options="{'no_create_edit': True, 'no_create': True}"
+                    />
                     <field name="date_from" />
                     <field name="date_to" />
                     <field name="draft" />


### PR DESCRIPTION
On the asset report, add a new criterion field `Asset Profiles` (Many2many).
For case there are a lot of groups in the profile. you can filter the profiles.

WDYT?

![Selection_001](https://user-images.githubusercontent.com/20896369/173279910-9badcd23-092a-4082-b798-890884d17449.png)

cc: @kittiu 