### PR TITLE
[11.0] account_fiscal_year: Replace 'Camptocamp SA' with 'Camptocamp' in authors

### DIFF
--- a/account_fiscal_year/__manifest__.py
+++ b/account_fiscal_year/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Account Fiscal Year',
     'version': '11.0.1.0.0',
     'category': 'Accounting',
-    'author': 'Camptocamp SA,'
+    'author': 'Camptocamp,'
               'Odoo Community Association (OCA)',
     'website': 'http://www.camptocamp.com',
     'depends': [


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 11.0.