### PR TITLE
[15.0][FIX] Asset Report: Sort depreciate line by date and id

### DIFF
--- a/account_asset_management/report/account_asset_report_xls.py
+++ b/account_asset_management/report/account_asset_report_xls.py
@@ -504,7 +504,7 @@ class AssetReportXlsx(models.AbstractModel):
             dls_all = asset.depreciation_line_ids.filtered(
                 lambda r: r.type == "depreciate"
             )
-            dls_all = dls_all.sorted(key=lambda r: r.line_date)
+            dls_all = dls_all.sorted(key=lambda r: (r.line_date, r.id))
             if not dls_all:
                 error_dict["no_table"] += asset
             # period_start_value


### PR DESCRIPTION
if date is same in depreciation line, the report will calculate Period Start Value and Period End Value may be not correct
![image](https://github.com/OCA/account-financial-tools/assets/24691983/8623768c-ee58-4f80-ae21-e74f1dc7274e)

cc: @Nantikan23