### PR TITLE
[14.0][FIX] account_asset_management: use Reversal Date to Accounting Date of reversal entry

### DIFF
--- a/account_asset_management/wizard/wiz_asset_move_reverse.py
+++ b/account_asset_management/wizard/wiz_asset_move_reverse.py
@@ -43,7 +43,7 @@ class WizAssetMoveReverse(models.TransientModel):
             .with_context(active_model="account.move", active_ids=move.ids)
             .create(
                 {
-                    "date": fields.Date.today(),
+                    "date": self.date_reversal,
                     "reason": self.reason,
                     "refund_method": "refund",
                     "journal_id": self.journal_id.id,


### PR DESCRIPTION
![reverse_asset](https://user-images.githubusercontent.com/51266019/216561416-53e45f6a-0642-45c9-ba74-cad6290a5d77.gif)
