### PR TITLE
[FIX] account_loan: Set name on line in order to make it compatible with assets

### DIFF
--- a/account_loan/wizard/account_loan_post.py
+++ b/account_loan/wizard/account_loan_post.py
@@ -45,6 +45,7 @@ class AccountLoanPost(models.TransientModel):
         res.append(
             {
                 "account_id": self.account_id.id,
+                "name": self.loan_id.name,
                 "partner_id": partner.id,
                 "credit": 0,
                 "debit": line.pending_principal_amount,


### PR DESCRIPTION
Otherwise an error is raised due to
https://github.com/OCA/account-financial-tools/blob/16.0/account_asset_management/models/account_move.py#L98-L101