### PR TITLE
[16.0][FIX] account_move_name_sequence: computed fields raising warning

### DIFF
--- a/account_move_name_sequence/models/account_journal.py
+++ b/account_move_name_sequence/models/account_journal.py
@@ -34,6 +34,9 @@ class AccountJournal(models.Model):
     )
     # Redefine the default to True as <=v13.0
     refund_sequence = fields.Boolean(default=True)
+    # has_sequence_holes is not relevant anymore (since based on sequence_prefix/number)
+    # -> compute=False to improve perf and to avoid displaying warning
+    has_sequence_holes = fields.Boolean(compute=False)
 
     @api.constrains("refund_sequence_id", "sequence_id")
     def _check_journal_sequence(self):

--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -9,11 +9,14 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     name = fields.Char(compute="_compute_name_by_sequence")
-    # highest_name, sequence_prefix and sequence_number are not needed any more
+    # highest_name, sequence_prefix, sequence_number are not needed any more
     # -> compute=False to improve perf
     highest_name = fields.Char(compute=False)
     sequence_prefix = fields.Char(compute=False)
     sequence_number = fields.Integer(compute=False)
+    # made_sequence_hole is not relevant anymore (since based on sequence_prefix/number)
+    # -> compute=False to improve perf and to avoid displaying warning
+    made_sequence_hole = fields.Boolean(compute=False)
 
     _sql_constraints = [
         (


### PR DESCRIPTION
Easy solution for #1614 by not computing related fields anymore thus warnings are not raised anymore for false gaps in sequence.

Still I guess we could find a way to preserve functionality to check if gap in sequence but cannot figure out how !