### PR TITLE
[FIX] account_journal_general_sequence: optimize recomputes when renumbering

### DIFF
--- a/account_journal_general_sequence/tests/test_numbering.py
+++ b/account_journal_general_sequence/tests/test_numbering.py
@@ -42,12 +42,15 @@ class RenumberCase(TestAccountReconciliationCommon):
         next_year_invoice = self._create_invoice(
             date_invoice="2023-12-31", auto_validate=True
         )
+        next_year_invoice.flush(["entry_number"], next_year_invoice)
         new_invoice = self._create_invoice(
             date_invoice="2022-05-10", auto_validate=True
         )
+        new_invoice.flush(["entry_number"], new_invoice)
         old_invoice = self._create_invoice(
             date_invoice="2022-04-30", auto_validate=True
         )
+        old_invoice.flush(["entry_number"], old_invoice)
         self.assertLess(new_invoice.entry_number, old_invoice.entry_number)
         # Fix entry number order with wizard; default values are OK
         wiz_f = Form(self.env["account.move.renumber.wizard"])


### PR DESCRIPTION

When calling `_next()` in a sequence, it issues calls to `search()`, especially if it is a no-gap or date-range-based sequence (which is common in this use case).

When doing a search, Odoo triggers recomputations. Thus, when doing both a write and a call to `_next()` in the same loop, Odoo had to flush to DB too often, causing a bottleneck.

Now, the process is more optimized:
1. Cache all new entry numbers.
2. Write them all.
3. Mark them all as modified at once, to batch-trigger recomputations.

To reduce the amount of recomputations, tracking is disabled for the entry number. After all, before renumbering there's already a warning telling you that you shouldn't renumber if you already published those entry numbers to your fiscal authority.

Another pseudo-improvement is that the info log is shorter. Enable debug logging to log the list of IDs changed.

A test was failing because it was relying on the fact that computations were not getting as lazy as they should. Manual flushes are added to imitate a user doing different invoice creations.

@moduon MT-3082 bw-port-of https://github.com/OCA/account-financial-tools/pull/1675