### PR TITLE
[16.0][BKP][IMP] account_journal_restrict_mode: make field readonly to not allow editing in the view

### DIFF
--- a/account_journal_restrict_mode/models/account_journal.py
+++ b/account_journal_restrict_mode/models/account_journal.py
@@ -8,7 +8,7 @@ from odoo.exceptions import UserError
 class AccountJournal(models.Model):
     _inherit = "account.journal"
 
-    restrict_mode_hash_table = fields.Boolean(default=True)
+    restrict_mode_hash_table = fields.Boolean(default=True, readonly=True)
 
     @api.constrains("restrict_mode_hash_table")
     def _check_journal_restrict_mode(self):


### PR DESCRIPTION
There is already a constrain, but this way we do not confuse the user as if it was possible to edit.

This is backported from v17