### PR TITLE
[11.0][FIX] account_asset_disposal: Journal Entry post after disposal

### DIFF
--- a/account_asset_disposal/__manifest__.py
+++ b/account_asset_disposal/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Account asset disposal",
     "summary": "Makes asset close account move automatically",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Accounting & Finance",
     "website": "http://github.com/OCA/account-financial-tools",
     "author": "Tecnativa, "

--- a/account_asset_disposal/__manifest__.py
+++ b/account_asset_disposal/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Account asset disposal",
     "summary": "Makes asset close account move automatically",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.0.2",
     "category": "Accounting & Finance",
     "website": "http://github.com/OCA/account-financial-tools",
     "author": "Tecnativa, "

--- a/account_asset_disposal/models/account_asset_asset.py
+++ b/account_asset_disposal/models/account_asset_asset.py
@@ -173,3 +173,20 @@ class AccountAssetAsset(models.Model):
             'disposal_date': False,
             'disposal_move_id': False,
         })
+
+
+class AccountAssetDepreciationLine(models.Model):
+    _inherit = "account.asset.depreciation.line"
+
+    @api.multi
+    def post_lines_and_close_asset(self):
+        assets_disposed_depreciation_lines = self.env["account.asset.depreciation.line"]
+        for line in self:
+            asset = line.asset_id
+            if "disposed" == asset.state and asset.currency_id.is_zero(
+                asset.value_residual
+            ):
+                assets_disposed_depreciation_lines |= line
+        super(
+            AccountAssetDepreciationLine, self - assets_disposed_depreciation_lines
+        ).post_lines_and_close_asset()

--- a/account_asset_disposal/models/account_asset_asset.py
+++ b/account_asset_disposal/models/account_asset_asset.py
@@ -51,11 +51,15 @@ class AccountAssetAsset(models.Model):
         if not float_is_zero(self.value_residual,
                              precision_rounding=self.currency_id.rounding):
             loss_value += self.value_residual
+        if hasattr(self, "account_analytic_id") and self.account_analytic_id:
+            account_analytic_id = self.account_analytic_id.id
+        else:
+            account_analytic_id = self.category_id.account_analytic_id.id
         return {
             'name': _('Asset loss'),
             'journal_id': self.category_id.journal_id.id,
             'account_id': loss_account.id,
-            'analytic_account_id': self.category_id.account_analytic_id.id,
+            'analytic_account_id': account_analytic_id,
             'date': date,
             'debit': loss_value,
             'credit': 0.0,


### PR DESCRIPTION
If you edit a journal entry from the asset after disposal (e.g.: cancel -> edit date -> post), the state changes to `Close` instead of keeping `Disposed`.