### PR TITLE
[14.0] account_fiscal_position_vat_check: remove field from warning banner

### DIFF
--- a/account_fiscal_position_vat_check/views/res_partner.xml
+++ b/account_fiscal_position_vat_check/views/res_partner.xml
@@ -20,11 +20,8 @@
                     role="alert"
                     attrs="{'invisible': [('show_warning_vat_required', '=', False)]}"
                 >
-                <b>Missing VAT number</b>: this partner has the fiscal position <em
-                    ><field
-                            name="property_account_position_id"
-                            readonly="1"
-                        /></em> that require to know the VAT number of the partner.
+                <b
+                    >Missing VAT number</b>: this partner has a fiscal position that requires to know the VAT number of the partner.
                 </div>
             </div>
             <group name="fiscal_information" position="inside">


### PR DESCRIPTION
Remove <field name="property_account_position_id"> from warning banner because other modules inherit the partner form view and put fields after property_account_position_id. Example : OCA module intrastat_product https://github.com/OCA/intrastat-extrastat/blob/14.0/intrastat_product/views/res_partner_view.xml : the field invoice_intrastat_detail is displayed in the warning banner !

Another possibility would be to set the view to a high priority, but it only works in other modules inherit the right view that added the field, and it's not always the case. Given the low added value of having the field "property_account_position_id" in the warning banner, I prefer to simply remove it. But, if reviewers prefer the solution with a high priority on the view, I'll make another PR.