### PR TITLE
[FIX] account_move_name_sequence: avoid fallback on odoo sequence name

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -59,3 +59,10 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         self.flush()
         return super()._post(soft=soft)
+
+    def _compute_name(self):
+        """Overwrite account module method in order to
+        avoid side effect if legacy code call it directly
+        like when creating entry from email.
+        """
+        return self._compute_name_by_sequence()

--- a/account_move_name_sequence/tests/__init__.py
+++ b/account_move_name_sequence/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_account_move_name_seq
 from . import test_sequence_concurrency
+from . import test_account_incoming_supplier_invoice

--- a/account_move_name_sequence/tests/test_account_incoming_supplier_invoice.py
+++ b/account_move_name_sequence/tests/test_account_incoming_supplier_invoice.py
@@ -1,0 +1,87 @@
+import json
+
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
+    """Testing creating account move fetching mail.alias"""
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.env["ir.config_parameter"].sudo().set_param(
+            "mail.catchall.domain", "test-company.odoo.com"
+        )
+
+        cls.internal_user = cls.env["res.users"].create(
+            {
+                "name": "Internal User",
+                "login": "internal.user@test.odoo.com",
+                "email": "internal.user@test.odoo.com",
+            }
+        )
+
+        cls.supplier_partner = cls.env["res.partner"].create(
+            {
+                "name": "Your Supplier",
+                "email": "supplier@other.company.com",
+                "supplier_rank": 10,
+            }
+        )
+
+        cls.journal = cls.company_data["default_journal_purchase"]
+
+        journal_alias = cls.env["mail.alias"].create(
+            {
+                "alias_name": "test-bill",
+                "alias_model_id": cls.env.ref("account.model_account_move").id,
+                "alias_defaults": json.dumps(
+                    {
+                        "move_type": "in_invoice",
+                        "company_id": cls.env.user.company_id.id,
+                        "journal_id": cls.journal.id,
+                    }
+                ),
+            }
+        )
+        cls.journal.write({"alias_id": journal_alias.id})
+
+    def test_supplier_invoice_mailed_from_supplier(self):
+        """this test is mainly inspired from
+        addons.account.tests.test_account_incoming_supplier_invoice
+        python module but we make sure account move is draft without
+        name
+        """
+        message_parsed = {
+            "message_id": "message-id-dead-beef",
+            "subject": "Incoming bill",
+            "from": "%s <%s>"
+            % (self.supplier_partner.name, self.supplier_partner.email),
+            "to": "%s@%s"
+            % (self.journal.alias_id.alias_name, self.journal.alias_id.alias_domain),
+            "body": "You know, that thing that you bought.",
+            "attachments": [b"Hello, invoice"],
+        }
+
+        invoice = self.env["account.move"].message_new(
+            message_parsed, {"move_type": "in_invoice", "journal_id": self.journal.id}
+        )
+
+        message_ids = invoice.message_ids
+        self.assertEqual(
+            len(message_ids), 1, "Only one message should be posted in the chatter"
+        )
+        self.assertEqual(
+            message_ids.body,
+            "<p>Vendor Bill Created</p>",
+            "Only the invoice creation should be posted",
+        )
+
+        following_partners = invoice.message_follower_ids.mapped("partner_id")
+        self.assertEqual(following_partners, self.env.user.partner_id)
+        self.assertEqual(invoice.state, "draft")
+        self.assertEqual(invoice.name, "/")


### PR DESCRIPTION
In case an alias is configured to fecth email to generate account entries. the new_message method directly call the _compute_name on account move which call the legacy code provide by account odoo module which should be avoid here.

To reproduce:

* configure an alias on your purchase journal
* send an email to that alias
* the invoice is draft with a number

to mitigate this behavior the suggested patch overwritte the former method '_compute_name' and call the new implemented method '_compute_name_by_sequence'.