### PR TITLE
[15.0][FIX] account_chart_update: do not repartion in groups + do append False IDS

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -398,7 +398,9 @@ class WizardUpdateChartsAccounts(models.TransientModel):
     def find_taxes_by_templates(self, templates):
         tax_ids = []
         for tax in templates:
-            tax_ids.append(self.find_tax_by_templates(tax))
+            tax_id = self.find_tax_by_templates(tax)
+            if tax_id:
+                tax_ids.append(tax_id)
         return self.env["account.tax"].browse(tax_ids)
 
     @tools.ormcache("templates")
@@ -498,9 +500,10 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                     )
                 )
 
-        # Mark to be removed the lines not found
-        remove_ids = [x for x in current_repartition.ids if x not in existing_ids]
-        result += [(2, x) for x in remove_ids]
+        if tax.amount_type != "group":
+            # Mark to be removed the lines not found
+            remove_ids = [x for x in current_repartition.ids if x not in existing_ids]
+            result += [(2, x) for x in remove_ids]
         return result
 
     @api.model


### PR DESCRIPTION
1) In tax groups repartition lines are not used, however when creating tax groups from templates the default repartition lines are created. If you run the chart update again, it will detect those "useless" default repartition lines and mark them to removal, raising an error when trying to do so as a minial of 2 repartition lines are needed (on base and one tax).

2) When matching taxes, if not match, do not add `False` to the list.

Forward port of https://github.com/OCA/account-financial-tools/pull/1376.