### PR TITLE
13.0_account-financial-tools_fix: add acl for group billing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
     rev: 2.5.2
     hooks:
       - id: setuptools-odoo-make-default
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.7.9
     hooks:
       - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
     rev: 2.5.2
     hooks:
       - id: setuptools-odoo-make-default
-  - repo: https://github.com/pycqa/flake8
+  - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:
       - id: flake8

--- a/account_spread_cost_revenue/security/ir.model.access.csv
+++ b/account_spread_cost_revenue/security/ir.model.access.csv
@@ -1,9 +1,13 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_account_spread_cost_revenue_full,Full access on account.spread,model_account_spread,account.group_account_manager,1,1,1,1
 access_account_spread_cost_revenue_read,Read access on account.spread,model_account_spread,account.group_account_user,1,0,0,0
+access_account_spread_cost_revenue_read_for_billing,Read access on account.spread for billing,model_account_spread,account.group_account_invoice,1,0,0,0
 access_account_spread_cost_revenue_line_full,Full access on account.spread.line,model_account_spread_line,account.group_account_manager,1,1,1,1
 access_account_spread_cost_revenue_line_read,Read access on account.spread.line,model_account_spread_line,account.group_account_user,1,0,0,0
+access_account_spread_cost_revenue_line_read_for_billing,Read access on account.spread.line for billing,model_account_spread_line,account.group_account_invoice,1,0,0,0
 access_account_spread_cost_revenue_template_full,Full access on account.spread.template,model_account_spread_template,account.group_account_manager,1,1,1,1
 access_account_spread_cost_revenue_template_read,Read access on account.spread.template,model_account_spread_template,account.group_account_user,1,0,0,0
+access_account_spread_cost_revenue_template_read_for_billing,Read access on account.spread.template for billing,model_account_spread_template,account.group_account_invoice,1,0,0,0
 access_account_spread_cost_revenue_template_auto_full,Full access on account.spread.template.auto,model_account_spread_template_auto,account.group_account_manager,1,1,1,1
 access_account_spread_cost_revenue_template_auto_read,Read access on account.spread.template.auto,model_account_spread_template_auto,account.group_account_user,1,0,0,0
+access_account_spread_cost_revenue_template_auto_read_for_billing,Read access on account.spread.template.autofor billing,model_account_spread_template_auto,account.group_account_invoice,1,0,0,0

--- a/account_spread_cost_revenue/tests/test_account_invoice_auto_spread.py
+++ b/account_spread_cost_revenue/tests/test_account_invoice_auto_spread.py
@@ -3,9 +3,7 @@
 
 from odoo.exceptions import UserError
 
-from odoo.addons.account_spread_cost_revenue.tests.test_account_invoice_spread import (
-    TestAccountInvoiceSpread,
-)
+from .test_account_invoice_spread import TestAccountInvoiceSpread
 
 
 class TestAccountInvoiceAutoSpread(TestAccountInvoiceSpread):


### PR DESCRIPTION
More ACL(s) needed for salesman(billing group) because before it they aren't able to post invoice .....