### PR TITLE
[16.0][FIX][account_chart_update] Remove account tax browsing since already a recordset

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -1079,7 +1079,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         when the referenced accounts are still not available).
         """
         done = self.env["account.tax"]
-        for k, v in todo_dict["account_dict"]["account.tax"].items():
+        for tax, v in todo_dict["account_dict"]["account.tax"].items():
             vals = {}
             for fld in [
                 "cash_basis_transition_account_id",
@@ -1096,7 +1096,6 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                             % v[fld].id
                         )
             if vals:
-                tax = self.env["account.tax"].browse(k)
                 tax.write(vals)
                 done |= tax
 


### PR DESCRIPTION
`todo_dict["account_dict"]["account.tax"].keys()` are already records, not just ID, so we can use them directly. 
Trying to browse causes an error : `psycopg2.ProgrammingError: can't adapt type 'account.tax'`.

The issue I had was when trying to create the chart of account for a french company : when clicking on create/update button, I had a traceback saying : 
```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/odoo/src/odoo/api.py", line 983, in get
    cache_value = field_cache[record._ids[0]]
KeyError: account.tax(4180,)During handling of the above exception, another exception occurred:Traceback (most recent call last):
  File "/odoo/src/odoo/fields.py", line 1139, in __get__
    value = env.cache.get(record, self)
  File "/odoo/src/odoo/api.py", line 990, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'account.tax(account.tax(4180,),).company_id'During handling of the above exception, another exception occurred:Traceback (most recent call last):
  File "/odoo/src/odoo/http.py", line 1583, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/odoo/src/odoo/service/model.py", line 134, in retrying
    result = func()
  File "/odoo/src/odoo/http.py", line 1612, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/odoo/src/odoo/http.py", line 1810, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/odoo/external-src/odoo-cloud-platform/monitoring_prometheus/models/ir_http.py", line 38, in _dispatch
    res = super()._dispatch(endpoint)
  File "/odoo/src/odoo/addons/base/models/ir_http.py", line 149, in _dispatch
    result = endpoint(**request.params)
  File "/odoo/src/odoo/http.py", line 698, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/odoo/src/addons/web/controllers/dataset.py", line 46, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/odoo/src/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/odoo/src/odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/odoo/src/odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/odoo/local-src/rs_account_chart_update/wizard/wizard_chart_update.py", line 99, in action_update_records
    super().action_update_records()
  File "/odoo/external-src/account-financial-tools/account_chart_update/wizard/wizard_chart_update.py", line 376, in action_update_records
    self._update_taxes_pending_for_accounts(todo_dict)
  File "/odoo/external-src/account-financial-tools/account_chart_update/wizard/wizard_chart_update.py", line 1097, in _update_taxes_pending_for_accounts
    tax.write(vals)
  File "/odoo/src/odoo/models.py", line 3638, in write
    self.check_access_rule('write')
  File "/odoo/src/odoo/models.py", line 3436, in check_access_rule
    invalid = self - self._filter_access_rules_python(operation)
  File "/odoo/src/odoo/models.py", line 3491, in _filter_access_rules_python
    return self.sudo().filtered_domain(dom or [])
  File "/odoo/src/odoo/models.py", line 5425, in filtered_domain
    data = record.mapped(key)
  File "/odoo/src/odoo/models.py", line 5345, in mapped
    recs = recs._fields[name].mapped(recs)
  File "/odoo/src/odoo/fields.py", line 1258, in mapped
    self.__get__(first(remaining), type(remaining))
  File "/odoo/src/odoo/fields.py", line 2791, in __get__
    return super().__get__(records, owner)
  File "/odoo/src/odoo/fields.py", line 1165, in __get__
    recs._fetch_field(self)
  File "/odoo/src/odoo/models.py", line 3152, in _fetch_field
    self._read(fnames)
  File "/odoo/src/odoo/models.py", line 3229, in _read
    cr.execute(query_str, params + [sub_ids])
  File "/odoo/src/odoo/sql_db.py", line 310, in execute
    _logger.debug("query: %s", self._format(query, params))
  File "/odoo/src/odoo/sql_db.py", line 302, in _format
    return self._obj.mogrify(query, params).decode(encoding, 'replace')
  File "/usr/local/lib/python3.9/dist-packages/psycopg2/extensions.py", line 113, in getquoted
    pobjs = [adapt(o) for o in self._seq]
  File "/usr/local/lib/python3.9/dist-packages/psycopg2/extensions.py", line 113, in <listcomp>
    pobjs = [adapt(o) for o in self._seq]
psycopg2.ProgrammingError: can't adapt type 'account.tax'The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPCError@https://integration.reservoirsun.odoo.camptocamp.fr/web/assets/18856-3a1e3c8/web.assets_backend.min.js:970:274
    makeErrorFromResponse@https://integration.reservoirsun.odoo.camptocamp.fr/web/assets/18856-3a1e3c8/web.assets_backend.min.js:974:163
    jsonrpc/promise</<@https://integration.reservoirsun.odoo.camptocamp.fr/web/assets/18856-3a1e3c8/web.assets_backend.min.js:981:34 
```

This is due to the fact that the keys of the dict `todo_dict["account_dict"]["account.tax"]`, are not integers representing the ids of the account.tax records, but entire account.tax records. 
Thus, the line  `tax = self.env["account.tax"].browse(k)` was resulting with `tax = account.tax(account.tax(4180,),)` instead of `tax = account.tax(4180,)`, and the `write` was failing. Removing the `browse`, since we already have the record, solves the issue.