### PR TITLE
[FIX] [16.0] account_fiscal_position_vat_check: Move show_warning_vat_required field from fiscal_information grp

### DIFF
--- a/account_fiscal_position_vat_check/views/res_partner.xml
+++ b/account_fiscal_position_vat_check/views/res_partner.xml
@@ -24,9 +24,9 @@
                         /></em> that require to know the VAT number of the partner.
                 </div>
             </div>
-            <group name="fiscal_information" position="inside">
+            <field name="is_company" position="after">
                 <field name="show_warning_vat_required" invisible="1" />
-            </group>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
Move this field from the group fiscal_information, because is modified in sale addon restricting it for the groups account.group_account_invoice and sales_team.group_sale_salesman

So if sale gets installed Odoo throws an error for the show_warning_vat_required field and its group restriction

```
Error: while parsing /opt/odoo/odoo-server/addons/sale/views/res_partner_views.xml:41

<form string=\"Partners\" __validate__=\"1\">
                <div class=\"alert alert-warning oe_edit_only\" role=\"alert\" attrs=\"{'invisible': [('same_vat_partner_id', '=', False)]}\">
                  A partner with the same <span><span class=\"o_vat_label\">Tax ID</span></span> already exists (<field name=\"same_vat_partner_id\"/>

Field 'show_warning_vat_required' used in attrs ({'invisible': [('show_warning_vat_required', '=', False)]}) is restricted to the group(s) account.group_account_invoice, sales_team.group_sale_salesman.

View error context:
{'file': '/opt/odoo/odoo-server/addons/sale/views/res_partner_views.xml',
 'line': 1,
 'name': 'res.partner.view.buttons',
 'view': ir.ui.view(1683,),
 'view.model': 'res.partner',
 'view.parent': ir.ui.view(122,),
 'xmlid': 'res_partner_view_buttons'}

```