### PR TITLE
[14.0][FIX] *: remove `python-dateutil` and `freezegun` from depends

### DIFF
--- a/account_asset_management/__manifest__.py
+++ b/account_asset_management/__manifest__.py
@@ -10,7 +10,6 @@
     "depends": ["account", "report_xlsx_helper"],
     "excludes": ["account_asset"],
     "development_status": "Mature",
-    "external_dependencies": {"python": ["python-dateutil"]},
     "author": "Noviat, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-financial-tools",
     "category": "Accounting & Finance",

--- a/account_journal_general_sequence/__manifest__.py
+++ b/account_journal_general_sequence/__manifest__.py
@@ -8,7 +8,6 @@
     "website": "https://github.com/OCA/account-financial-tools",
     "author": "Moduon, Odoo Community Association (OCA)",
     "license": "LGPL-3",
-    "external_dependencies": {"python": ["freezegun"]},
     "maintainers": ["yajo"],
     "depends": [
         "account",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # generated from manifests external_dependencies
-freezegun
 numpy-financial<=1.0.0
 numpy>=1.15
 vatnumber

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@
 freezegun
 numpy-financial<=1.0.0
 numpy>=1.15
-python-dateutil
 vatnumber


### PR DESCRIPTION
Regarding `python-dateutil`, such dependency is already included in Odoo requirements using a pinned
version [1]. Adding here could cause to upgrade the library to an
incompatible version.

Regarding `freezegun`, starting from v14, the library is installed by native Odoo's
requirements.txt [2]. Even if it were not, the library is only used in
tests, hence should not be installed in production environments.

[1] https://github.com/odoo/odoo/blob/1a264d7d9093/requirements.txt#L45
[2] https://github.com/odoo/odoo/blob/1a264d7d9093/requirements.txt#L7