### PR TITLE
[13.0][FIX] account_asset_management: asset compute multicompany

### DIFF
--- a/account_asset_management/readme/CONTRIBUTORS.rst
+++ b/account_asset_management/readme/CONTRIBUTORS.rst
@@ -19,3 +19,7 @@
 * `ForgeFlow <https://www.forgeflow.com>`_:
 
   * Jordi Ballester <jordi.ballester@forgeflow.com>
+
+* `XCG Consulting <https://xcg-consulting.fr>`_:
+
+  * Oury Balde <oury.balde@xcg-consulting.fr>

--- a/account_asset_management/wizard/account_asset_compute.xml
+++ b/account_asset_management/wizard/account_asset_compute.xml
@@ -10,6 +10,7 @@
                         name="date_end"
                         options="{'no_create': True, 'no_open': True}"
                     />
+                    <field name="company_id" groups="base.group_multi_company" />
                 </group>
                 <footer>
                     <button


### PR DESCRIPTION
This PR fixes a problem with how our system handles asset management, especially when calculating assets. The issue is with the asset_compute function used in (Invoicing / Assets / Compute Assets). It currently combines data from different companies incorrectly because it doesn't consider the company. This update includes the company in the asset calculation process, making sure that assets are correctly attributed to each company.

Note: the problem affects all versions. We should apply this fix to each one. I will start working on it as soon as it's approved here.