### PR TITLE
[16.0][FIX] account_asset_management: no create asset from cash basis

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -186,6 +186,8 @@ class AccountMoveLine(models.Model):
     @api.depends("account_id", "asset_id")
     def _compute_asset_profile(self):
         for rec in self:
+            if rec.move_id.tax_cash_basis_origin_move_id:
+                continue
             if rec.account_id.asset_profile_id and not rec.asset_id:
                 rec.asset_profile_id = rec.account_id.asset_profile_id
             elif rec.asset_id:


### PR DESCRIPTION
This PR fixes issue in case vendor bills have asset profile and undue vat. It shouldn't create asset when create cash basis entry.

Step to test:
1. Create bill and select asset profile and undue vat (cash basis)
2. After register payment, it will create CABA
![Selection_010](https://github.com/OCA/account-financial-tools/assets/20896369/4dd34275-3a98-4f7b-91ce-3a7d203e882f)
3. In cash basis entry will create asset too.
![Selection_011](https://github.com/OCA/account-financial-tools/assets/20896369/e66906bf-afbd-4bd9-977a-8a2c52693b12)
![Selection_012](https://github.com/OCA/account-financial-tools/assets/20896369/2782f38e-aa7e-48e7-9391-8b5546158845)
