### PR TITLE
[14.0][FIX] account_asset_management: Allow to write on moves with no asset permission

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -60,8 +60,10 @@ class AccountMove(models.Model):
 
     def write(self, vals):
         if set(vals).intersection(FIELDS_AFFECTS_ASSET_MOVE):
-            deprs = self.env["account.asset.line"].search(
-                [("move_id", "in", self.ids), ("type", "=", "depreciate")]
+            deprs = (
+                self.env["account.asset.line"]
+                .sudo()
+                .search([("move_id", "in", self.ids), ("type", "=", "depreciate")])
             )
             if deprs:
                 raise UserError(


### PR DESCRIPTION
Small fix.
Other module (ex. purchase) can't overwrite vals (journal_id and date) in account move. if not permission accountant.
