### PR TITLE
[13.0][FIX]account_asset_management: devaluate assets created in locked periods on the first open day

### DIFF
--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -141,6 +141,7 @@
                                         name="use_leap_years"
                                         attrs="{'invisible': [('days_calc', '=', True)]}"
                                     />
+                                    <field name="force_depreciation_in_open_period" />
                                 </group>
                                 <group>
                                     <separator


### PR DESCRIPTION
Fixes https://github.com/OCA/account-financial-tools/issues/1568

cc @ForgeFlow