### PR TITLE
[16.0][FIX] account_move_name_sequence: do not create duplicated sequences

### DIFF
--- a/account_move_name_sequence/models/account_journal.py
+++ b/account_move_name_sequence/models/account_journal.py
@@ -101,6 +101,10 @@ class AccountJournal(models.Model):
     @api.model
     def _create_sequence(self, vals, refund=False):
         seq_vals = self._prepare_sequence(vals, refund=refund)
+        domain = [(key, "=", value) for key, value in seq_vals.items()]
+        existing = self.env["ir.sequence"].search(domain, limit=1)
+        if existing:
+            return existing
         return self.env["ir.sequence"].sudo().create(seq_vals)
 
     def _prepare_sequence_current_moves(self, refund=False):


### PR DESCRIPTION
When switching the chart of account for the company, the module `account_move_name_sequence` creates new sequences that were actually already created, so the end users has to deal with duplicated records when creating journals. This proposed fix prevents the module to create duplicated sequences.

