### PR TITLE
[16.0][FIX] account_chart_update_multilang: error when English language is not active.

### DIFF
--- a/account_chart_update_multilang/tests/test_account_chart_update_multilang.py
+++ b/account_chart_update_multilang/tests/test_account_chart_update_multilang.py
@@ -32,7 +32,7 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
             ]
         )
         self.assertEqual(
-            new_tax.with_context(lang="en_EN").description, "tax description eng"
+            new_tax.with_context(lang="en_US").description, "tax description eng"
         )
         self.assertEqual(new_tax.with_context(lang="es_ES").name, "tax name es")
         self.assertEqual(
@@ -42,3 +42,15 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
         self.assertEqual(
             new_tax.with_context(lang="fr_FR").description, "tax description fr"
         )
+
+    def test_update_taxes_with_english_deactivate(self):
+        # When English is not active the chart update should work also
+        self.env["res.partner"].with_context(active_test=False).search([]).write(
+            {"lang": "es_ES"}
+        )
+        self.env["res.users"].with_context(active_test=False).search([]).write(
+            {"lang": "es_ES"}
+        )
+        lang_model = self.env["res.lang"]
+        lang_model.search([("code", "=", "en_US")]).write({"active": False})
+        self.test_update_taxes()

--- a/account_chart_update_multilang/wizards/wizard_chart_update.py
+++ b/account_chart_update_multilang/wizards/wizard_chart_update.py
@@ -16,7 +16,7 @@ class WizardUpdateChartsAccount(models.TransientModel):
 
     def _get_lang_selection_options(self):
         """Only can translate in base language by default."""
-        en = self.env["res.lang"]._lang_get("en_US")
+        en = self.env.ref("base.lang_en")
         return [(en.code, en.name)]
 
     def _update_other_langs(self, templates):


### PR DESCRIPTION
This fix makes possible to use this module without English language active. Other wise an error pop up making imposible to run the chart update!

https://www.loom.com/share/b4471a476624411f82c3f4b3e54a0833?sid=56654f95-8e28-44b3-83ff-73c3aafd63ac

@moduon MT-8060

@Shide @yajo @rafaelbn please review, if you can.