### PR TITLE
[12.0][FIX] account_asset_management: asset report multicompany

### DIFF
--- a/account_asset_management/security/account_asset_security.xml
+++ b/account_asset_management/security/account_asset_security.xml
@@ -23,5 +23,12 @@
       <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
     </record>
 
+    <record id="account_asset_report_multi_company_rule" model="ir.rule">
+      <field name="name">Account Asset Report multi-company</field>
+      <field ref="model_account_asset_report" name="model_id"/>
+      <field eval="True" name="global"/>
+      <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+    </record>
+
   </data>
 </odoo>


### PR DESCRIPTION
In multi-company environments, the assets report (Accounting / Report / Assets) show information another companies.
This PR is for fix this issue with a security rule.
