### PR TITLE
[14.0][FIX] account_move_force_removal: Do tests in post-install

### DIFF
--- a/account_move_force_removal/tests/test_move.py
+++ b/account_move_force_removal/tests/test_move.py
@@ -2,10 +2,11 @@
 # License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo.exceptions import UserError
-from odoo.tests import Form
+from odoo.tests import Form, tagged
 from odoo.tests.common import SavepointCase
 
 
+@tagged("post_install", "-at_install")
 class TestMove(SavepointCase):
     @classmethod
     def setUpClass(cls):
@@ -13,40 +14,20 @@ class TestMove(SavepointCase):
         cls.partner = cls.env["res.partner"].create(
             {"name": "Test customer", "customer_rank": 1}
         )
-        cls.journal = cls.env["account.journal"].create(
-            {
-                "name": "Test journal",
-                "type": "sale",
-                "code": "test-sale-jorunal",
-                "company_id": cls.env.company.id,
-            }
-        )
         cls.product = cls.env["product.product"].create(
             {"name": "Test product", "type": "service"}
         )
         cls.company = cls.env.company
-        account_type = cls.env.ref("account.data_account_type_other_income")
-        cls.income_account = cls.env["account.account"].search(
-            [
-                ("user_type_id", "=", account_type.id),
-                ("company_id", "=", cls.company.id),
-            ],
-            limit=1,
-        )
-
         invoice = Form(
             cls.env["account.move"].with_context(
-                default_type="out_invoice", default_company_id=cls.env.company.id
+                default_move_type="out_invoice", default_company_id=cls.env.company.id
             )
         )
         invoice.partner_id = cls.partner
-        invoice.journal_id = cls.journal
         with invoice.invoice_line_ids.new() as line_form:
-            line_form.name = cls.product.name
             line_form.product_id = cls.product
             line_form.quantity = 1.0
             line_form.price_unit = 10
-            line_form.account_id = cls.income_account
         invoice = invoice.save()
         invoice.action_post()
         cls.invoice = invoice


### PR DESCRIPTION
If not, there's no guarantee that the chart of accounts is populated, and the tests may fail.

@Tecnativa