### PR TITLE
[FIX] account_chart_update: false positive detecting diff on Html fields

### DIFF
--- a/account_chart_update/readme/CONTRIBUTORS.rst
+++ b/account_chart_update/readme/CONTRIBUTORS.rst
@@ -1,7 +1,6 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Pedro M. Baeza
-  * Jairo Llopis
   * Ernesto Tejeda
 
 * Jacques-Etienne Baudoux <je@bcim.be>
@@ -9,3 +8,4 @@
 * Nacho Muñoz <nacmuro@gmail.com>
 * Alberto Martín - Guadaltech <alberto.martin@guadaltech.es>
 * Fernando La Chica - GreenIce <fernandolachica@gmail.com>
+* Jairo Llopis (https://www.moduon.team/)

--- a/account_chart_update/tests/test_account_chart_update.py
+++ b/account_chart_update/tests/test_account_chart_update.py
@@ -327,7 +327,7 @@ class TestAccountChartUpdate(common.HttpCase):
         self.account_template.tag_ids = [
             (6, 0, [self.account_tag_1.id, self.account_tag_2.id])
         ]
-        self.fp_template.note = "<p>Test note</p>"
+        self.fp_template.note = "Test note. \n \n Multiline. \n"
         self.fp_template.account_ids.account_dest_id = new_account_tmpl.id
         self.fp_template.tax_ids.tax_dest_id = self.tax_template.id
         wizard = self.wizard_obj.create(self.wizard_vals)
@@ -341,7 +341,7 @@ class TestAccountChartUpdate(common.HttpCase):
         self.assertEqual(wizard.account_ids.account_id, self.account_template)
         self.assertEqual(wizard.account_ids.type, "updated")
         self.assertTrue(wizard.fiscal_position_ids)
-        self.assertTrue(wizard.fiscal_position_ids.type, "updated")
+        self.assertEqual(wizard.fiscal_position_ids.type, "updated")
         self.assertEqual(
             wizard.fiscal_position_ids.fiscal_position_id, self.fp_template
         )
@@ -359,7 +359,7 @@ class TestAccountChartUpdate(common.HttpCase):
         self.assertEqual(self.account.name, self.account_template.name)
         self.assertIn(self.account_tag_1, self.account.tag_ids)
         self.assertIn(self.account_tag_2, self.account.tag_ids)
-        self.assertEqual(self.fp.note, self.fp_template.note)
+        self.assertEqual(self.fp.note, f"<p>{self.fp_template.note}</p>")
         self.assertEqual(self.fp.account_ids.account_dest_id, new_account)
         self.assertEqual(self.fp.tax_ids.tax_dest_id, self.tax)
         wizard.unlink()
@@ -384,7 +384,6 @@ class TestAccountChartUpdate(common.HttpCase):
         self.assertFalse(wizard.fiscal_position_ids)
         self.tax_template.description = "Test description"
         self.account_template.name = "Other name"
-        self.fp_template.note = "<p>Test note</p>"
         wizard.unlink()
         # Remove objects
         new_tax_tmpl.unlink()


### PR DESCRIPTION
When executing the chart updater and selecting the "notes" field from fiscal positions, you were getting differences 100% of the time.

This was because [fiscal position's notes field is Html][1], while [the template field is Text][2].

@moduon MT-1912

[1]: https://github.com/odoo/odoo/blob/5ef647d5d452a1b334ad6f987d9bf0722b4b8ae7/addons/account/models/partner.py#L32
[2]: https://github.com/odoo/odoo/blob/5ef647d5d452a1b334ad6f987d9bf0722b4b8ae7/addons/account/models/chart_template.py#L1470