### PR TITLE
[FW][15.0][FIX] account_move_name_sequence: call flush before to post the moves

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -64,3 +64,7 @@ class AccountMove(models.Model):
         if not invoices_other_sequences and invoices_no_gap_sequences:
             return False
         return super(AccountMove, invoices_other_sequences)._is_end_of_seq_chain()
+
+    def _post(self, soft=True):
+        self.flush()
+        return super()._post(soft=soft)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

## Module 

account_move_name_sequence

## Describe the bug

When creating a credit note on a supplier bill, the following validation error is raised :

```
A move can not be posted with name "/" or empty value
Check the journal sequence, please
```

##  To Reproduce

Affected versions: 14.0, 15.0

Steps to reproduce the behavior:

1. Create a vendor bill and post it
2. Click on the Add credit note
3.  Select "Full refund" or "Full refund and new draft invoice" on the wizard then click on Revers

Fix https://github.com/OCA/account-financial-tools/issues/1501

This is a forward-port of https://github.com/OCA/account-financial-tools/pull/1514

Current behavior before PR:

An error is raised at the time of the creation of a credit note on the supplier bill.

Desired behavior after PR is merged:

Supplier bills should be properly reversed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


