### PR TITLE
[13.0][FIX] account_lock_to_date: raise validation error condition

### DIFF
--- a/account_lock_to_date/models/res_company.py
+++ b/account_lock_to_date/models/res_company.py
@@ -68,7 +68,7 @@ class ResCompany(models.Model):
             if (
                 old_fiscalyear_lock_to_date
                 and fiscalyear_lock_to_date
-                and fiscalyear_lock_to_date > old_fiscalyear_lock_to_date
+                and fiscalyear_lock_to_date < old_fiscalyear_lock_to_date
             ):
                 raise ValidationError(
                     _(


### PR DESCRIPTION
Fix raise validation error
The new lock to date for advisors must be set after the previous lock to date. from fiscalyear_lock_to_date > old_fiscalyear_lock_to_date to fiscalyear_lock_to_date < old_fiscalyear_lock_to_date