### PR TITLE
[FIX] account_journal_general_sequence: let non admins delete sequence ranges

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,11 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.12.0
+_commit: v1.14.1
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP
 generate_requirements_txt: true
 github_check_license: true
+github_ci_extra_env: {}
 github_enable_codecov: true
 github_enable_makepot: true
 github_enable_stale_action: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
               fi
           done
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     name: ${{ matrix.name }}
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py

--- a/account_journal_general_sequence/tests/test_numbering.py
+++ b/account_journal_general_sequence/tests/test_numbering.py
@@ -39,6 +39,9 @@ class RenumberCase(TestAccountReconciliationCommon):
     @users("test_manager")
     def test_renumber(self):
         # Post invoices in wrong order
+        next_year_invoice = self._create_invoice(
+            date_invoice="2023-12-31", auto_validate=True
+        )
         new_invoice = self._create_invoice(
             date_invoice="2022-05-10", auto_validate=True
         )
@@ -59,10 +62,12 @@ class RenumberCase(TestAccountReconciliationCommon):
         self.assertGreater(opening_invoice.entry_number, new_invoice.entry_number)
         # Renumber again, starting from zero
         wiz_f = Form(self.env["account.move.renumber.wizard"])
-        wiz_f.starting_number = 0
         wiz = wiz_f.save()
         wiz.action_renumber()
-        self.assertEqual(opening_invoice.entry_number, "2022/0000000000")
+        self.assertEqual(opening_invoice.entry_number, "2022/0000000001")
+        self.assertEqual(old_invoice.entry_number, "2022/0000000002")
+        self.assertEqual(new_invoice.entry_number, "2022/0000000003")
+        self.assertEqual(next_year_invoice.entry_number, "2023/0000000001")
 
     @users("test_invoicer")
     def test_install_no_entry_number(self):

--- a/account_journal_general_sequence/wizards/account_move_renumber_wizard.py
+++ b/account_journal_general_sequence/wizards/account_move_renumber_wizard.py
@@ -72,9 +72,9 @@ class AccountMoveRenumberWizard(models.TransientModel):
                 ("sequence_id", "=", self.sequence_id.id),
             ]
         )
-        future_ranges.unlink()
+        # Safe `sudo` calls; wizard only available for accounting managers
+        future_ranges.sudo().unlink()
         current_range = self.sequence_id._get_current_sequence(self.starting_date)
-        # Safe `sudo`; wizard only available for accounting managers
         current_range.sudo().number_next = self.starting_number
         self.sequence_id.sudo().number_next = self.starting_number
         # Renumber the moves


### PR DESCRIPTION
When the renumbering was done after a later sequence date range got added, the wizard was asking for admin permissions. Account managers are the ones that should take this decision, though. Fixed now.

Ports:


- [x] v14 #1575 
- [x] v16 #1576 

@moduon MT-2185