### PR TITLE
[16.0][FIX] account_usability : incorrect hierarchy of groups

### DIFF
--- a/account_usability/readme/CONFIGURE.rst
+++ b/account_usability/readme/CONFIGURE.rst
@@ -1,6 +1,0 @@
-To see all the menus, make sure:
-
-* Your user is member of the group
-  "Technical Settings / Show Full Accounting Features"
-
-* The page is running in debug mode

--- a/account_usability/readme/DEVELOP.rst
+++ b/account_usability/readme/DEVELOP.rst
@@ -1,0 +1,58 @@
+**Detailled Module Category Changes (ir.module.category)**
+
+- base.module_category_accounting_accounting
+
+*CE Without that module*
+-> Complete Name : Invoicing
+
+*CE With that module / EE*
+-> Complete Name: **Accounting**
+
+
+**Detailled Groups Changes (res.groups)**
+
+- account.group_account_invoice
+
+*CE Without that module*
+-> Complete Name : Invoicing / Billing
+-> Parent Category : base.module_category_accounting_accounting
+-> Implies : base.group_user
+
+*CE With that module / EE*
+-> Complete Name: **Accounting** / Billing
+
+
+- account.group_account_readonly
+
+*CE Without that module*
+-> Complete Name : Technical / Show Accounting Features - Readonly
+-> Parent : base.module_category_hidden
+-> Implies : base.group_user
+
+*CE With that module / EE*
+-> name: **Accounting / Read-only**
+-> Parent Category: **base.module_category_accounting_accounting**
+
+
+- account.group_account_user
+
+*CE Without that module*
+-> Complete Name : Technical / Show Full Accounting Features
+-> Parent : base.module_category_hidden
+-> Implies : account.group_account_invoice, account.group_account_readonly
+
+*CE With that module / EE*
+-> name: **Accounting / Bookkeeper**
+-> Parent Category: **base.module_category_accounting_accounting**
+
+
+- account.group_account_manager
+
+*CE Without that module*
+-> Complete Name : Invoicing / Billing Administrator
+-> Parent : base.module_category_accounting_accounting
+-> Implies : account.group_account_invoice
+
+*CE With that module / EE*
+-> name: **Accounting / Accountant**
+-> Implies : **account.group_account_user**

--- a/account_usability/readme/ROADMAP.rst
+++ b/account_usability/readme/ROADMAP.rst
@@ -1,2 +1,1 @@
-* Add a form view for the model ``account.bank.statement`` as Odoo SA privatized in EE the form view
-  in V16.0.
+* Add a form view for the model ``account.bank.statement`` as Odoo SA privatized in EE the form view in V16.0.

--- a/account_usability/security/res_groups.xml
+++ b/account_usability/security/res_groups.xml
@@ -5,27 +5,37 @@
     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 <odoo>
-    <!-- Rename groups to fit with EE naming
-    Previously named 'Show Accounting Features – Readonly' in CE ->
-    -->
+<!-- Change groups to fit with EE configuration -->
+
+<!-- Level 2:
+    Name:  Show Accounting Features - Readonly -> Read-only
+    Parent: Technical -> Accounting
+-->
+
     <record id="account.group_account_readonly" model="res.groups">
         <field name="name">Read-only</field>
         <field name="category_id" ref="base.module_category_accounting_accounting" />
     </record>
 
-    <!-- Rename groups to fit with EE naming
-    Previously named 'Show Full Accounting Features' in CE ->
-    -->
+<!-- Level 3:
+    Name: Show Full Accounting Features -> Bookkeeper
+    Parent: Technical -> Accounting
+-->
     <record id="account.group_account_user" model="res.groups">
         <field name="name">Bookkeeper</field>
         <field name="category_id" ref="base.module_category_accounting_accounting" />
     </record>
 
-    <!-- Rename groups to fit with EE naming
-    Previously named 'Billing Administrator' in CE ->
-    -->
+<!-- Level 4:
+    Name: Billing Administrator -> Accountant
+    Implied Groups : account.group_account_invoice -> account.group_account_user
+-->
     <record id="account.group_account_manager" model="res.groups">
         <field name="name">Accountant</field>
-        <field name="category_id" ref="base.module_category_accounting_accounting" />
+        <field
+            name="implied_ids"
+            eval="[(6, 0, [ref('account.group_account_user')])]"
+        />
     </record>
+
 </odoo>


### PR DESCRIPTION
- [FIX] account_usability: make account.group_account_manager depends on 'account.group_account_user' (and not 'account.group_account_invoice') to stick with EE design.
- [IMP] Documentation, adding detailled changes regarding groups in the DEVELOP.rst section.

Closes : https://github.com/OCA/account-financial-tools/issues/1558

CC : @remi-filament 