### PR TITLE
[16.0][FIX] account_asset_management: fix asset report

### DIFF
--- a/account_asset_management/report/account_asset_report_xls.py
+++ b/account_asset_management/report/account_asset_report_xls.py
@@ -499,7 +499,7 @@ class AssetReportXlsx(models.AbstractModel):
                 lambda r: r.type == "depreciate"
             )
             dls_all = dls_all.sorted(key=lambda r: r.line_date)
-            if not dls_all:
+            if not dls_all and asset.method_number:
                 error_dict["no_table"] += asset
             # period_start_value
             dls = dls_all.filtered(lambda r: r.line_date <= wiz.date_from)


### PR DESCRIPTION
The Financial Assets report generates an error message where there is an asset without depreciation table.
This is ok for most assets but not for those with method_number = 0 which is the case for assets of type 'Land and Buildings'.