### PR TITLE
[10.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/account_fiscal_year/__manifest__.py
+++ b/account_fiscal_year/__manifest__.py
@@ -6,7 +6,7 @@
     'name': 'Account Fiscal Year',
     'version': '10.0.1.0.1',
     'category': 'Accounting',
-    'author': 'Camptocamp SA,'
+    'author': 'Camptocamp,'
               'Odoo Community Association (OCA)',
     'website': 'http://www.camptocamp.com',
     'depends': [

--- a/account_tag_category/__manifest__.py
+++ b/account_tag_category/__manifest__.py
@@ -7,7 +7,7 @@
     "version": "10.0.1.0.0",
     "category": "Accounting & Finance",
     "website": "https://www.camptocamp.com/",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": [
         "account",

--- a/account_tax_analysis/__manifest__.py
+++ b/account_tax_analysis/__manifest__.py
@@ -11,7 +11,7 @@
         "base",
         "account",
     ],
-    "author": "Camptocamp SA, ACSONE SA/NV, Odoo Community Association (OCA)",
+    "author": "Camptocamp, ACSONE SA/NV, Odoo Community Association (OCA)",
     "category": 'Accounting & Finance',
     "website": "http://www.camptocamp.com",
     "license": "AGPL-3",

--- a/account_tax_update/__manifest__.py
+++ b/account_tax_update/__manifest__.py
@@ -22,7 +22,7 @@
 {
     "name": "Update tax wizard",
     "version": "1.0.44",
-    "author": "Therp BV, Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Therp BV, Camptocamp,Odoo Community Association (OCA)",
     "category": 'Base',
     'complexity': "normal",
     "description": """

--- a/account_type_inactive/__manifest__.py
+++ b/account_type_inactive/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'Accounting',
     'license': 'AGPL-3',
     'summary': "Allows to set account type to inactive",
-    'author': "Camptocamp SA,Odoo Community Association (OCA)",
+    'author': "Camptocamp,Odoo Community Association (OCA)",
     'website': 'http://www.camptocamp.com/',
     'depends': ['account_type_menu'],
     'data': ['views/account_type.xml'],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 10.0.