### PR TITLE
[FIX] account_move_name_sequence: redefine _onchange_journal_id

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -77,3 +77,9 @@ class AccountMove(models.Model):
 
     def _get_last_sequence(self, relaxed=False, with_prefix=None, lock=True):
         return super()._get_last_sequence(relaxed, None, lock)
+
+    @api.onchange("journal_id")
+    def _onchange_journal_id(self):
+        if not self.quick_edit_mode:
+            self.name = "/"
+            self._compute_name_by_sequence()


### PR DESCRIPTION
In v16, _onchange_journal_id is defined to update name when journal_id is modified.
During the creation of new account.move, this onchange is triggered and called the standard _compute_name method

How to reproduce issue:
* Create new invoice => Name is defined instead of to be 'Draft'