### PR TITLE
[WIP][16.0][FIX] account_move_name_sequence: build invoice name from journal entry sequence

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -27,6 +27,10 @@ class AccountMove(models.Model):
         ),
     ]
 
+    def _compute_name(self):
+        moves_to_compute = self.filtered(lambda m: m.quick_edit_mode)
+        return super(AccountMove, moves_to_compute)._compute_name()
+
     @api.depends("state", "journal_id", "date")
     def _compute_name_by_sequence(self):
         for move in self:

--- a/account_move_name_sequence/tests/test_account_move_name_seq.py
+++ b/account_move_name_sequence/tests/test_account_move_name_seq.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form, TransactionCase
 
 
 @tagged("post_install", "-at_install")
@@ -19,12 +19,34 @@ class TestAccountMoveNameSequence(TransactionCase):
     def setUp(self):
         super().setUp()
         self.company = self.env.ref("base.main_company")
+        self.partner = self.env.ref("base.res_partner_3")
         self.misc_journal = self.env["account.journal"].create(
             {
                 "name": "Test Journal Move name seq",
                 "code": "ADLM",
                 "type": "general",
                 "company_id": self.company.id,
+            }
+        )
+        self.sales_seq = self.env["ir.sequence"].create(
+            {
+                "name": "TB2C",
+                "implementation": "no_gap",
+                "prefix": "TB2CSEQ/%(range_year)s/",
+                "use_date_range": True,
+                "number_increment": 1,
+                "padding": 4,
+                "company_id": self.company.id,
+            }
+        )
+        self.sales_journal = self.env["account.journal"].create(
+            {
+                "name": "TB2C",
+                "code": "TB2C",
+                "type": "sale",
+                "company_id": self.company.id,
+                "refund_sequence": True,
+                "sequence_id": self.sales_seq.id,
             }
         )
         self.purchase_journal = self.env["account.journal"].create(
@@ -334,3 +356,19 @@ class TestAccountMoveNameSequence(TransactionCase):
 
     def test_constrains_date_sequence_true(self):
         self.assertTrue(self.env["account.move"]._constrains_date_sequence())
+
+    def test_prefix_move_name_journal_onchange(self):
+        product = self.env["product.product"].create({"name": "Product"})
+        with Form(
+            self.env["account.move"].with_context(default_move_type="out_invoice")
+        ) as invoice_form:
+            invoice_form.invoice_date = fields.Date.today()
+            invoice_form.partner_id = self.partner
+            with invoice_form.invoice_line_ids.new() as line_form:
+                line_form.product_id = product
+            invoice = invoice_form.save()
+            self.assertEqual("/", invoice.name)
+        invoice.journal_id = self.sales_journal
+        self.assertFalse(invoice.name)
+        invoice.action_post()
+        self.assertTrue(invoice.name.startswith("TB2CSEQ/"))


### PR DESCRIPTION
Steps to reproduce the error:

1. Create a Journal with an entry sequence with prefix not equal to the journal short code (e.g.: B2CSEQ vs B2C)
2. Create an invoice, set the default sales journal and save the form
3. Edit the invoice, set the journal created at 1) and save the form, you should see the invoice name with the short code instead of the prefix from the entry sequence. It is possible that you have to change the journal multiple times to trigger the bug.
4. Post/Confirm the invoice, should have the wrong prefix

I've recorded the following video using runboat

http://oca-account-financial-tools-16-0-de68cd391ba8.runboat.odoo-community.org

https://github.com/OCA/account-financial-tools/assets/95038732/555935e8-b404-49d3-8503-bd9ea298e767

