### PR TITLE
[15.0][FIX] account_balance_line: Show balance field (instead of adding it again) to avoid it being shown twice in some cases.

### DIFF
--- a/account_balance_line/views/account_move_line_view.xml
+++ b/account_balance_line/views/account_move_line_view.xml
@@ -13,8 +13,8 @@
         <field name="model">account.move.line</field>
         <field name="inherit_id" ref="account.view_move_line_tree_grouped" />
         <field name="arch" type="xml">
-            <field name="credit" position="after">
-                <field name="balance" sum="Total Balance" optional="show" />
+            <field name="balance" position="attributes">
+                <attribute name="optional">show</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/account-financial-tools/pull/1545

Show balance field (instead of adding it again) to avoid it being shown twice in some cases (Invoicing > Accounting > Ledgers > General Ledger).

**Before**
![antes](https://user-images.githubusercontent.com/4117568/210388859-77036b82-f68b-42db-89ab-c898979ad393.png)

**After**
![despues](https://user-images.githubusercontent.com/4117568/210388878-fb2f59e3-b4ff-4df0-840b-e9d68cb26d57.png)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT40902