### PR TITLE
[16.0][IMP] account_asset_number: Add Barcode type Configuration

### DIFF
--- a/account_asset_number/models/account_asset_profile.py
+++ b/account_asset_number/models/account_asset_profile.py
@@ -17,7 +17,28 @@ class AccountAssetProfile(models.Model):
         string="Asset Number Sequence",
         domain=lambda self: self._get_domain_sequence_id(),
     )
+    barcode_type = fields.Selection(
+        selection=[("barcode", "Barcode"), ("qr", "QR")],
+        default="barcode",
+    )
+    barcode_width = fields.Integer(
+        default=350,
+        help="Width (in px) of the barcode or the QR code",
+    )
+    barcode_height = fields.Integer(
+        default=75,
+        help="Height (in px) of the barcode or the QR code",
+    )
 
     @api.model
     def _get_domain_sequence_id(self):
         return [("company_id", "in", [False, self.env.company.id])]
+
+    @api.onchange("barcode_type")
+    def _onchange_barcode_type(self):
+        # Set default values when type is changed
+        if self.barcode_type == "barcode":
+            self.barcode_width = 300
+            self.barcode_height = 75
+        elif self.barcode_type == "qr":
+            self.barcode_width = 150

--- a/account_asset_number/report/account_asset_number_report.xml
+++ b/account_asset_number/report/account_asset_number_report.xml
@@ -10,26 +10,36 @@
                 </tr>
                 <tr>
                     <td class="text-center align-middle" style="height: 6rem;">
+                        <t t-set="profile" t-value="asset.profile_id" />
                         <t t-if="asset.number">
-                            <img
-                                alt="Barcode"
-                                t-if="len(asset.number) == 13"
-                                t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', quote_plus(asset.number or ''), 600, 150)"
-                                style="width:100%;height:4rem;"
-                            />
-                            <img
-                                alt="Barcode"
-                                t-elif="len(asset.number) == 8"
-                                t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', quote_plus(asset.number or ''), 600, 150)"
-                                style="width:100%;height:4rem;"
-                            />
-                            <img
-                                alt="Barcode"
-                                t-else=""
-                                t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', quote_plus(asset.number or ''), 600, 150)"
-                                style="width:100%;height:4rem"
-                            />
-                            <span t-field="asset.number" />
+                            <t t-if="profile.barcode_type == 'barcode'">
+                                <img
+                                    alt="Barcode"
+                                    t-if="len(asset.number) == 13"
+                                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', quote_plus(asset.number or ''), profile.barcode_width, profile.barcode_height)"
+                                    style="display: block; margin: 0 auto;"
+                                />
+                                <img
+                                    alt="Barcode"
+                                    t-elif="len(asset.number) == 8"
+                                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN8', quote_plus(asset.number or ''), profile.barcode_width, profile.barcode_height)"
+                                    style="display: block; margin: 0 auto;"
+                                />
+                                <img
+                                    alt="Barcode"
+                                    t-else=""
+                                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', quote_plus(asset.number or ''), profile.barcode_width, profile.barcode_height)"
+                                    style="display: block; margin: 0 auto;"
+                                />
+                            </t>
+                            <t t-elif="profile.barcode_type == 'qr'">
+                                <img
+                                    alt="QRcode"
+                                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('QR', quote_plus(asset.number or ''), profile.barcode_width, profile.barcode_width)"
+                                    style="display: block; margin: 0 auto;"
+                                />
+                            </t>
+                                <span t-field="asset.number" />
                         </t>
                         <t t-else="">
                             <span class="text-muted">No number available</span>

--- a/account_asset_number/views/account_asset_profile.xml
+++ b/account_asset_number/views/account_asset_profile.xml
@@ -8,15 +8,28 @@
             ref="account_asset_management.account_asset_profile_view_form"
         />
         <field name="arch" type="xml">
-            <xpath
-                expr="//sheet/group/group/field[@name='company_id']"
-                position="after"
-            >
-                <field name="use_sequence" />
-                <field
-                    name="sequence_id"
-                    attrs="{'invisible':[('use_sequence', '!=', True)], 'required':[('use_sequence', '=', True)]}"
-                />
+            <xpath expr="//sheet/group/group[last()]" position="after">
+                <group string="QR/Barcode Configuration">
+                    <field
+                        name="barcode_type"
+                        attrs="{'required': [('use_sequence', '=', True)]}"
+                    />
+                    <field
+                        name="barcode_width"
+                        attrs="{'required': [('use_sequence', '=', True)]}"
+                    />
+                    <field
+                        name="barcode_height"
+                        attrs="{'invisible': [('barcode_type', '=', 'qr')],
+                                'required': [('use_sequence', '=', True)]}"
+                    />
+                    <field name="use_sequence" />
+                    <field
+                        name="sequence_id"
+                        attrs="{'invisible': [('use_sequence', '!=', True)],
+                                'required': [('use_sequence', '=', True)]}"
+                    />
+                </group>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Updating **account asset number** lets you select the code type and set custom sizes for both QR codes and barcodes.
