### PR TITLE
FW 16.0 - [REF] account_move_name_sequence: Add unittest to create concurrency invoices

### DIFF
--- a/account_move_name_sequence/__manifest__.py
+++ b/account_move_name_sequence/__manifest__.py
@@ -19,6 +19,7 @@
     ],
     "demo": [
         "demo/ir_sequence_demo.xml",
+        "demo/account_journal_demo.xml",
     ],
     "data": [
         "views/account_journal.xml",

--- a/account_move_name_sequence/demo/account_journal_demo.xml
+++ b/account_move_name_sequence/demo/account_journal_demo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="journal_sale_std_demo" model="account.journal">
+        <field name="name">Standard Sale Journal Demo</field>
+        <field name="code">SSJD</field>
+        <field name="type">sale</field>
+        <field name="refund_sequence">True</field>
+        <field name="company_id" ref="base.main_company" />
+        <field name="sequence_id" ref="seq_sale_std_demo" />
+    </record>
+    <record id="journal_cash_std_demo" model="account.journal">
+        <field name="name">Standard Cash Journal Demo</field>
+        <field name="code">SCJD</field>
+        <field name="type">cash</field>
+        <field name="refund_sequence">True</field>
+        <field name="company_id" ref="base.main_company" />
+        <field name="sequence_id" ref="seq_cash_std_demo" />
+    </record>
+</odoo>

--- a/account_move_name_sequence/demo/ir_sequence_demo.xml
+++ b/account_move_name_sequence/demo/ir_sequence_demo.xml
@@ -1,11 +1,21 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="ir_sequence_demo" model="ir.sequence">
-        <field name="name">Standard Sequence Demo</field>
-        <field name="prefix">demo/%(range_year)s/</field>
+    <record id="seq_sale_std_demo" model="ir.sequence">
+        <field name="name">Standard Sale Sequence Demo</field>
+        <field name="prefix">SSS_demo/%(range_year)s/</field>
         <field name="use_date_range" eval="True" />
         <field name="number_next">1</field>
         <field name="number_increment">1</field>
         <field name="company_id" ref="base.main_company" />
+        <field name="implementation">standard</field>
+    </record>
+    <record id="seq_cash_std_demo" model="ir.sequence">
+        <field name="name">Standard Cash Sequence Demo</field>
+        <field name="prefix">SCS_demo/%(range_year)s/</field>
+        <field name="use_date_range" eval="True" />
+        <field name="number_next">1</field>
+        <field name="number_increment">1</field>
+        <field name="company_id" ref="base.main_company" />
+        <field name="implementation">standard</field>
     </record>
 </odoo>


### PR DESCRIPTION
Add demo data with standard implementation sequences

In order to test locks issues without changing data (then reverting)

Foward-port from: https://github.com/OCA/account-financial-tools/pull/1862