### PR TITLE
[14.0][FIX] account_move_template: TYPO tags -> tax_tag_ids

### DIFF
--- a/account_move_template/view/account_move_template.xml
+++ b/account_move_template/view/account_move_template.xml
@@ -166,6 +166,11 @@
                                 name="journal_id"
                                 options="{'no_open': True, 'no_create': True}"
                             />
+                            <field
+                                name="currency_id"
+                                options="{'no_open': True, 'no_create': True}"
+                                groups="base.group_multi_currency"
+                            />
                         </group>
                         <group name="main-right">
                             <field name="ref" />

--- a/account_move_template/wizard/account_move_template_run_view.xml
+++ b/account_move_template/wizard/account_move_template_run_view.xml
@@ -35,6 +35,11 @@ dicts and finding IDs of partners!
                     <field name="company_id" groups="base.group_multi_company" />
                     <field name="date" states="set_lines" />
                     <field name="journal_id" states="set_lines" />
+                    <field
+                        name="currency_id"
+                        states="set_lines"
+                        groups="base.group_multi_currency"
+                    />
                     <field name="ref" states="set_lines" />
                     <field name="partner_id" states="set_lines" />
                 </group>


### PR DESCRIPTION
When using taxes in a template the following error appears:
```
Odoo Server Error
Traceback (most recent call last):
  File "/opt/odoo/custom/src/repos/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/repos/odoo/odoo/http.py", line 685, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/repos/odoo/odoo/http.py", line 361, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/repos/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/repos/odoo/odoo/http.py", line 349, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/repos/odoo/odoo/http.py", line 914, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/repos/odoo/odoo/http.py", line 533, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1392, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1380, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/repos/odoo/odoo/api.py", line 399, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/repos/odoo/odoo/api.py", line 386, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/account_move_template/wizard/account_move_template_run.py", line 184, in generate_move
    move = self.env["account.move"].create(move_vals)
  File "<decorator-gen-280>", line 2, in create
  File "/opt/odoo/custom/src/repos/odoo/odoo/api.py", line 326, in _model_create_single
    return create(self, arg)
  File "/opt/odoo/auto/addons/nubeaerp_003068/models/account_move.py", line 9, in create
    move = super(AccountMove, self).create(vals)
  File "<decorator-gen-269>", line 2, in create
  File "/opt/odoo/custom/src/repos/odoo/odoo/api.py", line 326, in _model_create_single
    return create(self, arg)
  File "/opt/odoo/auto/addons/l10n_es_aeat_sii_oca/models/account_move.py", line 324, in create
    invoice = super().create(vals)
  File "<decorator-gen-268>", line 2, in create
  File "/opt/odoo/custom/src/repos/odoo/odoo/api.py", line 326, in _model_create_single
    return create(self, arg)
  File "/opt/odoo/auto/addons/account_banking_mandate/models/account_move.py", line 33, in create
    move = self.new(vals)
  File "/opt/odoo/custom/src/repos/odoo/odoo/models.py", line 5534, in new
    record._update_cache(values, validate=False)
  File "/opt/odoo/custom/src/repos/odoo/odoo/models.py", line 5180, in _update_cache
    cache.set(self, field, field.convert_to_cache(value, self, validate))
  File "/opt/odoo/custom/src/repos/odoo/odoo/fields.py", line 2928, in convert_to_cache
    ids.add(comodel.new(command[2], ref=command[1]).id)
  File "/opt/odoo/custom/src/repos/odoo/odoo/models.py", line 5534, in new
    record._update_cache(values, validate=False)
  File "/opt/odoo/custom/src/repos/odoo/odoo/models.py", line 5176, in _update_cache
    raise ValueError("Invalid field %r on model %r" % (e.args[0], self._name))
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/repos/odoo/odoo/http.py", line 641, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/repos/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: Invalid field 'tag_ids' on model 'account.move.line'
```


The problem has been solved, in addition a currency per journal has been added, and set on `account.move` and `account.move.line` data creation (Multi-Currencies).  
