### PR TITLE
[14.0] account_menu: move Templates menu out of Invoicing > Configuration

### DIFF
--- a/account_menu/views/menu.xml
+++ b/account_menu/views/menu.xml
@@ -11,11 +11,14 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         parent="account.menu_finance_entries"
         sequence="15"
     />
+    <!-- Accounting Templates are useful only when creating a new company/loading
+        a chart of accounts, so we put it under 'Settings > Technical' and not
+        under 'Invoicing > Configuration' -->
     <menuitem
         id="menu_account_coa_settings"
         sequence="200"
-        name="Templates"
-        parent="account.menu_finance_configuration"
+        name="Accounting Templates"
+        parent="base.menu_custom"
         groups="base.group_no_one"
     />
 </odoo>


### PR DESCRIPTION
Move Templates menu (account templates, tax templates, fiscal position templates, ...) from "Invoicing > Configuration" to "Settings > Technical". There are no many menu entries under "Invoicing > Configuration", it is not reasonable to put "Templates" under there. Accounting Templates are not used directly for accounting ; it is only used when creating a new company.