### PR TITLE
[FIX] bug that block invoice confirmation (issues/1602)

### DIFF
--- a/account_move_name_sequence/__manifest__.py
+++ b/account_move_name_sequence/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Account Move Number Sequence",
-    "version": "16.0.1.1.2",
+    "version": "16.0.2.0.0",
     "category": "Accounting",
     "license": "AGPL-3",
     "summary": "Generate journal entry number from sequence",

--- a/account_move_name_sequence/migrations/16.0.2.0.0/post-migration.py
+++ b/account_move_name_sequence/migrations/16.0.2.0.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2023 AKRETION
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(env, version):
+    if not version:
+        return
+
+    env.execute("""
+    ALTER TABLE account_move DROP CONSTRAINT IF EXISTS account_move_name_state_diagonal ;
+    """)

--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -15,15 +15,6 @@ class AccountMove(models.Model):
     sequence_prefix = fields.Char(compute=False)
     sequence_number = fields.Integer(compute=False)
 
-    _sql_constraints = [
-        (
-            "name_state_diagonal",
-            "CHECK(COALESCE(name, '') NOT IN ('/', '') OR state!='posted')",
-            'A move can not be posted with name "/" or empty value\n'
-            "Check the journal sequence, please",
-        ),
-    ]
-
     @api.depends("state", "journal_id", "date")
     def _compute_name_by_sequence(self):
         for move in self:


### PR DESCRIPTION
This bug aims to solve the issue https://github.com/OCA/account-financial-tools/issues/1602.
the bug is not systematic (see issue above) but it is due to the way in which the calculation of the "depends" field is carried out.
In fact de _post method do many actions before set state to "posted". Some action can trigger SQL check and block invoice confirmation.

