### PR TITLE
[14.0][FIX] account_move_line_sale_info: tests: _post -> action_post

### DIFF
--- a/account_move_line_sale_info/tests/test_account_move_line_sale_info.py
+++ b/account_move_line_sale_info/tests/test_account_move_line_sale_info.py
@@ -264,7 +264,7 @@ class TestAccountMoveLineSaleInfo(common.TransactionCase):
         picking.button_validate()
         sale._create_invoices()
         invoice = sale.invoice_ids[0]
-        invoice.post()
+        invoice._post()
         reversal_wizard = self.move_reversal_wiz(invoice)
         credit_note = self.env["account.move"].browse(
             reversal_wizard.reverse_moves()["res_id"]


### PR DESCRIPTION
Prevent this:
```
2023-10-10 10:20:22,046 871 WARNING odoo py.warnings: /__w/account-financial-tools/account-financial-tools/account_move_line_sale_info/tests/test_account_move_line_sale_info.py:267: DeprecationWarning: RedirectWarning method 'post()' is a deprecated alias to 'action_post()' or _post()
  invoice.post()
```

cc @ForgeFlow