### PR TITLE
[15.0][FIX] account_asset_management: unbalance expense when split lines

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -253,6 +253,11 @@ class AccountMoveLine(models.Model):
                 record._expand_asset_line()
         return True
 
+    def split_price_expense(self, qty):
+        """Check expense_id and split price if needed."""
+        if hasattr(self, "expense_id") and self.expense_id:
+            self.update({"debit": self.debit / qty})
+
     def _expand_asset_line(self):
         self.ensure_one()
         if self.asset_profile_id and self.quantity > 1.0:
@@ -261,6 +266,7 @@ class AccountMoveLine(models.Model):
                 aml = self.with_context(check_move_validity=False)
                 qty = self.quantity
                 name = self.name
+                aml.split_price_expense(qty)
                 aml.write({"quantity": 1, "name": "{} {}".format(name, 1)})
                 aml._onchange_price_subtotal()
                 for i in range(1, int(qty)):


### PR DESCRIPTION
This PR fixed error when create expense and select account is asset

Step to error:
1. Install module `account_asset_management` and `hr_expense`
2. Create asset profile and check `Create an asset by product item`
![Selection_004](https://github.com/user-attachments/assets/ae71d2aa-5761-4280-ab0a-8fc810e09e82)

3. Config asset profile in account
![Selection_007](https://github.com/user-attachments/assets/94f54ef6-3faa-45ff-8f75-740ae5a5f4da)

4. Create expense with product cost and **change qty morethan 1.** after that, select account with config asset profile
![Selection_005](https://github.com/user-attachments/assets/2a4686f9-d8a7-49b0-8fa2-79023a7cc155)

5. post journal will error
![Selection_006](https://github.com/user-attachments/assets/032f716a-fa95-4517-821f-60da5d293bf1)
