### PR TITLE
[14.0][FIX] account_asset_management: Poor performance updating assets massively

### DIFF
--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -19,6 +19,7 @@ class AccountAssetLine(models.Model):
         required=True,
         ondelete="cascade",
         check_company=True,
+        index=True,
     )
     previous_id = fields.Many2one(
         comodel_name="account.asset.line",

--- a/account_asset_management/readme/CONTRIBUTORS.rst
+++ b/account_asset_management/readme/CONTRIBUTORS.rst
@@ -20,3 +20,7 @@
 
   * Jordi Ballester <jordi.ballester@forgeflow.com>
   * Miquel Raïch <miquel.raich@forgeflow.com>
+
+* `NuoBiT <https://www.nuobit.com>`_:
+
+  * Kilian Niubo <kniubo@nuobit.com>


### PR DESCRIPTION
When updating assets massively the performance when searching for deprecation_lines_ids is very low. 
It is a difficult problem to detect since massive asset updates are not common.
 Indexing in this field dramatically improves the timing performance. 
For example, to update 3000 records it took 30 sec. With this index it takes to 2 seconds.

cc @eantones