### PR TITLE
Set the default date from and date to

### DIFF
--- a/account_asset_management/wizard/wiz_account_asset_report.xml
+++ b/account_asset_management/wizard/wiz_account_asset_report.xml
@@ -14,6 +14,7 @@
                     <field name="date_to" />
                     <field name="draft" />
                     <field name="company_id" groups="base.group_multi_company" />
+                    <field name="company_id" invisible="1" />
                 </group>
                 <footer>
           <button


### PR DESCRIPTION
Current Behavior:
When odoo only has 1 company and open Accounting -> Reporting -> Financial Assets -> Financial Assets Report.
Open the wizard, the Date from and Date to does not set as default.
![image](https://github.com/OCA/account-financial-tools/assets/19970138/61a3fb01-7401-4a77-ac06-9bfcba8a9b07)

Expected Behavior
When open Financial Assets Report wizard, the field Date From and Date To should be set by default from the current Company.

Note:
If there are multi company the date fields will be set as default.

 