### PR TITLE
[FIX] account_document_reversal: reversal from bank statement lines was not working correctly

### DIFF
--- a/account_document_reversal/models/account_payment.py
+++ b/account_document_reversal/models/account_payment.py
@@ -26,12 +26,11 @@ class AccountPayment(models.Model):
     def action_document_reversal(self, date=None, journal_id=None):
         """ Reverse all moves related to this payment + set state to cancel """
         # Check document readiness
-        valid_state = (
-            len(self.mapped("state")) == 1
-            and list(set(self.mapped("state")))[0] == "posted"
-        )
-        if not valid_state:
-            raise UserError(_("Only validated document can be cancelled (reversal)"))
+        for payment in self:
+            if payment.state not in ["sent", "posted"]:
+                raise UserError(
+                    _("Only validated document can be cancelled (reversal)")
+                )
         # Find moves to get reversed
         move_lines = self.mapped("move_line_ids").filtered(
             lambda x: x.journal_id == self.mapped("journal_id")[0]

--- a/account_document_reversal/tests/test_payment_reversal.py
+++ b/account_document_reversal/tests/test_payment_reversal.py
@@ -298,6 +298,7 @@ class TestPaymentReversal(SavepointCase):
         self.assertTrue(move_reconcile)
         self.assertTrue(reversed_move_reconcile)
         self.assertEqual(move_reconcile, reversed_move_reconcile)
+        self.assertFalse(bank_stmt_line.journal_entry_ids)
 
     def test_bank_statement_cancel_reversal_02(self):
         """ Tests that I can create a bank statement line and reconcile it
@@ -358,6 +359,7 @@ class TestPaymentReversal(SavepointCase):
         self.assertTrue(move_reconcile)
         self.assertTrue(reversed_move_reconcile)
         self.assertEqual(move_reconcile, reversed_move_reconcile)
+        self.assertFalse(bank_stmt_line.journal_entry_ids)
 
     def test_bank_statement_cancel_exception(self):
         """ Tests on exception case, if statement is already validated, but


### PR DESCRIPTION
When pressing the button to unreconcile the bank statement line it would do the cancel of the payment, but would still keep the statement line in gray (not being able to reconcile again), because the link between the statement line and the account moves was maintained.

