### PR TITLE
[16.0][IMP] account_asset_management: Keep line original price on expansion

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -250,12 +250,17 @@ class AccountMoveLine(models.Model):
 
     def _expand_asset_line(self):
         self.ensure_one()
-        if self.asset_profile_id and self.quantity > 1.0:
-            profile = self.asset_profile_id
-            if profile.asset_product_item:
-                aml = self.with_context(check_move_validity=False)
-                qty = self.quantity
-                name = self.name
-                aml.write({"quantity": 1, "name": "{} {}".format(name, 1)})
-                for i in range(1, int(qty)):
-                    aml.copy({"name": "{} {}".format(name, i + 1)})
+        if self.quantity > 1.0 and self.asset_profile_id.asset_product_item:
+            aml = self.with_context(check_move_validity=False)
+            qty = self.quantity
+            name = self.name
+            aml.write(
+                {
+                    "quantity": 1,
+                    "name": "{} {}".format(name, 1),
+                    # Make sure the price is not changed, like with account_invoice_pricelist
+                    "price_unit": self.price_unit,
+                }
+            )
+            for i in range(1, int(qty)):
+                aml.copy({"name": "{} {}".format(name, i + 1)})

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -599,8 +599,13 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         line = invoice.invoice_line_ids[0]
         self.assertTrue(line.price_unit > 0.0)
         line.quantity = 2
+        line_price = 670
+        line.price_unit = line_price
         line.asset_profile_id = asset_profile
         self.assertEqual(len(invoice.invoice_line_ids), 2)
+        self.assertTrue(
+            all([line.price_unit == line_price for line in invoice.invoice_line_ids])
+        )
         invoice.action_post()
         # get all asset after invoice validation
         current_asset = self.env["account.asset"].search([])


### PR DESCRIPTION
Some modules (`account-invoicing` repo's [`account_invoice_pricelist`](https://github.com/OCA/account-invoicing/tree/16.0/account_invoice_pricelist) for instance) re-calculate a move line's price unit when quantity is modified.

This brings problems to `account_asset_management` module when lines are expanded and quantity is set to 1, because line's price value can be lost and set to it's default value.

This modification forces price value not to be lost.

This video shows the problem when these modules are both installed:


https://github.com/OCA/account-financial-tools/assets/31987854/fd26ebd4-e73f-44fe-871a-b78266a3d6e4

