### PR TITLE
[16.0][FIX] account_asset_management: create refund invoices with assets

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -84,8 +84,8 @@ class AccountMove(models.Model):
             "date_start": self.date,
         }
 
-    def action_post(self):
-        ret_val = super().action_post()
+    def _post(self, soft=True):
+        ret_val = super()._post(soft=soft)
         for move in self:
             for aml in move.line_ids.filtered(
                 lambda line: line.asset_profile_id and not line.tax_line_id
@@ -180,6 +180,7 @@ class AccountMoveLine(models.Model):
         string="Asset",
         ondelete="restrict",
         check_company=True,
+        copy=False,
     )
 
     @api.depends("account_id", "asset_id")


### PR DESCRIPTION
Previous to this fix, the functionality was working when an invoice was posted when called from action_post. But in cases as reversals action_post is not used for posting the reversal invoice, _post function is used directly.

To solve the issue, the functionality is moved from action_post to _post, to ensure it's being executed in all invoice post scenarios.