### PR TITLE
[FIX] account_journal_general_sequence: provide defaults for sorting

### DIFF
--- a/account_journal_general_sequence/models/account_move.py
+++ b/account_journal_general_sequence/models/account_move.py
@@ -61,7 +61,9 @@ class AccountMove(models.Model):
         # Cache all the new numbers to avoid wasting recomputations, caused by
         # searches done by _next() in the loop below
         chosen_map = {}
-        for move in chosen.sorted(lambda one: (one.date, one.name, one.id)):
+        for move in chosen.sorted(
+            lambda one: (one.date or "", one.name or "", one.id or 0)
+        ):
             chosen_map[move.id] = move.journal_id.entry_number_sequence_id._next(
                 move.date
             )


### PR DESCRIPTION
Under some weird scenarios where some modules are involved, several invoices are posted at the same time, and no invoice exists, we could get to the case when `one.date` or `one.name` were `False`.

Here I provide a default value to avoid comparing `str` to `bool` in those cases.

Tried a lot but couldn't reproduce the test case in code, sorry 😕. However, the traceback was clear:

```
File "/opt/odoo/auto/addons/account_journal_general_sequence/models/account_move.py", line 64, in _compute_entry_number
  for move in chosen.sorted(lambda one: (one.date, one.name, one.id)):
File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5583, in sorted
  ids = tuple(item.id for item in sorted(self, key=key, reverse=reverse))
TypeError: '<' not supported between instances of 'str' and 'bool'
```

@moduon MT-5559