### PR TITLE
[15.0][IMP] account_move_line_purchase_info: Journal Entries are not bills

### DIFF
--- a/account_move_line_purchase_info/models/purchase_order.py
+++ b/account_move_line_purchase_info/models/purchase_order.py
@@ -42,7 +42,7 @@ class PurchaseOrder(models.Model):
             invoices = self.journal_entry_ids
 
         result = self.env["ir.actions.act_window"]._for_xml_id(
-            "account.action_move_in_invoice_type"
+            "account.action_move_journal_line"
         )
         # choose the view_mode accordingly
         if len(invoices) > 1:


### PR DESCRIPTION
This fixes this issue:

Create a PO, receive the products, return the products to vendors. Go to the PO and click on the Journal entries button:
![2022-11-03_18-36](https://user-images.githubusercontent.com/19620251/199794339-ec189d7a-9b07-47f7-bb26-318407b1056f.png)

One issue is found:

- The title shows "Bills" Instead of journal entries


cc @ForgeFlow

