### PR TITLE
[FIX] account_usability: add to view required field

### DIFF
--- a/account_usability/views/view_account_chart_template.xml
+++ b/account_usability/views/view_account_chart_template.xml
@@ -11,6 +11,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="arch" type="xml">
             <field name="complete_tax_set" position="after">
                 <field name="use_anglo_saxon" />
+                <field name="currency_id" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Add the missing required field currency_id in the form view of chart account template.

### Before this PR

If we try to create a new chart of the account template we receive this message error

![no-permite-crear-desde-0](https://user-images.githubusercontent.com/7593953/220982858-5d8eeb51-dbd0-4942-88f7-d9dee7610b88.png)

### After this PR
![after-changes](https://user-images.githubusercontent.com/7593953/220983406-7696815d-c0a3-4923-ba24-a9bb8cf1fb6f.png)
