### PR TITLE
[15.0][FIX] account_cost_center: enable default cost_center

### DIFF
--- a/account_cost_center/__manifest__.py
+++ b/account_cost_center/__manifest__.py
@@ -9,7 +9,7 @@
     "website": "https://github.com/OCA/account-financial-tools",
     "category": "Accounting",
     "version": "15.0.1.0.0",
-    "depends": ["account"],
+    "depends": ["account", "base_view_inheritance_extension"],
     "data": [
         "security/ir.model.access.csv",
         "security/account_cost_center_security.xml",

--- a/account_cost_center/views/account_move_views.xml
+++ b/account_cost_center/views/account_move_views.xml
@@ -19,6 +19,11 @@
             <field name="ref" position="after">
                 <field name="cost_center_id" />
             </field>
+            <field name="invoice_line_ids" position="attributes">
+                <attribute name="context" operation="update">{
+                    "default_cost_center_id": cost_center_id,
+                }</attribute>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
This fix restores the selection of the default cost center when creating invoice lines. That functionality was removed (for reasons that I'm not aware of) when module was ported to V15.