### PR TITLE
[16.0][FIX] account_fiscal_position_vat_check: fix view

### DIFF
--- a/account_fiscal_position_vat_check/views/res_partner.xml
+++ b/account_fiscal_position_vat_check/views/res_partner.xml
@@ -24,7 +24,7 @@
                         /></em> that require to know the VAT number of the partner.
                 </div>
             </div>
-            <group name="fiscal_information" position="inside">
+            <group name="sale" position="inside">
                 <field name="show_warning_vat_required" invisible="1" />
             </group>
         </field>


### PR DESCRIPTION
Avoid the error: Field 'show_warning_vat_required' used in attrs ({'invisible': [('show_warning_vat_required', '=', False)]}) is restricted to the group(s) account.group_account_invoice, sales_team.group_sale_salesman.