### PR TITLE
[17.0][OU-FIX] account_loan: use env in openupgrade load_data instead of cr

### DIFF
--- a/account_loan/migrations/17.0.1.0.0/post-migration.py
+++ b/account_loan/migrations/17.0.1.0.0/post-migration.py
@@ -6,5 +6,5 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(
-        env.cr, "account_loan", "migrations/17.0.1.0.0/noupdate_changes.xml"
+        env, "account_loan", "migrations/17.0.1.0.0/noupdate_changes.xml"
     )


### PR DESCRIPTION
Use env in openupgrade load_data instead of cr

As stated in https://github.com/OCA/openupgradelib/blob/master/openupgradelib/openupgrade.py#L297, the param should `env`, instead of the cursor

@Tecnativa