### PR TITLE
[16.0][IMP] account_move_template: Company compatibility in tests

### DIFF
--- a/account_move_template/tests/test_account_move_template_options.py
+++ b/account_move_template/tests/test_account_move_template_options.py
@@ -14,18 +14,30 @@ class TestAccountMoveTemplateEnhanced(TransactionCase):
         cls.Account = cls.env["account.account"]
         cls.Template = cls.env["account.move.template"]
         cls.Partner = cls.env["res.partner"]
+        cls.company = cls.env.company
 
-        cls.journal = cls.Journal.search([("type", "=", "general")], limit=1)
+        cls.journal = cls.Journal.search(
+            [("type", "=", "general"), ("company_id", "=", cls.company.id)], limit=1
+        )
         cls.ar_account_id = cls.Account.search(
-            [("account_type", "=", "asset_receivable")], limit=1
+            [
+                ("account_type", "=", "asset_receivable"),
+                ("company_id", "=", cls.company.id),
+            ],
+            limit=1,
         )
         cls.ap_account_id = cls.Account.search(
-            [("account_type", "=", "liability_payable")], limit=1
+            [
+                ("account_type", "=", "liability_payable"),
+                ("company_id", "=", cls.company.id),
+            ],
+            limit=1,
         )
         cls.income_account_id = cls.Account.search(
             [
                 ("account_type", "=", "income_other"),
                 ("internal_group", "=", "income"),
+                ("company_id", "=", cls.company.id),
             ],
             limit=1,
         )
@@ -33,6 +45,7 @@ class TestAccountMoveTemplateEnhanced(TransactionCase):
             [
                 ("account_type", "=", "expense"),
                 ("internal_group", "=", "expense"),
+                ("company_id", "=", cls.company.id),
             ],
             limit=1,
         )


### PR DESCRIPTION
Company compatibility in tests

We need to obtain records from the company in question to avoid errors if there is data created in different companies.

```
odoo.exceptions.UserError: Incompatible companies on records:
- 'AR Line 1' belongs to company 'My Company (San Francisco)' and 'Account' (account_id: '430000 Clientes (euros)') belongs to another company.
- 'AR Line 1' belongs to company 'My Company (San Francisco)' and 'Account if Negative' (opt_account_id: '400000 Proveedores (euros)') belongs to another company.
- 'Income Line 2' belongs to company 'My Company (San Francisco)' and 'Account' (account_id: '768000 Diferencias positivas de cambio') belongs to another company.
- 'Income Line 2' belongs to company 'My Company (San Francisco)' and 'Account if Negative' (opt_account_id: '600000 Compras de mercaderías') belongs to another company.
- 'Income Line 2' belongs to company 'My Company (San Francisco)' and 'Account' (account_id: '768000 Diferencias positivas de cambio') belongs to another company.
```

@Tecnativa