### PR TITLE
[FIX] account_journal_general_sequence: avoid renaming bottleneck

### DIFF
--- a/account_journal_general_sequence/wizards/account_move_renumber_wizard.py
+++ b/account_journal_general_sequence/wizards/account_move_renumber_wizard.py
@@ -78,6 +78,7 @@ class AccountMoveRenumberWizard(models.TransientModel):
         current_range.sudo().number_next = self.starting_number
         self.sequence_id.sudo().number_next = self.starting_number
         # Renumber the moves
+        moves = moves.with_context(skip_invoice_sync=True)
         moves.entry_number = False
         moves.flush_recordset(["entry_number"])
         moves._compute_entry_number()


### PR DESCRIPTION
When renumbering the moves, a lot of recomputes were executed, specially after Yeeeeaah was merged (a.k.a. https://github.com/odoo/odoo/pull/96134).

None of those recomputes is needed. The entry number we're adding here has no impact on taxes, invoices, or anything related. We can just skip all that stuff and make renumbering actually be able to finish in less than 100 years.

@moduon MT-2806