### PR TITLE
[13.0] account_spread_cost_revenue: update migration major script

### DIFF
--- a/account_spread_cost_revenue/migrations/13.0.1.0.0/pre-migration.py
+++ b/account_spread_cost_revenue/migrations/13.0.1.0.0/pre-migration.py
@@ -1,7 +1,14 @@
+# Copyright 2023 Engenere - Antônio S. P. Neto
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.tools import sql
+from openupgradelib import openupgrade
+
+_rename_columns = {
+    "res_company": [("auto_archive", "auto_archive_spread")],
+    "account_spread": [("invoice_line_id", None)],
+}
 
 
-def migrate(cr, version):
-    sql.rename_column(cr, "res_partner", "auto_archive", "auto_archive_spread")
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, _rename_columns)


### PR DESCRIPTION
The purpose of this PR is to update the migration script between major versions 12.0 and 13.0 for the `account_spread_cost_revenue` module, which was incomplete. 

Tested in a real migration.