### PR TITLE
[15.0][IMP] base_vat_optional_vies: vies sync in children contact

### DIFF
--- a/base_vat_optional_vies/__manifest__.py
+++ b/base_vat_optional_vies/__manifest__.py
@@ -3,13 +3,17 @@
 # Copyright 2017 Tecnativa - David Vidal
 # Copyright 2019 FactorLibre - Rodrigo Bonilla
 # Copyright 2022 Moduon - Eduardo de Miguel
+# Copyright 2023 Moduon - Emilio Pascual
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Optional validation of VAT via VIES",
     "category": "Accounting",
     "version": "15.0.1.0.3",
     "depends": ["base_vat"],
-    "data": ["views/res_partner_view.xml"],
+    "data": [
+        "views/res_partner_view.xml",
+        "views/res_config_settings_view.xml",
+    ],
     "author": "Tecnativa," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-financial-tools",
     "license": "AGPL-3",

--- a/base_vat_optional_vies/models/__init__.py
+++ b/base_vat_optional_vies/models/__init__.py
@@ -1,1 +1,2 @@
 from . import res_partner
+from . import res_config_settings

--- a/base_vat_optional_vies/models/res_config_settings.py
+++ b/base_vat_optional_vies/models/res_config_settings.py
@@ -1,0 +1,23 @@
+# Copyright 2022-2023 Moduon Team S.L. <info@moduon.team>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    def execute_update_check_vies(self):
+        # Only parent partners, children are synced from parent
+        count_partners = self.env["res.partner"].search_count(
+            [("parent_id", "=", False)]
+        )
+        self.env["res.partner"].search([("parent_id", "=", False)]).check_vat()
+        return {
+            "effect": {
+                "fadeout": "slow",
+                "message": _("Vies passed calculated in %s partners") % count_partners,
+                "img_url": "/web/static/src/img/smile.svg",
+                "type": "rainbow_man",
+            }
+        }

--- a/base_vat_optional_vies/models/res_partner.py
+++ b/base_vat_optional_vies/models/res_partner.py
@@ -2,6 +2,7 @@
 # Copyright 2017 Tecnativa - David Vidal
 # Copyright 2019 FactorLibre - Rodrigo Bonilla
 # Copyright 2022 Moduon - Eduardo de Miguel
+# Copyright 2023 Moduon - Emilio Pascual
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo import _, api, fields, models
 
@@ -21,7 +22,7 @@ class ResPartner(models.Model):
         )
         partner = self.env.context.get("vat_partner")
         if partner:
-            partner.update({"vies_passed": False})
+            partner.update({"vies_passed": self.parent_id.vies_passed or False})
         return res
 
     @api.model

--- a/base_vat_optional_vies/readme/CONTRIBUTORS.rst
+++ b/base_vat_optional_vies/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
 * Alexandre Díaz <alexandre.diaz@tecnativa.com>
 * Harald Panten <harald.panten@sygel.es>
 * Eduardo de Miguel <edu@moduon.team>
+* Emilio Pascual <emilio@moduon.team>

--- a/base_vat_optional_vies/tests/tes_config_settings.py
+++ b/base_vat_optional_vies/tests/tes_config_settings.py
@@ -1,0 +1,44 @@
+# Copyright 2022-2023 Moduon Team S.L. <info@moduon.team>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from unittest import mock
+
+from odoo.tests import common
+
+
+class TestConfigSettings(common.TransactionCase):
+    def setUp(self):
+        super(TestConfigSettings, self).setUp()
+        self.company = self.env.user.company_id
+        self.partner1_test = self.env["res.partner"].create(
+            {
+                "name": "Test partner",
+                "is_company": True,
+                "vat": "ESB87530432",
+                "country_id": self.env.ref("base.be").id,
+            }
+        )
+        self.partner2_test = self.env["res.partner"].create(
+            {
+                "name": "Test partner2",
+                "is_company": True,
+                "vat": "ESB87530432",
+            }
+        )
+        self.vatnumber_path = "odoo.addons.base_vat.models.res_partner.check_vies"
+
+    def test_execute_update_check_vies_validate(self):
+        with mock.patch(self.vatnumber_path) as mock_vatnumber:
+            self.company.vat_check_vies = True
+            mock_vatnumber.check_vies.return_value = True
+            self.env["res.config.settings"].execute_update_check_vies()
+            self.assertTrue(self.partner1_test.vies_passed)
+            self.assertFalse(self.partner2_test.vies_passed)
+
+    def test_execute_update_check_vies_no_validate(self):
+        with mock.patch(self.vatnumber_path) as mock_vatnumber:
+            self.company.vat_check_vies = False
+            mock_vatnumber.check_vies.return_value = False
+            self.env["res.config.settings"].execute_update_check_vies()
+            self.assertFalse(self.partner1_test.vies_passed)
+            self.assertFalse(self.partner2_test.vies_passed)

--- a/base_vat_optional_vies/tests/test_res_partner.py
+++ b/base_vat_optional_vies/tests/test_res_partner.py
@@ -4,7 +4,7 @@
 # Copyright 2022 Moduon - Eduardo de Miguel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-import mock
+from unittest import mock
 
 from odoo.exceptions import ValidationError
 from odoo.tests import common
@@ -17,6 +17,9 @@ class TestResPartner(common.TransactionCase):
         self.company.vat_check_vies = True
         self.partner = self.env["res.partner"].create(
             {"name": "Test partner", "is_company": True}
+        )
+        self.partner_child = self.env["res.partner"].create(
+            {"name": "Test partner child", "parent_id": self.partner.id}
         )
         self.vatnumber_path = "odoo.addons.base_vat.models.res_partner.check_vies"
 
@@ -59,3 +62,12 @@ class TestResPartner(common.TransactionCase):
     def test_validate_wrong_vat_shows_simple_message(self):
         with self.assertRaisesRegex(ValidationError, "does not seem to be valid"):
             self.partner.vat = "ES11111111A"
+
+    def test_sync_vies_passed_parent_with_child(self):
+        with mock.patch(self.vatnumber_path) as mock_vatnumber:
+            mock_vatnumber.check_vies.return_value = True
+            self.partner.vat = "ESB87530432"
+            self.partner.country_id = self.env.ref("base.be")
+            self.assertEqual(self.partner.vies_passed, self.partner_child.vies_passed)
+            self.partner.vat = False
+            self.assertEqual(self.partner.vies_passed, self.partner_child.vies_passed)

--- a/base_vat_optional_vies/views/res_config_settings_view.xml
+++ b/base_vat_optional_vies/views/res_config_settings_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Moduon Team S.L.
+     License Other proprietary
+ -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.account</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_vat.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//div[@id='vies_service_setting']/div[hasclass('o_setting_right_pane')]"
+                position="inside"
+            >
+                <button
+                    type="object"
+                    name="execute_update_check_vies"
+                    string="Compute check vies"
+                    class="oe_link"
+                    icon="fa-arrow-right"
+                    confirm="This process can take a long time. Are you sure you want to start the process?"
+                    attrs="{'invisible': [('vat_check_vies', '=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Sync field vies_passed from parent partner to children contact.
- Wizard in settings to update vies_passed field after activate check vies.

@moduon MT-1044 @rafaelbn @fcvalgar please review

https://www.loom.com/share/797fbfd505cd4bba9d4ef8e3119226ea?sid=9e699662-2ee5-443e-a3f8-64baaf7d6195