### PR TITLE
[16.0][IMP] account_move_budget: add budget smart button in partner form + add multi-company rules

### DIFF
--- a/account_move_budget/__manifest__.py
+++ b/account_move_budget/__manifest__.py
@@ -14,6 +14,7 @@
     "depends": ["account", "date_range"],
     "data": [
         "security/ir.model.access.csv",
+        "security/account_move_budget.xml",
         "views/account_move_budget_line_views.xml",
         "views/account_move_budget_views.xml",
         "views/res_partner_view.xml",

--- a/account_move_budget/__manifest__.py
+++ b/account_move_budget/__manifest__.py
@@ -16,5 +16,6 @@
         "security/ir.model.access.csv",
         "views/account_move_budget_line_views.xml",
         "views/account_move_budget_views.xml",
+        "views/res_partner_view.xml",
     ],
 }

--- a/account_move_budget/models/__init__.py
+++ b/account_move_budget/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_move_budget
 from . import account_move_budget_line
+from . import res_partner

--- a/account_move_budget/models/res_partner.py
+++ b/account_move_budget/models/res_partner.py
@@ -1,0 +1,32 @@
+# Copyright 2024 ForgeFlow S.L. (http://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class Partner(models.Model):
+    _inherit = "res.partner"
+
+    budget_count = fields.Integer(
+        "# Budgets", compute="_compute_budget_count", compute_sudo=False
+    )
+
+    def _get_budget_ids(self):
+        self.ensure_one()
+        budget_lines = self.env["account.move.budget.line"].search(
+            [("partner_id", "=", self.id)]
+        )
+        return budget_lines.mapped("budget_id.id")
+
+    def _compute_budget_count(self):
+        for partner in self:
+            partner.budget_count = len(partner._get_budget_ids())
+
+    def action_view_budget(self):
+        self.ensure_one()
+        budget_ids = self._get_budget_ids()
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "account_move_budget.account_move_budget_act_window"
+        )
+        action["domain"] = [("id", "in", budget_ids)]
+        return action

--- a/account_move_budget/security/account_move_budget.xml
+++ b/account_move_budget/security/account_move_budget.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record model="ir.rule" id="rule_account_move_budget_company">
+        <field name="name">Account Move Budget Multi-Company</field>
+        <field name="model_id" ref="account_move_budget.model_account_move_budget" />
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+
+    <record model="ir.rule" id="rule_account_move_budget_line_company">
+        <field name="name">Account Move Budget Line Multi-Company</field>
+        <field
+            name="model_id"
+            ref="account_move_budget.model_account_move_budget_line"
+        />
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    </record>
+</odoo>

--- a/account_move_budget/static/description/index.html
+++ b/account_move_budget/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/account_move_budget/static/description/index.html
+++ b/account_move_budget/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -423,7 +424,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_move_budget/tests/test_account_move_budget.py
+++ b/account_move_budget/tests/test_account_move_budget.py
@@ -56,6 +56,46 @@ class TestAccountMoveBudget(TransactionCase):
             }
         )
 
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "Test Partner", "company_id": cls.env.company.id}
+        )
+
+        cls.budget1 = cls.env["account.move.budget"].create(
+            {
+                "name": "Budget 1",
+                "company_id": cls.env.company.id,
+                "date_from": "2023-01-01",
+                "date_to": "2023-12-31",
+            }
+        )
+        cls.budget2 = cls.env["account.move.budget"].create(
+            {
+                "name": "Budget 2",
+                "company_id": False,
+                "date_from": "2024-01-01",
+                "date_to": "2024-12-31",
+            }
+        )
+
+        cls.budget_line1 = cls.env["account.move.budget.line"].create(
+            {
+                "partner_id": cls.partner.id,
+                "company_id": cls.env.company.id,
+                "budget_id": cls.budget1.id,
+                "date": "2023-01-01",
+                "account_id": cls.account.id,
+            }
+        )
+        cls.budget_line2 = cls.env["account.move.budget.line"].create(
+            {
+                "partner_id": cls.partner.id,
+                "company_id": False,
+                "budget_id": cls.budget2.id,
+                "date": "2024-01-01",
+                "account_id": cls.account.id,
+            }
+        )
+
     def test_01_create_account_move_budget(self):
         move_form = Form(self.env["account.move.budget"])
         move_form.name = "Budget Test 01"
@@ -137,3 +177,19 @@ class TestAccountMoveBudget(TransactionCase):
         move_line_form.account_id = self.account
         with self.assertRaises(ValidationError):
             move_line_form.save()
+
+    def test_07_compute_budget_info(self):
+        self.partner._compute_budget_count()
+        self.assertEqual(self.partner.budget_count, 2)
+
+        budget_ids = self.partner._get_budget_ids()
+        expected_ids = {self.budget1.id, self.budget2.id}
+        self.assertEqual(set(budget_ids), expected_ids)
+
+    def test_08_action_view_budget(self):
+        action = self.partner.action_view_budget()
+
+        budget_ids = self.partner._get_budget_ids()
+        expected_domain = [("id", "in", budget_ids)]
+
+        self.assertEqual(action["domain"], expected_domain)

--- a/account_move_budget/views/res_partner_view.xml
+++ b/account_move_budget/views/res_partner_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_partner_form_inherit" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button
+                    class="oe_stat_button"
+                    name="action_view_budget"
+                    type="object"
+                    groups="account.group_account_user"
+                    icon="fa-usd"
+                >
+                        <field string="Budgets" name="budget_count" widget="statinfo" />
+                </button>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Adds a smart button on the partner form to redirect the user to all budgets where the partner has been assigned in the budget lines.

- Adds multi company rules