### PR TITLE
[14.0][IMP] account_asset_management: add asset_profile_id and asset_id on invoice_lines form

### DIFF
--- a/account_asset_management/views/account_move.xml
+++ b/account_asset_management/views/account_move.xml
@@ -39,6 +39,20 @@
                 />
             </xpath>
             <xpath
+                expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='quantity']"
+                position="before"
+            >
+                <field
+                    name="asset_profile_id"
+                    attrs="{'column_invisible': [('parent.move_type', 'not in', ('in_invoice', 'in_refund'))]}"
+                />
+                <field
+                    name="asset_id"
+                    attrs="{'column_invisible': [('parent.move_type', 'not in', ('out_invoice', 'out_refund'))]}"
+                    groups="account.group_account_manager"
+                />
+            </xpath>
+            <xpath
                 expr="//notebook//field[@name='line_ids']/tree/field[@name='date_maturity']"
                 position="after"
             >


### PR DESCRIPTION
In this case, this implementation is necessary mainly for situations where the inclusion of invoice lines is not done through the tree view, but rather through the form view (as is the case with the Brazilian localization, l10n-brazil).

cc @douglascstd @rvalyi @antoniospneto @renatonlima 