### PR TITLE
[15.0][FIX] account_fiscal_year: avoid trigger of uninstall 'fiscalyear' date range type

### DIFF
--- a/account_fiscal_year/migrations/15.0.1.0.0/pre-migration.py
+++ b/account_fiscal_year/migrations/15.0.1.0.0/pre-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        DELETE FROM ir_model_data imd
+        USING date_range_type drt
+        WHERE imd.model = 'date.range.type' AND imd.res_id = drt.id
+            AND imd.name = 'fiscalyear'""",
+    )


### PR DESCRIPTION
Due to https://github.com/OCA/account-financial-tools/commit/070595a19bfe2d7bfbcc35e9c6ac91ae7bfd19ed.