### PR TITLE
[15.0][FIX] account_move_name_sequence: Not propagate with_prefix parameter

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -68,3 +68,6 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         self.flush()
         return super()._post(soft=soft)
+
+    def _get_last_sequence(self, relaxed=False, with_prefix=None, lock=True):
+        return super()._get_last_sequence(relaxed, None, lock)


### PR DESCRIPTION
With the "account_move_name_sequence" module the "_get_last_sequence" method does not have to propagate the with_prefix parameter.  The sequence_prefix parameter will not be completed and will give error as it is False in this line of code. https://github.com/OCA/OCB/blob/15.0/addons/account/models/sequence_mixin.py#L164


Fix https://github.com/OCA/account-financial-tools/issues/1561