### PR TITLE
[16.0][FIX] account_asset_management: Display significant information about the error

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -1235,15 +1235,14 @@ class AccountAsset(models.Model):
             try:
                 with self.env.cr.savepoint():
                     result += depreciation.create_move()
-            except Exception:
-                e = exc_info()[0]
+            except Exception as e:
                 tb = "".join(format_exception(*exc_info()))
                 asset_ref = depreciation.asset_id.name
                 if depreciation.asset_id.code:
                     asset_ref = "[{}] {}".format(depreciation.asset_id.code, asset_ref)
                 error_log += _(
                     "\nError while processing asset '{ref}': {exception}"
-                ).format(ref=asset_ref, exception=str(e))
+                ).format(ref=asset_ref, exception=repr(e))
                 error_msg = _("Error while processing asset '{ref}': \n\n{tb}").format(
                     ref=asset_ref, tb=tb
                 )


### PR DESCRIPTION
Forward-port of #1788 

As it was, the information put was like:

```
Error mientras se procesa el activo '....': <class 'odoo.exceptions.UserError'>
```

Now, it is:

```
Error mientras se procesa el activo '....': UserError("No puedes usar esta cuenta (...) en este diario, consulta la sección 'Control-Acceso' en la pestaña 'Configuración avanzada' en el diario relacionado.")
```

@Tecnativa TT46362