### PR TITLE
[IMP]asset management: compensate deviation via last entry

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -738,9 +738,8 @@ class AccountAsset(models.Model):
                         line = table[table_i_start]["lines"][line_i_start]
                         line["days"] = 0
                         line["amount"] = amount_diff
-                    # compensate in first depreciation entry
-                    # after last posting
-                    line = table[table_i_start]["lines"][line_i_start]
+                    # compensate in last depreciation entry
+                    line = table[-1]["lines"][-1]
                     line["amount"] -= amount_diff
 
             else:  # no posted lines

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -383,7 +383,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
             )
 
     def test_04_prorata_init_cur_year(self):
-        """Prorata temporis depreciation with init value in curent year."""
+        """Prorata temporis depreciation with init value in current year."""
         asset = self.asset_model.create(
             {
                 "name": "test asset",
@@ -400,7 +400,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         self.dl_model.create(
             {
                 "asset_id": asset.id,
-                "amount": 279.44,
+                "amount": 269.44,
                 "line_date": time.strftime("%Y-11-30"),
                 "type": "depreciate",
                 "init_entry": True,
@@ -410,24 +410,16 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         asset.compute_depreciation_board()
         asset.invalidate_recordset()
         # check the depreciated value is the initial value
-        self.assertAlmostEqual(asset.value_depreciated, 279.44, places=2)
+        self.assertAlmostEqual(asset.value_depreciated, 269.44, places=2)
         # check computed values in the depreciation board
-        if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[2].amount, 44.75, places=2
-            )
-        else:
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[2].amount, 45.64, places=2
-            )
         self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55, places=2)
         if calendar.isleap(date.today().year):
             self.assertAlmostEqual(
-                asset.depreciation_line_ids[-1].amount, 9.11, places=2
+                asset.depreciation_line_ids[-1].amount, 8.31, places=2
             )
         else:
             self.assertAlmostEqual(
-                asset.depreciation_line_ids[-1].amount, 8.22, places=2
+                asset.depreciation_line_ids[-1].amount, 8.31, places=2
             )
 
     def test_05_degressive_linear(self):


### PR DESCRIPTION
account_asset_management, change logic to compensate deviation of posted entries.

Before this PR, deviations are corrected in the first period after posted/init entries.

This leads to rather strange situations illustrated by the following example:

Create an asset with
- purchase value 120 EUR
- start date 2022-12-01
- duration 1 year
- linear, prorata temporis
- monthly depreciation

Set lock date to 2022-12-31.
Intuitevely one would expect a depreciation table with 10 EUR/month depreciation. But the pro-rata temporis will calculate for period december 2022 : 31 / 365 * 120 = 10.19 EUR.

The user changes the INIT entry value to 10 EUR since his legacy system has calculated 10 EUR / month. This will probably be the case when the 'legacy' system is a spreadsheet. After recompute the compensation is calculated for 2023-01 and becomes 99.81 EUR.

After this PR, we continue with the monthly depreciation amount of 10 EUR and compensate in the last month (with also 10 EUR in the last month).
Result: clean depreciation table matching end user expectation.