### PR TITLE
[16.0][FIX] account_chart_update: fix _update_accounts when creating account

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -1159,7 +1159,8 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             if wiz_account.type == "new":
                 # Create the account
                 tax_template_ref = {
-                    tax: self.find_tax_by_templates(tax) for tax in template.tax_ids
+                    tax: self.env["account.tax"].browse(self.find_tax_by_templates(tax))
+                    for tax in template.tax_ids
                 }
                 vals = self.chart_template_id._get_account_vals(
                     self.company_id,


### PR DESCRIPTION
After reading the source code, I realized that `tax_template_ref` should contain a dict of tax recordset and not just ids:

https://github.com/OCA/account-financial-tools/blob/778562e078dea4a4cbf872632eea8aabc3c445eb/account_chart_update/wizard/wizard_chart_update.py#L1164-L1169

definition of `_get_account_vals` in odoo:
https://github.com/odoo/odoo/blob/6afdb0f18c767e0006acd72b1f064f526fe330af/addons/account/models/chart_template.py#L957-L963

I had this error when trying to update a chart account:

```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/odoo/lib/python3.10/site-packages/odoo/http.py", line 1591, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/odoo/lib/python3.10/site-packages/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/odoo/lib/python3.10/site-packages/odoo/http.py", line 1618, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/odoo/lib/python3.10/site-packages/odoo/http.py", line 1822, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/odoo/lib/python3.10/site-packages/odoo/addons/website/models/ir_http.py", line 237, in _dispatch
    response = super()._dispatch(endpoint)
  File "/odoo/lib/python3.10/site-packages/odoo/addons/extendable/models/ir_http.py", line 20, in _dispatch
    return super()._dispatch(endpoint)
  File "/odoo/lib/python3.10/site-packages/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/odoo/lib/python3.10/site-packages/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/odoo/lib/python3.10/site-packages/odoo/addons/web/controllers/dataset.py", line 46, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/odoo/lib/python3.10/site-packages/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/odoo/lib/python3.10/site-packages/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/odoo/lib/python3.10/site-packages/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/odoo/lib/python3.10/site-packages/odoo/addons/account_chart_update/wizard/wizard_chart_update.py", line 421, in action_update_records
    self._update_accounts()
  File "/odoo/lib/python3.10/site-packages/odoo/addons/account_chart_update/wizard/wizard_chart_update.py", line 1167, in _update_accounts
    vals = self.chart_template_id._get_account_vals(
  File "/app/odoo/addons/ebt_account_template_legacy_code/models/account_chart_template.py", line 11, in _get_account_vals
    vals = super()._get_account_vals(
  File "/app/odoo/addons/ebt_account_template_deprecated/models/account_chart_template.py", line 11, in _get_account_vals
    vals = super()._get_account_vals(
  File "/app/odoo/addons/ebt_account_template_aggregated_account/models/account_chart_template.py", line 11, in _get_account_vals
    vals = super()._get_account_vals(
  File "/odoo/lib/python3.10/site-packages/odoo/addons/account/models/chart_template.py", line 959, in _get_account_vals
    tax_ids.append(tax_template_ref[tax].id)
AttributeError: 'int' object has no attribute 'id'

The above server error caused the following client error:
RPC_ERROR://odoo.preprod.ebtrans.acsone.eu/web/assets/412834-7f603a3/web.assets_backend.min.js:999:163)
    at XMLHttpRequest.<anonymous> (https://odoo.preprod.ebtrans.acsone.eu/web/assets/412834-7f603a3/web.assets_backend.min.js:1007:13)

```