### PR TITLE
[13.0][FIX]account_move_line_sale_info: pick the info directly form sale line ids field

### DIFF
--- a/account_move_line_sale_info/models/account_move.py
+++ b/account_move_line_sale_info/models/account_move.py
@@ -12,17 +12,7 @@ class AccountMove(models.Model):
         res = super()._prepare_interim_account_line_vals(
             line, move, debit_interim_account
         )
-        if (
-            not res.get("move_id", False)
-            or not res.get("product_id", False)
-            or not res.get("quantity", False)
-        ):
-            return res
-        am = self.env["account.move"].browse(res["move_id"])
-        sale_line_id = am.invoice_line_ids.filtered(
-            lambda il: il.product_id.id == res["product_id"]
-            and il.quantity == res["quantity"]
-        ).mapped("sale_line_id")
+        sale_line_id = line.sale_line_ids
         if sale_line_id and len(sale_line_id) == 1:
             res["sale_line_id"] = sale_line_id.id
         return res
@@ -31,17 +21,7 @@ class AccountMove(models.Model):
         res = super()._prepare_expense_account_line_vals(
             line, move, debit_interim_account
         )
-        if (
-            not res.get("move_id", False)
-            or not res.get("product_id", False)
-            or not res.get("quantity", False)
-        ):
-            return res
-        am = self.env["account.move"].browse(res["move_id"])
-        sale_line_id = am.invoice_line_ids.filtered(
-            lambda il: il.product_id.id == res["product_id"]
-            and il.quantity == res["quantity"]
-        ).mapped("sale_line_id")
+        sale_line_id = line.sale_line_ids
         if sale_line_id and len(sale_line_id) == 1:
             res["sale_line_id"] = sale_line_id.id
         return res


### PR DESCRIPTION
Current code does a search on product and quantity:

* That is not efficient nor accurate
* We rely in the sale_line_ids field of standard Odoo
* We don't change the main behavior, if one invoice line pays more than one sale line then the sale_line_id field is not filled in.
cc @ForgeFlow