### PR TITLE
[FIX] account_journal_general_sequence: unique entry number per journal

### DIFF
--- a/account_journal_general_sequence/i18n/account_journal_general_sequence.pot
+++ b/account_journal_general_sequence/i18n/account_journal_general_sequence.pot
@@ -73,7 +73,7 @@ msgstr ""
 
 #. module: account_journal_general_sequence
 #: model:ir.model.constraint,message:account_journal_general_sequence.constraint_account_move_entry_number_unique
-msgid "Entry number must be unique per company."
+msgid "Entry number must be unique per journal."
 msgstr ""
 
 #. module: account_journal_general_sequence

--- a/account_journal_general_sequence/i18n/es.po
+++ b/account_journal_general_sequence/i18n/es.po
@@ -79,8 +79,8 @@ msgstr "Número de asiento"
 
 #. module: account_journal_general_sequence
 #: model:ir.model.constraint,message:account_journal_general_sequence.constraint_account_move_entry_number_unique
-msgid "Entry number must be unique per company."
-msgstr "El número de asiento debe ser único por compañía."
+msgid "Entry number must be unique per journal."
+msgstr "El número de asiento debe ser único por diario."
 
 #. module: account_journal_general_sequence
 #: model:ir.model.fields,field_description:account_journal_general_sequence.field_account_journal__id

--- a/account_journal_general_sequence/models/account_move.py
+++ b/account_journal_general_sequence/models/account_move.py
@@ -15,8 +15,8 @@ class AccountMove(models.Model):
     _sql_constraints = [
         (
             "entry_number_unique",
-            "UNIQUE(entry_number, company_id)",
-            "Entry number must be unique per company.",
+            "UNIQUE(entry_number, journal_id)",
+            "Entry number must be unique per journal.",
         ),
     ]
 


### PR DESCRIPTION
The sequence is applied per journal. Thus, we can't require one number per company, but per journal.

bwports: https://github.com/OCA/account-financial-tools/pull/1672 https://github.com/OCA/account-financial-tools/pull/1673

@moduon MT-3082