### PR TITLE
[14.0][FIX] account_sequence_option

### DIFF
--- a/account_sequence_option/models/account_move.py
+++ b/account_sequence_option/models/account_move.py
@@ -46,7 +46,7 @@ class AccountMove(models.Model):
                 if (
                     rec.create_date
                     and rec.state in ("draft", "cancel")
-                    and rec.name not in (False, "/")
+                    and rec.name in (False, "/")
                     and not rec.sequence_option
                 ):
                     rec.name = "/"


### PR DESCRIPTION
Wrong condition was causing the lost of the invoice number on invoices that had been already validated and number assigned previously and without sequence_option.