### PR TITLE
[16.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/account_fiscal_year/__manifest__.py
+++ b/account_fiscal_year/__manifest__.py
@@ -9,7 +9,7 @@
     "development_status": "Production/Stable",
     "category": "Accounting",
     "website": "https://github.com/OCA/account-financial-tools",
-    "author": "Agile Business Group, Camptocamp SA, "
+    "author": "Agile Business Group, Camptocamp, "
     "Odoo Community Association (OCA)",
     "maintainers": ["eLBati"],
     "license": "AGPL-3",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 16.0.