### PR TITLE
[FIX] base_vat_optional_vies: change dependency

### DIFF
--- a/base_vat_optional_vies/__manifest__.py
+++ b/base_vat_optional_vies/__manifest__.py
@@ -11,7 +11,7 @@
         'base_vat',
     ],
     'external_dependencies': {
-        'python': ['vatnumber'],
+        'python': ['stdnum'],
     },
     'data': [
         'views/res_partner_view.xml',

--- a/base_vat_optional_vies/models/res_partner.py
+++ b/base_vat_optional_vies/models/res_partner.py
@@ -34,7 +34,7 @@ class ResPartner(models.Model):
             return self.simple_vat_check(country_code, vat_number)
         return res
 
-    @api.constrains('vat')
+    @api.constrains("vat", "country_id")
     def check_vat(self):
         for partner in self:
             partner = partner.with_context(vat_partner=partner)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # generated from manifests external_dependencies
 numpy
-vatnumber
+python-stdnum


### PR DESCRIPTION
This module required `vatnumber` just to make sure upstream odoo behaved as expected.

However, upstream changed to using `stdnum` in https://github.com/odoo/odoo/commit/c377e46da1a99fae928269fcf95317a8ca4e88f6, so that's what we should require here now.

Besides, tests were bringing false positives and negatives. Now they test the correct behavior.

@moduon MT-5599