### PR TITLE
[15.0][FIX] account_asset_management: Allow to write on moves with no asset permission

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -60,8 +60,10 @@ class AccountMove(models.Model):
 
     def write(self, vals):
         if set(vals).intersection(FIELDS_AFFECTS_ASSET_MOVE):
-            deprs = self.env["account.asset.line"].search(
-                [("move_id", "in", self.ids), ("type", "=", "depreciate")]
+            deprs = (
+                self.env["account.asset.line"]
+                .sudo()
+                .search([("move_id", "in", self.ids), ("type", "=", "depreciate")])
             )
             if deprs:
                 raise UserError(


### PR DESCRIPTION
- first commit forward from https://github.com/OCA/account-financial-tools/pull/1436


- ~~last commit fix permission when we add other permission (example: purchase user) in `account_asset_management.view_move_form` view~~
![Selection_004](https://github.com/OCA/account-financial-tools/assets/20896369/713c4882-b09e-4577-b011-f5842c628c18)

~~Purchase User can't see bills. it will error~~
