### PR TITLE
[FIX] account_move_name_sequence: Use account move date to compute prefix

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -46,7 +46,10 @@ class AccountMove(models.Model):
                     seq = move.journal_id.refund_sequence_id
                 else:
                     seq = move.journal_id.sequence_id
-                name = seq.next_by_id(sequence_date=move.date)
+                # next_by_id(date) only applies on ir.sequence.date_range selection
+                # => we use with_context(ir_sequence_date=date).next_by_id()
+                # which applies on ir.sequence.date_range selection AND prefix
+                name = seq.with_context(ir_sequence_date=move.date).next_by_id()
             move.name = name
 
     # We must by-pass this constraint of sequence.mixin


### PR DESCRIPTION


In case you want name your invoice YYYY-MM-SEQ (ie: 2022-07-00001)
where:
 * YYYY: is the account move year
 * MM: is the account move month
 * SEQ: is a numerical sequence that is continue along the fiscal year
   assuming fiscal year is over two years (ie: from july to june next year)

Before this commit the sequence prefix use now() to be compute but the
range is selected with the account move date.

This commit make consistency computing prefix with the account
move date as well.

So account move manage the first janunary for the last day of
the previous year will properly use the account move date.