### PR TITLE
[FIX] account_chart_update: responsive views

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update_view.xml
+++ b/account_chart_update/wizard/wizard_chart_update_view.xml
@@ -204,11 +204,9 @@
                         </notebook>
                     </page>
                 </notebook>
-                <group
-                    attrs="{'invisible':[('state','!=','ready'),]}"
-                    string="Records to create/update"
-                >
-                    <notebook colspan="4">
+                <div attrs="{'invisible':[('state','!=','ready')]}">
+                    <h3>Records to create/update</h3>
+                    <notebook>
                         <page
                             string="Taxes"
                             attrs="{'invisible': [('update_tax', '=', False)]}"
@@ -314,7 +312,7 @@
                             </field>
                         </page>
                     </notebook>
-                </group>
+                </div>
                 <group
                     col="4"
                     colspan="4"


### PR DESCRIPTION
Make its 2nd step usable.

Cherry-picked from https://github.com/OCA/account-financial-tools/pull/1538.

Quoting from https://github.com/OCA/account-financial-tools/pull/1538#issuecomment-1368894588:

> I added a small new improvement. Makes 2nd step page go from this:
> 
> https://user-images.githubusercontent.com/973709/210229560-1abd2efa-4f7d-44fd-9d9f-bdf2e76afefc.mp4
> 
> to this:
> 
> 
> https://user-images.githubusercontent.com/973709/210229578-12ebe37b-a0e7-43d2-923c-abd8ddaa18c7.mp4
> 
> FTR same problem as upstream https://github.com/odoo/odoo/pull/90946.
> 

@moduon MT-1923