### PR TITLE
[16.0][FIX] account_asset_management: Allow to write on moves with no asset permission

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -59,8 +59,10 @@ class AccountMove(models.Model):
 
     def write(self, vals):
         if set(vals).intersection(FIELDS_AFFECTS_ASSET_MOVE):
-            deprs = self.env["account.asset.line"].search(
-                [("move_id", "in", self.ids), ("type", "=", "depreciate")]
+            deprs = (
+                self.env["account.asset.line"]
+                .sudo()
+                .search([("move_id", "in", self.ids), ("type", "=", "depreciate")])
             )
             if deprs:
                 raise UserError(


### PR DESCRIPTION
Forward from https://github.com/OCA/account-financial-tools/pull/1670