### PR TITLE
[14.0][FIX] manages VIES connection errors

### DIFF
--- a/base_vat_optional_vies/__manifest__.py
+++ b/base_vat_optional_vies/__manifest__.py
@@ -10,6 +10,7 @@
     "category": "Accounting",
     "version": "14.0.2.1.0",
     "depends": ["base_vat"],
+    "external_dependencies": {"python": ["zeep"]},
     "data": [
         "views/res_partner_view.xml",
         "views/res_config_settings_views.xml",

--- a/base_vat_optional_vies/static/description/index.html
+++ b/base_vat_optional_vies/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # generated from manifests external_dependencies
 numpy-financial<=1.0.0
 numpy>=1.15
+zeep


### PR DESCRIPTION
I don't know if it's the correct repository or solution, I found an error in VIES VAT check when the remote server is unavailable for some reasons, and this error is not managed by python library (or there is another reason that I don't know) (many IDK ;) )

How to replicate:
1. enable vat_check_vies
2. install l10n_it_fatturapa_pec
3. configure PEC fetchmail server
4. receive some invoices from SDI
5. ensure VAT VIES site is working but overloaded (😁)
