### PR TITLE
[13.0][FIX] account_asset_management: removal of non-depreciable assets

### DIFF
--- a/account_asset_management/tests/account_asset_test_data.xml
+++ b/account_asset_management/tests/account_asset_test_data.xml
@@ -50,6 +50,16 @@
             <field name="method_number" eval="5" />
             <field name="method_period">year</field>
         </record>
+        <record id="account_asset_profile_art" model="account.asset.profile">
+            <field name="account_expense_depreciation_id" ref="account.a_expense" />
+            <field name="account_asset_id" ref="account.xfa" />
+            <field name="account_depreciation_id" ref="account.xfa" />
+            <field name="journal_id" ref="account.expenses_journal" />
+            <field name="name">Art</field>
+            <field name="method_time">year</field>
+            <field name="method_number" eval="0" />
+            <field name="method_period">year</field>
+        </record>
         <!-- Assets -->
         <record id="account_asset_asset_ict0" model="account.asset">
             <field name="state">draft</field>

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -254,6 +254,9 @@ class AccountAssetRemove(models.TransientModel):
         if not dlines:
             asset.compute_depreciation_board()
             dlines = _dlines(asset)
+        residual_value = asset.value_residual
+        if not dlines:
+            return residual_value
         first_to_depreciate_dl = dlines[0]
 
         first_date = first_to_depreciate_dl.line_date


### PR DESCRIPTION
Assets such as art are not subject to a depreciation board, but
nevertheless they must be created as asset, and are subject to
removal, just like any other asset. Without this fix, when trying
to remove the asset you would get an error message.

cc @ForgeFlow