### PR TITLE
[16.0][IMP] stock_account_anglo_saxon_cogs_kit: correct account in vendor bills for purchase of consumable kit

### DIFF
--- a/stock_account_anglo_saxon_cogs_kit/__manifest__.py
+++ b/stock_account_anglo_saxon_cogs_kit/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Stock Account Anglo Saxon COGS Kit",
     "category": "Accounting",
     "version": "16.0.1.0.0",
-    "depends": ["sale_mrp"],
+    "depends": ["sale_mrp", "purchase_mrp"],
     "data": [],
     "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-financial-tools",

--- a/stock_account_anglo_saxon_cogs_kit/models/account_move_line.py
+++ b/stock_account_anglo_saxon_cogs_kit/models/account_move_line.py
@@ -12,3 +12,9 @@ class AccountMoveLine(models.Model):
             p.type == "product" and p.valuation == "real_time"
             for p in self.sale_line_ids.mapped("move_ids.product_id")
         )
+
+    def _can_use_stock_accounts(self):
+        return super()._can_use_stock_accounts() or any(
+            p.type == "product" and p.valuation == "real_time"
+            for p in self.purchase_line_id.mapped("move_ids.product_id")
+        )

--- a/stock_account_anglo_saxon_cogs_kit/static/description/index.html
+++ b/stock_account_anglo_saxon_cogs_kit/static/description/index.html
@@ -1,20 +1,19 @@
-<?xml version="1.0" encoding="utf-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
 <title>Stock Account Anglo Saxon COGS Kit</title>
 <style type="text/css">
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 7952 2016-07-26 18:15:59Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
 
-See http://docutils.sf.net/docs/howto/html-stylesheets.html for how to
+See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
 */
 
@@ -369,7 +368,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:95246b5c8140145c330025892f1165ea1839841376ce1796732d29fb5b4c1962
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/account-financial-tools/tree/16.0/stock_account_anglo_saxon_cogs_kit"><img alt="OCA/account-financial-tools" src="https://img.shields.io/badge/github-OCA%2Faccount--financial--tools-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/account-financial-tools-16-0/account-financial-tools-16-0-stock_account_anglo_saxon_cogs_kit"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runboat.odoo-community.org/builds?repo=OCA/account-financial-tools&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/account-financial-tools/tree/16.0/stock_account_anglo_saxon_cogs_kit"><img alt="OCA/account-financial-tools" src="https://img.shields.io/badge/github-OCA%2Faccount--financial--tools-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/account-financial-tools-16-0/account-financial-tools-16-0-stock_account_anglo_saxon_cogs_kit"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/account-financial-tools&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>The Odoo Official documentation recommends to use consumable for kit products and only to be
 storable in case Anglosaxon accounting:</p>
 <p><a class="reference external" href="https://www.odoo.com/documentation/16.0/applications/inventory_and_mrp/manufacturing/management/kit_shipping.html">https://www.odoo.com/documentation/16.0/applications/inventory_and_mrp/manufacturing/management/kit_shipping.html</a></p>
@@ -382,17 +381,17 @@ storable if they don’t want to track quantities for the kit.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="id1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id5">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-financial-tools/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -400,15 +399,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id2">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id3">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
 <ul class="simple">
 <li>ForgeFlow, S.L. (<a class="reference external" href="https://www.forgeflow.com">https://www.forgeflow.com</a>)
 * Marina Alapont &lt;<a class="reference external" href="mailto:marina.alapont&#64;forgeflow.com">marina.alapont&#64;forgeflow.com</a>&gt;
@@ -416,14 +415,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
-<p><a class="reference external" href="https://github.com/MarinaAForgeFlow"><img alt="MarinaAForgeFlow" src="https://github.com/MarinaAForgeFlow.png?size=40px" /></a> <a class="reference external" href="https://github.com/AaronHForgeFlow"><img alt="AaronHForgeFlow" src="https://github.com/AaronHForgeFlow.png?size=40px" /></a></p>
+<p><a class="reference external image-reference" href="https://github.com/MarinaAForgeFlow"><img alt="MarinaAForgeFlow" src="https://github.com/MarinaAForgeFlow.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/AaronHForgeFlow"><img alt="AaronHForgeFlow" src="https://github.com/AaronHForgeFlow.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/account-financial-tools/tree/16.0/stock_account_anglo_saxon_cogs_kit">OCA/account-financial-tools</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
When a Bill is created associated with a PO, Odoo computes the account to assign to the journal items (https://github.com/odoo/odoo/blob/0e1e7bf9c96b8fe4a06dfe3f858a837a8fdf386d/addons/stock_account/models/account_move.py#L242). 

It will only assign the correct stock account for storable products (https://github.com/odoo/odoo/blob/0e1e7bf9c96b8fe4a06dfe3f858a837a8fdf386d/addons/stock_account/models/account_move.py#L276). This causes problems when you purchase a kit that is configured as a consumable, because the expense account is assigned instead of the stock input account, which is needed to reconcile with the components received.

With the changes, the correct account is used in the bill.