### PR TITLE
[IMP] account_chart_update: let user choose digits

### DIFF
--- a/account_chart_update/models/__init__.py
+++ b/account_chart_update/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import account_account
 from . import ir_model_fields

--- a/account_chart_update/models/account_account.py
+++ b/account_chart_update/models/account_account.py
@@ -1,0 +1,21 @@
+# Copyright 2022-2023 Moduon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class AccountAccount(models.Model):
+    _inherit = "account.account"
+
+    # Overridden fields
+    code_prefix = fields.Char(
+        compute="_compute_code_prefix",
+        store=True,
+        help="Account code without trailing zeros.",
+    )
+
+    @api.depends("code")
+    def _compute_code_prefix(self):
+        """Get account code without trailing zeros."""
+        for one in self:
+            one.code_prefix = one.code and one.code.rstrip("0")

--- a/account_chart_update/readme/CONTRIBUTORS.rst
+++ b/account_chart_update/readme/CONTRIBUTORS.rst
@@ -1,9 +1,9 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Pedro M. Baeza
-  * Jairo Llopis
   * Ernesto Tejeda
 
+* Jairo Llopis (https://www.moduon.team/)
 * Jacques-Etienne Baudoux <je@bcim.be>
 * Sylvain Van Hoof <sylvain@okia.be>
 * Nacho Muñoz <nacmuro@gmail.com>

--- a/account_chart_update/security/ir.model.access.csv
+++ b/account_chart_update/security/ir.model.access.csv
@@ -1,9 +1,9 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_wizard_update_charts_accounts,wizard.update.charts.accounts,model_wizard_update_charts_accounts,,1,1,1,1
-access_wizard_update_charts_accounts_account,wizard.update.charts.accounts.account,model_wizard_update_charts_accounts_account,,1,1,1,1
-access_wizard_tax_matching,wizard.tax.matching,model_wizard_tax_matching,,1,1,1,1
-access_wizard_fp_matching,wizard.fp.matching,model_wizard_fp_matching,,1,1,1,1
-access_wizard_account_matching,wizard.account.matching,model_wizard_account_matching,,1,1,1,1
-access_wizard_update_charts_accounts_tax,wizard.update.charts.accounts.tax,model_wizard_update_charts_accounts_tax,,1,1,1,1
-access_wizard_matching,wizard.matching,model_wizard_matching,,1,1,1,1
-access_wizard_update_charts_accounts_fiscal_position,wizard.update.charts.accounts.fiscal.position,model_wizard_update_charts_accounts_fiscal_position,,1,1,1,1
+access_wizard_update_charts_accounts,wizard.update.charts.accounts,model_wizard_update_charts_accounts,base.group_erp_manager,1,1,1,1
+access_wizard_update_charts_accounts_account,wizard.update.charts.accounts.account,model_wizard_update_charts_accounts_account,base.group_erp_manager,1,1,1,1
+access_wizard_tax_matching,wizard.tax.matching,model_wizard_tax_matching,base.group_erp_manager,1,1,1,1
+access_wizard_fp_matching,wizard.fp.matching,model_wizard_fp_matching,base.group_erp_manager,1,1,1,1
+access_wizard_account_matching,wizard.account.matching,model_wizard_account_matching,base.group_erp_manager,1,1,1,1
+access_wizard_update_charts_accounts_tax,wizard.update.charts.accounts.tax,model_wizard_update_charts_accounts_tax,base.group_erp_manager,1,1,1,1
+access_wizard_matching,wizard.matching,model_wizard_matching,base.group_erp_manager,1,1,1,1
+access_wizard_update_charts_accounts_fiscal_position,wizard.update.charts.accounts.fiscal.position,model_wizard_update_charts_accounts_fiscal_position,base.group_erp_manager,1,1,1,1

--- a/account_chart_update/tests/test_account_chart_update.py
+++ b/account_chart_update/tests/test_account_chart_update.py
@@ -589,3 +589,36 @@ class TestAccountChartUpdate(common.HttpCase):
         self.assertTrue(list(self.account.get_xml_id().values())[0])
         self.assertTrue(list(self.fp.get_xml_id().values())[0])
         wizard.unlink()
+
+    def test_custom_digits(self):
+        self.account.name = "changed"
+        # Change chart template to use 10 digits
+        self.chart_template.code_digits = 10
+        # Open wizard, select chart, code digits are inherited
+        wiz_f = common.Form(self.wizard_obj.with_company(self.company))
+        wiz_f.chart_template_id = self.chart_template
+        self.assertEqual(wiz_f.code_digits, 10)
+        # Execute it
+        wiz = wiz_f.save()
+        wiz.action_find_records()
+        wiz.action_update_records()
+        # Capital account updated its digits
+        self.assertEqual(self.account.name, "Test")
+        self.assertEqual(self.account.code, "1000000000")
+
+    def test_matching_code_prefix(self):
+        # User had 10 digits
+        self.account.name = "changed"
+        self.account.code = "1000000000"
+        # Open wizard, select chart, code digits are inherited
+        wiz_f = common.Form(self.wizard_obj.with_company(self.company))
+        wiz_f.chart_template_id = self.chart_template
+        wiz_f.recreate_xml_ids = True
+        self.assertEqual(wiz_f.code_digits, 6)
+        # Execute it
+        wiz = wiz_f.save()
+        wiz.action_find_records()
+        wiz.action_update_records()
+        # Capital account updated its digits
+        self.assertEqual(self.account.name, "Test")
+        self.assertEqual(self.account.code, "100000")

--- a/account_chart_update/wizard/wizard_chart_update_view.xml
+++ b/account_chart_update/wizard/wizard_chart_update_view.xml
@@ -232,11 +232,9 @@
                         </notebook>
                     </page>
                 </notebook>
-                <group
-                    attrs="{'invisible':[('state','!=','ready'),]}"
-                    string="Records to create/update"
-                >
-                    <notebook colspan="4">
+                <div attrs="{'invisible':[('state','!=','ready')]}">
+                    <h3>Records to create/update</h3>
+                    <notebook>
                         <page
                             string="Taxes"
                             attrs="{'invisible': [('update_tax', '=', False)]}"
@@ -342,7 +340,7 @@
                             </field>
                         </page>
                     </notebook>
-                </group>
+                </div>
                 <group
                     col="4"
                     colspan="4"

--- a/account_chart_update/wizard/wizard_chart_update_view.xml
+++ b/account_chart_update/wizard/wizard_chart_update_view.xml
@@ -35,7 +35,6 @@
                         name="company_id"
                         attrs="{'invisible':[('state','!=','init')]}"
                     />
-                    <field name="code_digits" invisible="1" />
                     <field
                         name="chart_template_id"
                         domain="[('visible', '=', True)]"
@@ -57,6 +56,11 @@
                             >
                                 <field name="continue_on_errors" />
                                 <field name="recreate_xml_ids" />
+                                <field
+                                    name="code_digits"
+                                    options="{'invisible': [('update_account', '=', False)]}"
+                                    readonly="1"
+                                />
                             </group>
                         </group>
                         <group>
@@ -155,11 +159,19 @@
                                         edit="false"
                                         default_order="sequence"
                                     >
-                                        <field name="sequence" widget="handle" />
-                                        <field name="matching_value" />
+                                        <field
+                                            name="sequence"
+                                            widget="handle"
+                                            force_save="1"
+                                        />
+                                        <field name="matching_value" force_save="1" />
                                     </tree>
                                     <form>
-                                        <field name="matching_value" readonly="1" />
+                                        <field
+                                            name="matching_value"
+                                            readonly="1"
+                                            force_save="1"
+                                        />
                                     </form>
                                 </field>
                             </page>
@@ -174,11 +186,19 @@
                                         edit="false"
                                         default_order="sequence"
                                     >
-                                        <field name="sequence" widget="handle" />
-                                        <field name="matching_value" />
+                                        <field
+                                            name="sequence"
+                                            widget="handle"
+                                            force_save="1"
+                                        />
+                                        <field name="matching_value" force_save="1" />
                                     </tree>
                                     <form>
-                                        <field name="matching_value" readonly="1" />
+                                        <field
+                                            name="matching_value"
+                                            readonly="1"
+                                            force_save="1"
+                                        />
                                     </form>
                                 </field>
                             </page>
@@ -193,11 +213,19 @@
                                         edit="false"
                                         default_order="sequence"
                                     >
-                                        <field name="sequence" widget="handle" />
-                                        <field name="matching_value" />
+                                        <field
+                                            name="sequence"
+                                            widget="handle"
+                                            force_save="1"
+                                        />
+                                        <field name="matching_value" force_save="1" />
                                     </tree>
                                     <form>
-                                        <field name="matching_value" readonly="1" />
+                                        <field
+                                            name="matching_value"
+                                            readonly="1"
+                                            force_save="1"
+                                        />
                                     </form>
                                 </field>
                             </page>


### PR DESCRIPTION
Before this change, if somebody decided to use a different amount of digits for their account codes, every time the wizard got executed it detected every account as something to change.

Also, if someone already had created a valid account with a different amount of digits, when executing the wizard it wouldn't detect it as a valid match because of this reason.

FTR, digits are hardcoded in the chart template. This is usually done by Odoo and sometimes the digits chosen is somewhat arbitrary.

After this change, the user can now change the desired amount of digits generated by the wizard.

![imagen](https://user-images.githubusercontent.com/973709/209550431-52a2b088-bdd8-48ed-b9e1-83191e30cadf.png)


Also, there's a new option for matching accounts. It is called "code prefix". It just detects that the account has the same code as the account template, followed by any amount of zeros. This new option is enabled by default, with lower priority than the "code" option.

![imagen](https://user-images.githubusercontent.com/973709/209550487-36b18bdb-ac3b-4137-99a1-1e2de09bcdbb.png)


OTOH, only managers will be able to execute the chart of account wizard. This reflects [the requirement hardcoded upstream][1].

Summarizing, now you can choose to have a different amount of digits in your accounts, and that'll be just OK.

@moduon MT-1923

[1]: https://github.com/odoo/odoo/blob/4ac5ec6a2c4b3e2707446acb1cd693808f0d3c8a/addons/account/models/chart_template.py#L234