### PR TITLE
[16.0][ENH] account_spread_cost_revenue, add specific date option [WIP]

### DIFF
--- a/account_spread_cost_revenue/views/account_spread.xml
+++ b/account_spread_cost_revenue/views/account_spread.xml
@@ -243,8 +243,10 @@
                         <group>
                             <field name="period_number" />
                             <field name="period_type" />
-                            <field name="spread_date" />
                             <field name="days_calc" />
+                            <field name="spread_date" />
+                            <field name="spread_end_date" />
+                            <field name="period_number_actual" />
                             <field name="suitable_journal_ids" invisible="1" />
                             <field name="journal_id" widget="selection" />
                         </group>


### PR DESCRIPTION
Adding option to manually specify the end date. System will try to find the actual period in float and use it to get the monthly amount.

Currently, only period type = month seem to be correct. For year and quarter, still WIP.

![image](https://github.com/OCA/account-financial-tools/assets/1973598/e86298ea-ea1d-4560-a179-23b62bdcacc0)
