### PR TITLE
[16.0][FIX] account_move_name_sequence: Not propagate with_prefix parameter

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -70,3 +70,6 @@ class AccountMove(models.Model):
         if moves:
             self.flush_model(["name", "journal_id", "move_type", "state"])
         return super()._fetch_duplicate_supplier_reference(only_posted=only_posted)
+
+    def _get_last_sequence(self, relaxed=False, with_prefix=None, lock=True):
+        return super()._get_last_sequence(relaxed, None, lock)

--- a/account_move_name_sequence/tests/test_account_move_name_seq.py
+++ b/account_move_name_sequence/tests/test_account_move_name_seq.py
@@ -309,7 +309,6 @@ class TestAccountMoveNameSequence(TransactionCase):
                 ],
             }
         )
-        in_refund_invoice._compute_split_sequence()
         self.assertEqual(in_refund_invoice.name, "/")
         in_refund_invoice.action_post()
         error_msg = "You cannot delete an item linked to a posted entry."


### PR DESCRIPTION
With the "account_move_name_sequence" module the "_get_last_sequence" method does not have to propagate the with_prefix parameter.  The sequence_prefix parameter will not be completed and will give error as it is False in this line of code. https://github.com/OCA/OCB/blob/16.0/addons/account/models/sequence_mixin.py#L169

Issue: #1561 