### PR TITLE
[FIX] 15.0 account_move_name_sequence: Use account move date to compute prefix

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -46,7 +46,10 @@ class AccountMove(models.Model):
                     seq = move.journal_id.refund_sequence_id
                 else:
                     seq = move.journal_id.sequence_id
-                name = seq.next_by_id(sequence_date=move.date)
+                # next_by_id(date) only applies on ir.sequence.date_range selection
+                # => we use with_context(ir_sequence_date=date).next_by_id()
+                # which applies on ir.sequence.date_range selection AND prefix
+                name = seq.with_context(ir_sequence_date=move.date).next_by_id()
             move.name = name
 
     # We must by-pass this constraint of sequence.mixin

--- a/account_move_name_sequence/tests/test_account_move_name_seq.py
+++ b/account_move_name_sequence/tests/test_account_move_name_seq.py
@@ -6,6 +6,8 @@
 
 from datetime import datetime
 
+from freezegun import freeze_time
+
 from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests import tagged
@@ -84,6 +86,57 @@ class TestAccountMoveNameSequence(TransactionCase):
         move.button_draft()
         move.action_post()
         self.assertEqual(move.name, move_name)
+
+    def test_prefix_move_name_use_move_date(self):
+        seq = self.misc_journal.sequence_id
+        seq.prefix = "TEST-%(year)s-%(month)s-"
+        self.env["ir.sequence.date_range"].sudo().create(
+            {
+                "date_from": "2021-07-01",
+                "date_to": "2022-06-30",
+                "sequence_id": seq.id,
+            }
+        )
+        with freeze_time("2022-01-01"):
+            move = self.env["account.move"].create(
+                {
+                    "date": "2021-12-31",
+                    "journal_id": self.misc_journal.id,
+                    "line_ids": [
+                        (0, 0, {"account_id": self.account1.id, "debit": 10}),
+                        (0, 0, {"account_id": self.account2.id, "credit": 10}),
+                    ],
+                }
+            )
+            move.action_post()
+        self.assertEqual(move.name, "TEST-2021-12-0001")
+        with freeze_time("2022-01-01"):
+            move = self.env["account.move"].create(
+                {
+                    "date": "2022-06-30",
+                    "journal_id": self.misc_journal.id,
+                    "line_ids": [
+                        (0, 0, {"account_id": self.account1.id, "debit": 10}),
+                        (0, 0, {"account_id": self.account2.id, "credit": 10}),
+                    ],
+                }
+            )
+            move.action_post()
+        self.assertEqual(move.name, "TEST-2022-06-0002")
+
+        with freeze_time("2022-01-01"):
+            move = self.env["account.move"].create(
+                {
+                    "date": "2022-07-01",
+                    "journal_id": self.misc_journal.id,
+                    "line_ids": [
+                        (0, 0, {"account_id": self.account1.id, "debit": 10}),
+                        (0, 0, {"account_id": self.account2.id, "credit": 10}),
+                    ],
+                }
+            )
+            move.action_post()
+        self.assertEqual(move.name, "TEST-2022-07-0001")
 
     def test_in_refund(self):
         in_refund_invoice = self.env["account.move"].create(


### PR DESCRIPTION


In case you want name your invoice YYYY-MM-SEQ (ie: 2022-07-00001)
where:
 * YYYY: is the account move year
 * MM: is the account move month
 * SEQ: is a numerical sequence that is continue along the fiscal year
   assuming fiscal year is over two years (ie: from july to june next year)

Before this commit the sequence prefix use now() to be compute but the
range is selected with the account move date.

This commit make consistency computing prefix with the account
move date as well.

So account move manage the first janunary for the last day of
the previous year will properly use the account move date.

Co-authored-by: Alexis de Lattre <alexis.delattre@akretion.com>