### PR TITLE
[FIX] account_loan: use company_ids in ir.rule multi-company

### DIFF
--- a/account_loan/data/ir_sequence_data.xml
+++ b/account_loan/data/ir_sequence_data.xml
@@ -10,5 +10,6 @@
         <field name="code">account.loan</field>
         <field name="prefix">ACL</field>
         <field name="padding">6</field>
+        <field name="company_id" eval="False" />
     </record>
 </odoo>

--- a/account_loan/security/account_loan_security.xml
+++ b/account_loan/security/account_loan_security.xml
@@ -5,7 +5,7 @@
         <field ref="model_account_loan" name="model_id" />
         <field eval="True" name="global" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 </odoo>

--- a/account_loan/tests/test_loan.py
+++ b/account_loan/tests/test_loan.py
@@ -184,6 +184,7 @@ class TestLoan(TransactionCase):
         loan.rate = 2
         loan.compute_lines()
         line = loan.line_ids.filtered(lambda r: r.sequence == 1)
+
         self.assertAlmostEqual(
             -numpy_financial.pmt(1 / 100 / 12, periods, amount, when="begin"),
             line.payment_amount,


### PR DESCRIPTION
Enabel patch from https://github.com/OCA/account-financial-tools/pull/1760 to 15.0 version