### PR TITLE
[FIX] [16.0] account_chart_update: Write Chart Template on Company only when changes

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -433,8 +433,9 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 self._update_taxes_pending_for_accounts(todo_dict)
             if self.update_fiscal_position and perform_rest:
                 self._update_fiscal_positions()
-            # Store new chart in the company
-            self.company_id.chart_template_id = self.chart_template_id
+            # Store new chart in the company if has been changed
+            if self.company_id.chart_template_id != self.chart_template_id:
+                self.company_id.chart_template_id = self.chart_template_id
             _logger.removeHandler(handler)
             self.log = log_output.getvalue()
         # Check if errors where detected and wether we should stop.


### PR DESCRIPTION
Do not write Chart Template on Company if it's the same Chart Template.

This will avoid some unwanted writes when Chart Template is set.
Eg.: https://github.com/OCA/l10n-spain/blob/16.0/l10n_es_vat_prorate/models/res_company.py#L32

MT-8222 @moduon @rafaelbn @Gelojr @fcvalgar please review if you want :)