### PR TITLE
[FIX] account_journal_general_sequence: let non admins delete sequence ranges

### DIFF
--- a/account_journal_general_sequence/tests/test_numbering.py
+++ b/account_journal_general_sequence/tests/test_numbering.py
@@ -39,6 +39,9 @@ class RenumberCase(TestAccountReconciliationCommon):
     @users("test_manager")
     def test_renumber(self):
         # Post invoices in wrong order
+        next_year_invoice = self._create_invoice(
+            date_invoice="2023-12-31", auto_validate=True
+        )
         new_invoice = self._create_invoice(
             date_invoice="2022-05-10", auto_validate=True
         )
@@ -59,10 +62,12 @@ class RenumberCase(TestAccountReconciliationCommon):
         self.assertGreater(opening_invoice.entry_number, new_invoice.entry_number)
         # Renumber again, starting from zero
         wiz_f = Form(self.env["account.move.renumber.wizard"])
-        wiz_f.starting_number = 0
         wiz = wiz_f.save()
         wiz.action_renumber()
-        self.assertEqual(opening_invoice.entry_number, "2022/0000000000")
+        self.assertEqual(opening_invoice.entry_number, "2022/0000000001")
+        self.assertEqual(old_invoice.entry_number, "2022/0000000002")
+        self.assertEqual(new_invoice.entry_number, "2022/0000000003")
+        self.assertEqual(next_year_invoice.entry_number, "2023/0000000001")
 
     @users("test_invoicer")
     def test_install_no_entry_number(self):

--- a/account_journal_general_sequence/wizards/account_move_renumber_wizard.py
+++ b/account_journal_general_sequence/wizards/account_move_renumber_wizard.py
@@ -72,9 +72,9 @@ class AccountMoveRenumberWizard(models.TransientModel):
                 ("sequence_id", "=", self.sequence_id.id),
             ]
         )
-        future_ranges.unlink()
+        # Safe `sudo` calls; wizard only available for accounting managers
+        future_ranges.sudo().unlink()
         current_range = self.sequence_id._get_current_sequence(self.starting_date)
-        # Safe `sudo`; wizard only available for accounting managers
         current_range.sudo().number_next = self.starting_number
         self.sequence_id.sudo().number_next = self.starting_number
         # Renumber the moves


### PR DESCRIPTION
When the renumbering was done after a later sequence date range got added, the wizard was asking for admin permissions. Account managers are the ones that should take this decision, though. Fixed now.

@moduon MT-2185 fw-port of #1573 