### PR TITLE
[14.0][FIX] - incompatibility with account_invoice_constraint_chronology

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -9,11 +9,6 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     name = fields.Char(compute="_compute_name_by_sequence")
-    # highest_name, sequence_prefix and sequence_number are not needed any more
-    # -> compute=False to improve perf
-    highest_name = fields.Char(compute=False)
-    sequence_prefix = fields.Char(compute=False)
-    sequence_number = fields.Integer(compute=False)
 
     _sql_constraints = [
         (


### PR DESCRIPTION
The module account_invoice_constraint_chronology and account_move_name_sequence are incompatible because of the removal of the compute of the following fields : 

- highest_name
- sequence_prefix
- sequence_number