### PR TITLE
[15.0][ENH] account_asset_management: default salvage value

### DIFF
--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -79,6 +79,15 @@ class AccountAssetProfile(models.Model):
         check_company=True,
         string="Asset Groups",
     )
+    salvage_value = fields.Float(
+        digits="Account",
+        help="The estimated value that an asset will realize upon "
+        "its sale at the end of its useful life.\n"
+        "This value is used to determine the depreciation amounts.",
+    )
+    salvage_type = fields.Selection(
+        selection=[("fixed", "Fixed"), ("percent", "Percentage of Price")]
+    )
     method = fields.Selection(
         selection=lambda self: self._selection_method(),
         string="Computation Method",

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -947,3 +947,30 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         last_line.create_move()
         self.assertEqual(asset.value_residual, 0)
         self.assertEqual(asset.state, "close")
+
+    def test_21_asset_profile_salvage_value(self):
+        """Compute salvage value from asset profile."""
+        # Case percent
+        self.car5y.salvage_type = "percent"
+        self.car5y.salvage_value = 5
+        asset = self.asset_model.create(
+            {
+                "name": "test asset",
+                "profile_id": self.car5y.id,
+                "purchase_value": 1000,
+                "date_start": time.strftime("%Y-07-07"),
+            }
+        )
+        self.assertEqual(asset.salvage_value, 50)
+        # Case fixed amount
+        self.car5y.salvage_type = "fixed"
+        self.car5y.salvage_value = 5
+        asset = self.asset_model.create(
+            {
+                "name": "test asset",
+                "profile_id": self.car5y.id,
+                "purchase_value": 1000,
+                "date_start": time.strftime("%Y-07-07"),
+            }
+        )
+        self.assertEqual(asset.salvage_value, 5)

--- a/account_asset_management/views/account_asset_profile.xml
+++ b/account_asset_management/views/account_asset_profile.xml
@@ -20,6 +20,18 @@
             </div>
                 <group>
                     <group>
+                        <label for="salvage_value" />
+                        <div>
+                            <field name="salvage_value" class="oe_inline" nolabel="1" />
+                            <span
+                                    class="o_form_label oe_inline"
+                                    attrs="{'invisible':[('salvage_type','!=','percent')]}"
+                                >%</span>
+                        </div>
+                        <field
+                                name="salvage_type"
+                                attrs="{'required': [('salvage_value', '!=', 0.0)]}"
+                            />
                         <field name="group_ids" widget="many2many_tags" />
                         <field name="asset_product_item" />
                         <field name="active" invisible="1" />


### PR DESCRIPTION
This PR adds the field **Salvage Value** in the asset profile for default salvage value when creating the asset.

**Example**

1. Set Salvage Value in the asset profile
2. Create an asset with an asset profile
3. Salvage Value in asset changes following Salvage Value set in the asset profile

![Selection_038](https://user-images.githubusercontent.com/51266019/214780654-7baec996-8ed1-4774-8e36-d20027edfbae.png)

![asset](https://user-images.githubusercontent.com/51266019/214780640-acd70619-2024-40c9-9567-b30908d831fe.gif)
