### PR TITLE
[16.0][FIX] account_chart_update: prevent malformed xmlid during update

### DIFF
--- a/account_chart_update/tests/test_account_chart_update.py
+++ b/account_chart_update/tests/test_account_chart_update.py
@@ -543,6 +543,14 @@ class TestAccountChartUpdate(common.TransactionCase):
         self.assertEqual(self.tax.description, self.tax_template.description)
         self.assertEqual(self.account.code, self.account_template.code)
         self.assertEqual(self.fp.name, self.fp_template.name)
+        fp_id = wizard.find_fp_by_templates(self.fp_template)
+        fp_rec = self.env["account.fiscal.position"].browse(fp_id)
+        expected_xmlid = "{}.{}_{}".format(
+            "account_chart_update",
+            wizard.company_id.id,
+            "account_fiscal_position_template-{}".format(self.fp_template.id),
+        )
+        self.assertEqual(fp_rec.get_external_id().get(fp_id), expected_xmlid)
         wizard.unlink()
 
         # Test match by another field, there is no match by XML-ID
@@ -613,6 +621,7 @@ class TestAccountChartUpdate(common.TransactionCase):
         self.assertTrue(list(self.tax.get_external_id().values())[0])
         self.assertTrue(list(self.account.get_external_id().values())[0])
         self.assertTrue(list(self.fp.get_external_id().values())[0])
+        self.assertEqual(fp_rec.get_external_id().get(fp_id), expected_xmlid)
         wizard.unlink()
 
         # Test 2 recreate XML-ID
@@ -642,4 +651,5 @@ class TestAccountChartUpdate(common.TransactionCase):
         self.assertTrue(list(self.tax.get_external_id().values())[0])
         self.assertTrue(list(self.account.get_external_id().values())[0])
         self.assertTrue(list(self.fp.get_external_id().values())[0])
+        self.assertEqual(fp_rec.get_external_id().get(fp_id), expected_xmlid)
         wizard.unlink()

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -1100,14 +1100,14 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         ir_model_data.search(
             [("model", "=", real_obj._name), ("res_id", "=", real_obj.id)]
         ).unlink()
-        template_xmlid.copy(
+        new_rec = template_xmlid.copy(
             {
                 "model": real_obj._name,
                 "res_id": real_obj.id,
-                "name": new_xml_id,
                 "noupdate": True,
             }
         )
+        new_rec.name = new_xml_id
 
     def _update_taxes(self):
         """Process taxes to create/update/deactivate."""


### PR DESCRIPTION
When a copy of an ir_model_data record is made, the name is now overwritten, including a random 4-digit hash at the end, resulting in the format:
<module_name>.<xmlid_template>_<random 4-digit number>

This occurs at this point in the base code:
https://github.com/odoo/odoo/blob/16.0/odoo/addons/base/models/ir_model.py#L2067

Instead of the expected format when generating XMLIDs from this record:
<module_name>.<id_company>_<xmlid_template>

For example, here when generating:
https://github.com/OCA/account-financial-tools/blob/16.0/account_chart_update/wizard/wizard_chart_update.py#L1099

And here to determine if it is found or not:
https://github.com/OCA/account-financial-tools/blob/16.0/account_chart_update/wizard/wizard_chart_update.py#L893

I am aware that there are other search criteria besides the XMLID, but for example, in fiscal positions, a user can change the name and if the XMLID is lost for any reason, when the chart of accounts is updated, it will not be found, and a new one will be generated.

With the small patch I am including, the name is set after the copy, preserving it. In the regeneration method itself, the XMLID is searched for and deleted before copying, ensuring that there will be no attempt to duplicate an identical one.

In the tests, a case has been implemented where, without the patch, a malformed XMLID would be obtained.