### PR TITLE
[14.0] remove useless vatnumber lib

### DIFF
--- a/base_vat_optional_vies/__manifest__.py
+++ b/base_vat_optional_vies/__manifest__.py
@@ -9,7 +9,6 @@
     "category": "Accounting",
     "version": "14.0.1.0.3",
     "depends": ["base_vat"],
-    "external_dependencies": {"python": ["vatnumber"]},
     "data": ["views/res_partner_view.xml"],
     "author": "Tecnativa," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-financial-tools",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # generated from manifests external_dependencies
 numpy-financial<=1.0.0
 numpy>=1.15
-vatnumber


### PR DESCRIPTION
this lib is not used anymore by source code and recent pip install failled