### PR TITLE
[15.0][IMP] account_chart_update: reduce permissions

### DIFF
--- a/account_chart_update/security/ir.model.access.csv
+++ b/account_chart_update/security/ir.model.access.csv
@@ -1,9 +1,9 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_wizard_update_charts_accounts,wizard.update.charts.accounts,model_wizard_update_charts_accounts,,1,1,1,1
-access_wizard_update_charts_accounts_account,wizard.update.charts.accounts.account,model_wizard_update_charts_accounts_account,,1,1,1,1
-access_wizard_tax_matching,wizard.tax.matching,model_wizard_tax_matching,,1,1,1,1
-access_wizard_fp_matching,wizard.fp.matching,model_wizard_fp_matching,,1,1,1,1
-access_wizard_account_matching,wizard.account.matching,model_wizard_account_matching,,1,1,1,1
-access_wizard_update_charts_accounts_tax,wizard.update.charts.accounts.tax,model_wizard_update_charts_accounts_tax,,1,1,1,1
-access_wizard_matching,wizard.matching,model_wizard_matching,,1,1,1,1
-access_wizard_update_charts_accounts_fiscal_position,wizard.update.charts.accounts.fiscal.position,model_wizard_update_charts_accounts_fiscal_position,,1,1,1,1
+access_wizard_update_charts_accounts,wizard.update.charts.accounts,model_wizard_update_charts_accounts,base.group_erp_manager,1,1,1,1
+access_wizard_update_charts_accounts_account,wizard.update.charts.accounts.account,model_wizard_update_charts_accounts_account,base.group_erp_manager,1,1,1,1
+access_wizard_tax_matching,wizard.tax.matching,model_wizard_tax_matching,base.group_erp_manager,1,1,1,1
+access_wizard_fp_matching,wizard.fp.matching,model_wizard_fp_matching,base.group_erp_manager,1,1,1,1
+access_wizard_account_matching,wizard.account.matching,model_wizard_account_matching,base.group_erp_manager,1,1,1,1
+access_wizard_update_charts_accounts_tax,wizard.update.charts.accounts.tax,model_wizard_update_charts_accounts_tax,base.group_erp_manager,1,1,1,1
+access_wizard_matching,wizard.matching,model_wizard_matching,base.group_erp_manager,1,1,1,1
+access_wizard_update_charts_accounts_fiscal_position,wizard.update.charts.accounts.fiscal.position,model_wizard_update_charts_accounts_fiscal_position,base.group_erp_manager,1,1,1,1


### PR DESCRIPTION
Only managers will be able to execute the chart of account wizard. This reflects [the requirement hardcoded upstream][1].

Rescued from #1538 

@moduon MT-1923

[1]: https://github.com/odoo/odoo/blob/4ac5ec6a2c4b3e2707446acb1cd693808f0d3c8a/addons/account/models/chart_template.py#L234