### PR TITLE
[FIX] account_usability: broken account.tax.group search

### DIFF
--- a/account_usability/views/view_account_tax_group.xml
+++ b/account_usability/views/view_account_tax_group.xml
@@ -36,11 +36,7 @@
         <field name="model">account.tax.group</field>
         <field name="arch" type="xml">
             <search string="Account Tax Groups">
-                <field
-                    name="name"
-                    filter_domain="['|', ('sequence', '=like', str(self) + '%'), ('name', 'ilike', self)]"
-                    string="Account Tax Group"
-                />
+                <field name="name" />
             </search>
         </field>
     </record>


### PR DESCRIPTION
Before this patch, when going to `account.tax.group` search and searching for "7", we got this exception:

```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 368, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 357, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 919, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1284, in search_read
    return self.do_search_read(model, fields, offset, limit, domain, sort)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1303, in do_search_read
    return Model.web_search_read(domain, fields, offset=offset, limit=limit, order=sort)
  File "/opt/odoo/auto/addons/web/models/models.py", line 62, in web_search_read
    records = self.search_read(domain, fields, offset=offset, limit=limit, order=order)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5044, in search_read
    records = self.search(domain or [], offset=offset, limit=limit, order=order)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1810, in search
    res = self._search(args, offset=offset, limit=limit, order=order, count=count)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4711, in _search
    query = self._where_calc(args)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4467, in _where_calc
    return expression.expression(domain, self).query
  File "/opt/odoo/custom/src/odoo/odoo/osv/expression.py", line 442, in __init__
    self.parse()
  File "/opt/odoo/custom/src/odoo/odoo/osv/expression.py", line 957, in parse
    expr, params = self.__leaf_to_sql(leaf, model, alias)
  File "/opt/odoo/auto/addons/base_search_fuzzy/hooks.py", line 22, in _wrapper
    return original(self, leaf, model, alias)
  File "/opt/odoo/custom/src/odoo/odoo/osv/expression.py", line 1081, in __leaf_to_sql
    params = [field.convert_to_column(right, model, validate=False)]
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1329, in convert_to_column
    return int(value or 0)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: invalid literal for int() with base 10: '7%'
```

The same happened with any other value.

@moduon MT-2875