### PR TITLE
[15.0][FIX] account_move_line_purchase_info: separate vendor bills from journal entries on PO

### DIFF
--- a/account_move_line_purchase_info/__manifest__.py
+++ b/account_move_line_purchase_info/__manifest__.py
@@ -11,6 +11,10 @@
     "category": "Generic",
     "depends": ["purchase_stock"],
     "license": "AGPL-3",
-    "data": ["security/account_security.xml", "views/account_move_view.xml"],
+    "data": [
+        "security/account_security.xml",
+        "views/account_move_view.xml",
+        "views/purchase_order_view.xml",
+    ],
     "installable": True,
 }

--- a/account_move_line_purchase_info/models/__init__.py
+++ b/account_move_line_purchase_info/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_move
 from . import purchase_order_line
 from . import stock_move
+from . import purchase_order

--- a/account_move_line_purchase_info/models/purchase_order.py
+++ b/account_move_line_purchase_info/models/purchase_order.py
@@ -1,8 +1,25 @@
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
+
+    @api.depends("order_line.invoice_lines.move_id")
+    def _compute_journal_entries(self):
+        for order in self:
+            journal_entries = order.mapped("order_line.invoice_lines.move_id").filtered(
+                lambda r: r.move_type == "entry"
+            )
+            order.journal_entry_ids = journal_entries
+            order.journal_entries_count = len(journal_entries)
+
+    journal_entries_count = fields.Integer(compute="_compute_journal_entries")
+    journal_entry_ids = fields.Many2many(
+        comodel_name="account.move",
+        relation="journal_entries_ids_purchase_order",
+        compute="_compute_journal_entries",
+        string="Journal Entries",
+    )
 
     @api.depends("order_line.invoice_lines.move_id")
     def _compute_invoice(self):
@@ -14,3 +31,33 @@ class PurchaseOrder(models.Model):
             )
             order.invoice_ids = invoices
             order.invoice_count = len(invoices)
+
+    def action_view_journal_entries(self, invoices=False):
+        """This function returns an action that display existing journal entries of
+        given purchase order ids. When only one found, show the journal entry
+        immediately.
+        """
+        if not invoices:
+            self.sudo()._read(["journal_entry_ids"])
+            invoices = self.journal_entry_ids
+
+        result = self.env["ir.actions.act_window"]._for_xml_id(
+            "account.action_move_in_invoice_type"
+        )
+        # choose the view_mode accordingly
+        if len(invoices) > 1:
+            result["domain"] = [("id", "in", invoices.ids)]
+        elif len(invoices) == 1:
+            res = self.env.ref("account.view_move_form", False)
+            form_view = [(res and res.id or False, "form")]
+            if "views" in result:
+                result["views"] = form_view + [
+                    (state, view) for state, view in result["views"] if view != "form"
+                ]
+            else:
+                result["views"] = form_view
+            result["res_id"] = invoices.id
+        else:
+            result = {"type": "ir.actions.act_window_close"}
+
+        return result

--- a/account_move_line_purchase_info/tests/test_account_move_line_purchase_info.py
+++ b/account_move_line_purchase_info/tests/test_account_move_line_purchase_info.py
@@ -225,3 +225,21 @@ class TestAccountMoveLinePurchaseInfo(common.TransactionCase):
         )
         name_get_no_ctx = po_line.name_get()
         self.assertEqual(name_get_no_ctx, [(po_line.id, po_line.name)])
+
+    def test_purchase_order_with_journal_entries_and_vendor_bills(self):
+        purchase = self._create_purchase([(self.product, 1)])
+        purchase.button_confirm()
+        purchase._compute_invoice()
+        purchase._compute_journal_entries()
+        self.assertEqual(purchase.journal_entry_ids.id, False)
+        self.assertEqual(purchase.invoice_ids.id, False)
+        self.assertEqual(purchase.journal_entries_count, 0)
+        self.assertEqual(purchase.invoice_count, 0)
+        purchase.picking_ids.move_ids_without_package.quantity_done = 1
+        purchase.picking_ids.button_validate()
+        self.assertEqual(purchase.journal_entries_count, 1)
+        self.assertEqual(purchase.invoice_count, 0)
+        purchase.action_create_invoice()
+        self.assertEqual(purchase.journal_entries_count, 1)
+        self.assertEqual(purchase.invoice_count, 1)
+        self.assertNotEqual(purchase.action_view_journal_entries(), None)

--- a/account_move_line_purchase_info/views/purchase_order_view.xml
+++ b/account_move_line_purchase_info/views/purchase_order_view.xml
@@ -1,0 +1,27 @@
+<odoo>
+    <record id="view_move_line_journal_entries_form" model="ir.ui.view">
+        <field name="name">purchase.order.form.journal.entry</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form" />
+        <field name="arch" type="xml">
+            <button name="action_view_invoice" position="after">
+                <button
+                    type="object"
+                    name="action_view_journal_entries"
+                    class="oe_stat_button"
+                    icon="fa-list-ul"
+                    attrs="{'invisible':['|', ('journal_entries_count', '=', 0), ('state', 'in', ('draft','sent','to approve'))]}"
+                    groups="account.group_account_user"
+                >
+                    <field
+                        name="journal_entries_count"
+                        widget="statinfo"
+                        string="Journal Entries"
+                    />
+                    <field name='journal_entry_ids' invisible="1" />
+                </button>
+            </button>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Journal entries and Vendor Bills appear mixed in Vendor Bills button on Purchase Order Form, I separated them. 

@ForgeFlow