### PR TITLE
[16.0][FIX] account_invoice_constraint_chronology: fix issue with already numbered invoice

### DIFF
--- a/account_invoice_constraint_chronology/model/account_move.py
+++ b/account_invoice_constraint_chronology/model/account_move.py
@@ -96,6 +96,7 @@ class AccountMove(models.Model):
             [
                 (
                     ("name", ">", self.name),
+                    ("name", "!=", "/"),
                     ("invoice_date", "<", self.invoice_date),
                 )
             ]
@@ -106,6 +107,7 @@ class AccountMove(models.Model):
             [
                 (
                     ("name", "<", self.name),
+                    ("name", "!=", "/"),
                     ("invoice_date", ">", self.invoice_date),
                 )
             ]

--- a/account_invoice_constraint_chronology/tests/test_account_invoice_constraint_chronology.py
+++ b/account_invoice_constraint_chronology/tests/test_account_invoice_constraint_chronology.py
@@ -225,3 +225,12 @@ class TestAccountInvoiceConstraintChronology(common.TransactionCase):
             ),
         ):
             self.invoice_1_a_15.action_post()
+
+    def test_post_invoice_with_name(self):
+        # invoice 1 has a number (not /)
+        assert self.invoice_1.state == "draft"
+        assert self.invoice_1.name > "/"
+        # invoice 2 is dated after invoice 1 and is named '/'
+        invoice2 = self.invoice_1.copy()
+        invoice2.invoice_date = self.invoice_1.invoice_date + timedelta(days=1)
+        self.invoice_1.action_post()


### PR DESCRIPTION
An already numbered invoice should not conflict with future draft invoices named /.