### PR TITLE
[13.0] [FIX] account_fiscal_year: Replace 'Camptocamp SA' with 'Camptocamp' in authors

### DIFF
--- a/account_fiscal_year/__manifest__.py
+++ b/account_fiscal_year/__manifest__.py
@@ -8,8 +8,7 @@
     "development_status": "Beta",
     "category": "Accounting",
     "website": "https://github.com/OCA/account-financial-tools",
-    "author": "Agile Business Group, Camptocamp, "
-    "Odoo Community Association (OCA)",
+    "author": "Agile Business Group, Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["eLBati"],
     "license": "AGPL-3",
     "application": False,

--- a/account_fiscal_year/__manifest__.py
+++ b/account_fiscal_year/__manifest__.py
@@ -8,7 +8,7 @@
     "development_status": "Beta",
     "category": "Accounting",
     "website": "https://github.com/OCA/account-financial-tools",
-    "author": "Agile Business Group, Camptocamp SA, "
+    "author": "Agile Business Group, Camptocamp, "
     "Odoo Community Association (OCA)",
     "maintainers": ["eLBati"],
     "license": "AGPL-3",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 13.0.