### PR TITLE
[16.0][IMP] account_loan: add multi-company ir_rule for 'account_loan_line'

### DIFF
--- a/account_loan/models/account_loan_line.py
+++ b/account_loan/models/account_loan_line.py
@@ -26,7 +26,10 @@ class AccountLoanLine(models.Model):
         ondelete="cascade",
     )
     company_id = fields.Many2one(
-        "res.company", readonly=True, related="loan_id.company_id"
+        "res.company",
+        readonly=True,
+        related="loan_id.company_id",
+        store=True,
     )
     partner_id = fields.Many2one(
         "res.partner", readonly=True, related="loan_id.partner_id"

--- a/account_loan/security/account_loan_security.xml
+++ b/account_loan/security/account_loan_security.xml
@@ -8,4 +8,13 @@
             ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
+
+    <record id="account_loan_line_multi_company_rule" model="ir.rule">
+        <field name="name">Account loan line multi-company</field>
+        <field ref="model_account_loan_line" name="model_id" />
+        <field eval="True" name="global" />
+        <field name="domain_force">
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
This is a small fix:
  There is already a multi-company ir.rule on account loan but none on account loan line.

For the moment, it is not possible for a user to access loans of companies to which he hasn't access but, he can see lines of those loans!
 