### PR TITLE
[FIX] account_move_name_sequence: inverse name

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -54,6 +54,7 @@ class AccountMove(models.Model):
                 # which applies on ir.sequence.date_range selection AND prefix
                 name = seq.with_context(ir_sequence_date=move.date).next_by_id()
             move.name = name
+        self._inverse_name()
 
     # We must by-pass this constraint of sequence.mixin
     def _constrains_date_sequence(self):


### PR DESCRIPTION
The core compute function for the name is calling at the end the function self._inverse_name(),
which updates the payment_reference when required.
This code was currently missing, causing the payment_reference not being properly computed,
for example, when using QR-Bills.