### PR TITLE
[IMP] account_menu: Show Account move lines on Partner

### DIFF
--- a/account_menu/__manifest__.py
+++ b/account_menu/__manifest__.py
@@ -24,6 +24,7 @@
         "views/view_account_tax_group.xml",
         "views/view_account_tax_template.xml",
         "views/view_account_type.xml",
+        "views/view_account_move_line.xml",
     ],
     "demo": ["demo/res_groups.xml"],
     "installable": True,

--- a/account_menu/views/view_account_move_line.xml
+++ b/account_menu/views/view_account_move_line.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Copyright (C) 2023 - Creu Blanca
+@author: Enric Tobella
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+    <record id="account.action_account_moves_all_tree" model="ir.actions.act_window">
+        <field name="binding_model_id" ref="base.model_res_partner" />
+    </record>
+</odoo>


### PR DESCRIPTION
This functionality was lost due to the change of id of the action. If you come from v11, the menu was showed properly, however, this needs to be ported to 11, 12, 15 and 16