### PR TITLE
[CHG][16.0] account_loan: modifications to work in multi-company context

### DIFF
--- a/account_loan/data/ir_sequence_data.xml
+++ b/account_loan/data/ir_sequence_data.xml
@@ -10,5 +10,6 @@
         <field name="code">account.loan</field>
         <field name="prefix">ACL</field>
         <field name="padding">6</field>
+        <field name="company_id" eval="False" />
     </record>
 </odoo>

--- a/account_loan/security/account_loan_security.xml
+++ b/account_loan/security/account_loan_security.xml
@@ -5,7 +5,7 @@
         <field ref="model_account_loan" name="model_id" />
         <field eval="True" name="global" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Some changes to be able to use account_loan in a mult-company context:

- [FIX] account_loan: use company_ids in ir.rule multi-company
    I think the user should be able to see only loans of company he has access to. For the moment, it is not possible to create a loan in a multi-company context.

- [CHG] account_loan: set company_id to false on sequence so sequence can be used in a multi-company context
    The sequence on loans will continue across the different companies. For the moment, the sequence is only set on in the main company and in other companies, no sequence is created.