### PR TITLE
[13.0][IMP] account_document_reversal: Exclude cancelled payments from bank reconciliation

### DIFF
--- a/account_document_reversal/models/__init__.py
+++ b/account_document_reversal/models/__init__.py
@@ -1,5 +1,3 @@
-# Copyright 2019 Ecosoft Co., Ltd (http://ecosoft.co.th/)
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 from . import account
 from . import account_document_reversal
 from . import account_payment
@@ -7,3 +5,4 @@ from . import account_bank_statement
 from . import account_move
 from . import sale
 from . import purchase
+from . import reconciliation_widget

--- a/account_document_reversal/models/account_bank_statement.py
+++ b/account_document_reversal/models/account_bank_statement.py
@@ -39,4 +39,5 @@ class AccountPayment(models.Model):
         for payment in payments_to_revert:
             payment.unreconcile()
             payment.action_document_reversal(date=date, journal_id=journal_id)
+        self.write({"move_name": False})
         return True

--- a/account_document_reversal/models/reconciliation_widget.py
+++ b/account_document_reversal/models/reconciliation_widget.py
@@ -1,0 +1,61 @@
+# Copyright 2023 ForgeFlow, S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class AccountReconciliation(models.AbstractModel):
+    _inherit = "account.reconciliation.widget"
+
+    def _search_domain_payment_reconciliation_to_remove(self, domain):
+        start_index = domain.index(("statement_line_id", "=", False))
+        end_index = domain.index(("balance", "!=", 0.0)) + 1
+        return start_index, end_index
+
+    @api.model
+    def _domain_move_lines_for_reconciliation(
+        self,
+        st_line,
+        aml_accounts,
+        partner_id,
+        excluded_ids=None,
+        search_str=False,
+        mode="rp",
+    ):
+        domain = super()._domain_move_lines_for_reconciliation(
+            st_line,
+            aml_accounts,
+            partner_id,
+            excluded_ids=excluded_ids,
+            search_str=search_str,
+            mode=mode,
+        )
+        aml_accounts = [
+            st_line.journal_id.default_credit_account_id.id,
+            st_line.journal_id.default_debit_account_id.id,
+        ]
+        try:
+            (
+                start_index,
+                end_index,
+            ) = self._search_domain_payment_reconciliation_to_remove(domain)
+        except ValueError as e:
+            raise ValidationError(
+                _(
+                    "Could not implement the restriction to remove "
+                    "reversed payments: %s"
+                )
+                % str(e)
+            )
+
+        domain_reconciliation_to_add = [
+            "&",
+            ("statement_line_id", "=", False),
+            ("account_id", "in", aml_accounts),
+            ("payment_id", "<>", False),
+            ("balance", "!=", 0.0),
+            ("payment_id.state", "!=", "cancelled"),
+        ]
+        if start_index and end_index:
+            domain[start_index:end_index] = domain_reconciliation_to_add
+        return domain


### PR DESCRIPTION
Otherwise they will always appear, and they should never be considered.

cc @JaumeBforgeFlow 