### PR TITLE
[14.0][IMP] account_loan: bump numpy ver to <1.25

### DIFF
--- a/account_loan/__manifest__.py
+++ b/account_loan/__manifest__.py
@@ -20,7 +20,7 @@
     ],
     "installable": True,
     "external_dependencies": {
-        "python": ["numpy==1.15", "numpy-financial<=1.0.0"],
+        "python": ["numpy>=1.15", "numpy-financial<=1.0.0"],
         "deb": ["libatlas-base-dev"],
     },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # generated from manifests external_dependencies
 freezegun
 numpy-financial<=1.0.0
-numpy==1.15
+numpy>=1.15
 python-dateutil
 vatnumber


### PR DESCRIPTION
Having trouble installing such an old version of numpy, so took the chance to suggest an upgrade.

Genuine question: numpy isn't even used directly in the module, shouldn't the dependency be dropped and only numpy-financial be kept?