### PR TITLE
[16.0][FIX] account_asset_management: pass for context correct active_id.

### DIFF
--- a/account_asset_management/wizard/wiz_asset_move_reverse.py
+++ b/account_asset_management/wizard/wiz_asset_move_reverse.py
@@ -40,7 +40,9 @@ class WizAssetMoveReverse(models.TransientModel):
         move = self.line_id.move_id
         move_reversal = (
             self.env["account.move.reversal"]
-            .with_context(active_model="account.move", active_ids=move.ids)
+            .with_context(
+                active_model="account.move", active_ids=move.ids, active_id=move.id
+            )
             .create(
                 {
                     "date": fields.Date.today(),


### PR DESCRIPTION
If not specified the value of active_id will be that of account.asset.line.