### PR TITLE
[13.0][FIX] account_move_line_sale_info: add the sale line information to credit notes

### DIFF
--- a/account_move_line_sale_info/models/account_move.py
+++ b/account_move_line_sale_info/models/account_move.py
@@ -68,3 +68,8 @@ class AccountMoveLine(models.Model):
         index=True,
         copy=False,
     )
+
+    def _copy_data_extend_business_fields(self, values):
+        # Same way Odoo standard does for purchase_line_id field
+        super(AccountMoveLine, self)._copy_data_extend_business_fields(values)
+        values["sale_line_id"] = self.sale_line_id.id


### PR DESCRIPTION
Steps to reproduce the bug:
Create sales order, deliver and invoice and post the invoice
Create a credit note from the invoice
Result: The credit note account move lines are not linked to the sale order line
Expected Result: The credit note account move lines are linked to the sale order line, same as happens with purchases

cc @ForgeFlow
