### PR TITLE
[16.0][FIX] account_journal_restrict_mode: Ensure that the secure sequence is always created.

### DIFF
--- a/account_journal_restrict_mode/models/account_journal.py
+++ b/account_journal_restrict_mode/models/account_journal.py
@@ -17,3 +17,13 @@ class AccountJournal(models.Model):
                 raise UserError(
                     _("Journal %s must have Lock Posted Entries enabled.") % rec.name
                 )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Proposed fix to odoo https://github.com/odoo/odoo/pull/147738.
+        # But while they don't merge (as it's not an issue they will face in odoo standard)...
+        journals = super().create(vals_list)
+        for journal in journals:
+            if journal.restrict_mode_hash_table and not journal.secure_sequence_id:
+                journal._create_secure_sequence(["secure_sequence_id"])
+        return journals

--- a/account_journal_restrict_mode/tests/test_account_journal_restrict_mode.py
+++ b/account_journal_restrict_mode/tests/test_account_journal_restrict_mode.py
@@ -2,14 +2,24 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import UserError
-from odoo.tests import common
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
-class TestAccountJournalRestrictMode(common.TransactionCase):
+@tagged("post_install", "-at_install")
+class TestAccountJournalRestrictMode(AccountTestInvoicingCommon):
     @classmethod
-    def setUpClass(cls):
-        super(TestAccountJournalRestrictMode, cls).setUpClass()
+    def setUpClass(cls, chart_template_ref=None):
+        super(TestAccountJournalRestrictMode, cls).setUpClass(
+            chart_template_ref=chart_template_ref
+        )
         cls.account_journal_obj = cls.env["account.journal"]
+        cls.company_obj = cls.env["res.company"]
+        cls.currency_obj = cls.env["res.currency"]
+        cls.chart_template_obj = cls.env["account.chart.template"]
+        # Refs
+        cls.country_be = cls.env.ref("base.be")
 
     def test_journal_default_lock_entries(self):
         journal = self.account_journal_obj.create(
@@ -18,3 +28,25 @@ class TestAccountJournalRestrictMode(common.TransactionCase):
         self.assertTrue(journal.restrict_mode_hash_table)
         with self.assertRaises(UserError):
             journal.write({"restrict_mode_hash_table": False})
+
+    def test_journal_default_secure_sequence_new_company(self):
+        test_company = self.company_obj.create(
+            {
+                "name": "My Test Company",
+                "currency_id": self.currency_obj.search([("name", "=", "EUR")]).id,
+                "country_id": self.country_be.id,
+            }
+        )
+        self.chart_template_obj.search([], limit=1).with_company(
+            test_company
+        ).try_loading(company=test_company, install_demo=False)
+        journals = self.env["account.journal"].search(
+            [("company_id", "=", test_company.id)]
+        )
+        self.assertTrue(journals)
+        self.assertTrue(
+            all(
+                journal.restrict_mode_hash_table and journal.secure_sequence_id
+                for journal in journals
+            )
+        )


### PR DESCRIPTION
Currently the secure sequence is only created on the write operation. But during the set up of a new company, when the inventory valuation and other journals are created upon setting up the chart of accounts, only the create method is called, not the write, and as a consequence no secure sequence is created.

@MarinaAForgeFlow @LoisRForgeFlow 