### PR TITLE
[15.0][FIX] account_asset_management: Allow to unlink w/o billing permission

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -43,8 +43,12 @@ class AccountMove(models.Model):
 
     def unlink(self):
         # for move in self:
-        deprs = self.env["account.asset.line"].search(
-            [("move_id", "in", self.ids), ("type", "in", ["depreciate", "remove"])]
+        deprs = (
+            self.env["account.asset.line"]
+            .sudo()
+            .search(
+                [("move_id", "in", self.ids), ("type", "in", ["depreciate", "remove"])]
+            )
         )
         if deprs and not self.env.context.get("unlink_from_asset"):
             raise UserError(


### PR DESCRIPTION
Some users may be allowed to unlink invoices without billing access, but with current code, they are not able as the asset line check is done without sudo, and other users except billing or higher ones aren't allowed to access to that model.

@Tecnativa TT49673