### PR TITLE
[14.0][IMP] account_lock_to_date: bypass functionality via context

### DIFF
--- a/account_lock_to_date/models/account_move.py
+++ b/account_lock_to_date/models/account_move.py
@@ -7,6 +7,8 @@ from odoo.exceptions import ValidationError
 class AccountMove(models.Model):
     _inherit = "account.move"
 
+    EDIT_SENTINEL = object()
+
     def _check_lock_to_dates(self):
         """Prevent moves that are on or after lock to date.
 
@@ -15,6 +17,8 @@ class AccountMove(models.Model):
         Other users will also be restricted by the period_lock_to_date.
         """
         is_advisor = self.user_has_groups("account.group_account_manager")
+        if self.env.context.get("bypass_account_lock_to_date") is self.EDIT_SENTINEL:
+            return
         for move in self:
             advisor_lock_to_date = move.company_id.fiscalyear_lock_to_date
             user_lock_to_date = move.company_id.period_lock_to_date

--- a/account_lock_to_date/tests/test_account_lock_to_date_update.py
+++ b/account_lock_to_date/tests/test_account_lock_to_date_update.py
@@ -135,3 +135,13 @@ class TestAccountLockToDateUpdate(TransactionCase):
         with self.assertRaises(ValidationError):
             self.company.period_lock_to_date = "2900-01-01"
             self.company.fiscalyear_lock_to_date = "2900-02-01"
+
+    def test_06_lock_period_with_bypass(self):
+        """We test that journal entries can be posted after the locked date
+        when the bypass option is enabled."""
+        self.company.period_lock_to_date = "2900-01-01"
+        self.company.fiscalyear_lock_to_date = "2900-02-01"
+        move = self.create_account_move("2900-01-01").with_context(
+            bypass_account_lock_to_date=self.env["account.move"].EDIT_SENTINEL
+        )
+        move.with_user(self.demo_user.id).action_post()


### PR DESCRIPTION
[HT00849]

Allows modules that depend on account_lock_to_date to bypass the period lock by using the context. It facilitates operations like reconciliation or journal entries in locked periods when the bypass is enabled.

This is based on the bypass mechanism from the account_journal_lock_date module, which enables other modules to utilize the bypass for similar situations involving account.move, when necessary.

cc @marcelsavegnago @douglascstd @WesleyOliveira98 