### PR TITLE
[16.0][FIX] account_move_name_sequence: test error unlink moves without check sequence

### DIFF
--- a/account_move_name_sequence/tests/test_account_move_name_seq.py
+++ b/account_move_name_sequence/tests/test_account_move_name_seq.py
@@ -282,9 +282,7 @@ class TestAccountMoveNameSequence(TransactionCase):
             invoice.unlink()
         invoice.button_draft()
         invoice.button_cancel()
-        error_msg = "You cannot delete this entry, as it has already consumed a"
-        with self.assertRaisesRegex(UserError, error_msg):
-            invoice.unlink()
+        invoice.unlink()
 
     def test_remove_invoice_error_secuence_standard(self):
         implementation = {"implementation": "standard"}


### PR DESCRIPTION
Now you can unlink moves without check sequence

view fix: https://github.com/odoo/odoo/commit/6112f4f59aeb5dc5a3b698edd861b19f25da7017

