### PR TITLE
[FIX] wizard_chart_update.py

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -1159,7 +1159,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             if wiz_account.type == "new":
                 # Create the account
                 tax_template_ref = {
-                    tax.id: self.find_tax_by_templates(tax) for tax in template.tax_ids
+                    tax: self.find_tax_by_templates(tax) for tax in template.tax_ids
                 }
                 vals = self.chart_template_id._get_account_vals(
                     self.company_id,


### PR DESCRIPTION
Here is the issue I get on my Odoo when I want to update my account chart from l10n_fr to l10n_fr_oca :

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1589, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1616, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 1820, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/auto/addons/website/models/ir_http.py", line 237, in _dispatch
    response = super()._dispatch(endpoint)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/auto/addons/web/controllers/dataset.py", line 46, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/account_chart_update/wizard/wizard_chart_update.py", line 421, in action_update_records
    self._update_accounts()
  File "/opt/odoo/auto/addons/account_chart_update/wizard/wizard_chart_update.py", line 1164, in _update_accounts
    vals = self.chart_template_id._get_account_vals(
  File "/opt/odoo/auto/addons/account/models/chart_template.py", line 959, in _get_account_vals
    tax_ids.append(tax_template_ref[tax].id)
KeyError: account.tax.template(70,)

After reading the source code, I found that in the called `_get_account_vals()` method in odoo/account/models/chart_template.py, at line 959 a tax record is given as key to the `tax_template_ref` dict for getting the corresponding value and not its id, which is currently used as key when the `tax_template_ref` dict is built in the `_update_accounts()` method of the wizard (updated line in this PR)...