### PR TITLE
[14.0][FIX] remove duplicated field in account_menu

### DIFF
--- a/account_menu/views/view_account_tag.xml
+++ b/account_menu/views/view_account_tag.xml
@@ -7,11 +7,6 @@
         <field name="arch" type="xml">
             <xpath expr="//group" position="after">
                 <group>
-                    <group id="applicability">
-                        <field name="applicability" widget="selection" />
-                    </group>
-                </group>
-                <group>
                     <group id="links">
                         <label
                             for="account_ids"


### PR DESCRIPTION
![Screenshot(185)](https://github.com/OCA/account-financial-tools/assets/7657311/51fdb44c-98f0-4516-a4e9-1eec3a0f69f9)
