### PR TITLE
[15.0][FIX] account_asset_management: report filter multi company

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -1276,7 +1276,7 @@ class AccountAsset(models.Model):
         """
         Update list in custom module to add/drop columns or change order
         """
-        return [
+        fields = [
             "account",
             "name",
             "code",
@@ -1285,13 +1285,16 @@ class AccountAsset(models.Model):
             "depreciation_base",
             "salvage_value",
         ]
+        if self.env.user.has_group("base.group_multi_company"):
+            fields = fields + ["company"]
+        return fields
 
     @api.model
     def _xls_active_fields(self):
         """
         Update list in custom module to add/drop columns or change order
         """
-        return [
+        fields = [
             "account",
             "name",
             "code",
@@ -1308,13 +1311,16 @@ class AccountAsset(models.Model):
             "prorata",
             "state",
         ]
+        if self.env.user.has_group("base.group_multi_company"):
+            fields = fields + ["company"]
+        return fields
 
     @api.model
     def _xls_removal_fields(self):
         """
         Update list in custom module to add/drop columns or change order
         """
-        return [
+        fields = [
             "account",
             "name",
             "code",
@@ -1323,6 +1329,9 @@ class AccountAsset(models.Model):
             "depreciation_base",
             "salvage_value",
         ]
+        if self.env.user.has_group("base.group_multi_company"):
+            fields = fields + ["company"]
+        return fields
 
     @api.model
     def _xls_asset_template(self):

--- a/account_asset_management/report/account_asset_report_xls.py
+++ b/account_asset_management/report/account_asset_report_xls.py
@@ -296,6 +296,14 @@ class AssetReportXlsx(models.AbstractModel):
                 },
                 "width": 8,
             },
+            "company": {
+                "header": {"type": "string", "value": self._("Company")},
+                "asset": {
+                    "type": "string",
+                    "value": self._render("asset.company_id.name or ''"),
+                },
+                "width": 20,
+            },
         }
         asset_template.update(self.env["account.asset"]._xls_asset_template())
 
@@ -423,6 +431,8 @@ class AssetReportXlsx(models.AbstractModel):
 
         if not wiz.draft:
             dom.append(("state", "!=", "draft"))
+        if wiz.company_ids:
+            dom.append(("company_id", "in", wiz.company_ids.ids))
         assets = self.env["account.asset"].search(dom)
         grouped_assets = {}
         self._group_assets(assets, parent_group, grouped_assets)

--- a/account_asset_management/wizard/wiz_account_asset_report.xml
+++ b/account_asset_management/wizard/wiz_account_asset_report.xml
@@ -13,19 +13,22 @@
                     <field name="date_from" />
                     <field name="date_to" />
                     <field name="draft" />
-                    <field name="company_id" groups="base.group_multi_company" />
+                    <field
+                        name="company_ids"
+                        widget="many2many_tags"
+                        groups="base.group_multi_company"
+                    />
                 </group>
                 <footer>
-          <button
+                    <button
                         name="xls_export"
                         string="Generate Report"
                         type="object"
                         default_focus="1"
                         class="oe_highlight"
                     />
-          or
-          <button string="Cancel" class="oe_link" special="cancel" />
-        </footer>
+                    <button string="Cancel" class="oe_link" special="cancel" />
+                </footer>
             </form>
         </field>
     </record>


### PR DESCRIPTION
This PR enhance asset report for support multi-company

**Step to test (before):**
Admin has permission 2 company
![Selection_006](https://github.com/OCA/account-financial-tools/assets/20896369/986ed5b8-3ef2-4195-88ab-042873f515c2)


1. Create Asset in each company
![Selection_001](https://github.com/OCA/account-financial-tools/assets/20896369/206da2ec-3c95-4934-b181-d128c6beea63)
2. Run Financial Asset Report with company **TH Company**, we assume report should run only TH Company 
![Selection_002](https://github.com/OCA/account-financial-tools/assets/20896369/512a26c6-8d99-439b-9ecb-f0f5c432315b)
3. Report show all asset without filter company
![Selection_003](https://github.com/OCA/account-financial-tools/assets/20896369/79b555b1-9426-4c10-861b-b1e044bb2ee0)
4. Try change company to **Your Company**, same result

--------------------------------------

- In code, `company_id` use for onchange `date_from, date_to` only. no filter company
- This PR change it to filter company and allow filter with more than 1 company
- `date_from`, `date_to` we can default following Fiscal Year from user company

![Selection_012](https://github.com/OCA/account-financial-tools/assets/20896369/2c863394-eb16-4b9e-8490-eef9554da349)
![Selection_013](https://github.com/OCA/account-financial-tools/assets/20896369/3ce28dc1-7b4a-47ba-8eea-4b3efdf50812)
