### PR TITLE
[16.0][FIX+IMP] account_chart_update: Don't depend on l10n_generic_coa + TransactionCase

### DIFF
--- a/account_chart_update/__manifest__.py
+++ b/account_chart_update/__manifest__.py
@@ -10,7 +10,7 @@
     "version": "16.0.2.0.1",
     "author": "Tecnativa, BCIM, Okia, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-financial-tools",
-    "depends": ["account", "l10n_generic_coa"],
+    "depends": ["account"],
     "category": "Accounting",
     "license": "AGPL-3",
     "data": [


### PR DESCRIPTION
Forward-port of #1713 

- Depending on l10n_generic_coa is the lazy option for not putting proper initialization data on the test, and it also couples the tests to the external module changes.
- Switch to TransactionCase, for populating once the company, CoA, etc.
- Speed up a bit the tests, removing superflual mail operations.

@Tecnativa 