### PR TITLE
[16.0][FIX] account_asset_number: barcode type report

### DIFF
--- a/account_asset_number/report/account_asset_number_report.xml
+++ b/account_asset_number/report/account_asset_number_report.xml
@@ -14,19 +14,19 @@
                             <img
                                 alt="Barcode"
                                 t-if="len(asset.number) == 13"
-                                t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', quote_plus(asset.number or ''), 600, 150)"
+                                t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', quote_plus(asset.number or ''), 600, 150)"
                                 style="width:100%;height:4rem;"
                             />
                             <img
                                 alt="Barcode"
                                 t-elif="len(asset.number) == 8"
-                                t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', quote_plus(asset.number or ''), 600, 150)"
+                                t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', quote_plus(asset.number or ''), 600, 150)"
                                 style="width:100%;height:4rem;"
                             />
                             <img
                                 alt="Barcode"
                                 t-else=""
-                                t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', quote_plus(asset.number or ''), 600, 150)"
+                                t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', quote_plus(asset.number or ''), 600, 150)"
                                 style="width:100%;height:4rem"
                             />
                             <span t-field="asset.number" />


### PR DESCRIPTION
Asset number report can't generate barcode because odoo change `type` to `barcode_type`