### PR TITLE
[IMP]asset management: add depreciated value to facilitate import

### DIFF
--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -61,6 +61,14 @@
                             <field name="company_id" invisible="1" />
                             <field name="code" />
                             <field
+                                name="import_depreciated_value"
+                                attrs="{'readonly': [('state', '!=', 'draft')]}"
+                            />
+                            <field
+                                name="import_depreciated_date"
+                                attrs="{'invisible': [('import_depreciated_value', '=', 0)], 'required': [('import_depreciated_value', '!=', 0)]}"
+                            />
+                            <field
                                 name="company_id"
                                 widget="selection"
                                 groups="base.group_multi_company"


### PR DESCRIPTION
Module: account_asset_manangement

This commit adds the fields import_depreciated_value, import_depreciated_date to facilitate importing assets from another accounting package.

Assume You have an asset of 5000 EUR, depreciated over 5 years whereby 700 EUR has already been depreciated previous fiscal year. If you set import_depreciated_value to 700 and import_date to the last day of your previous fiscal year in the import file the depreciation table will be calculated as from the beginning of the current fiscal year and a single 'init' entry will be created on the last day of the previous fiscal year.