### PR TITLE
[16.0][FIX] account_chart_update: Translatable fields without transla…

### DIFF
--- a/account_chart_update_multilang/tests/test_account_chart_update_multilang.py
+++ b/account_chart_update_multilang/tests/test_account_chart_update_multilang.py
@@ -54,3 +54,20 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
         lang_model = self.env["res.lang"]
         lang_model.search([("code", "=", "en_US")]).write({"active": False})
         self.test_update_taxes()
+
+    def test_update_fiscal_position(self):
+        """Fiscal position without translations should not be taking into
+        account of being translated."""
+        self.fp_template.note = ""
+        wizard = self.wizard_obj.create(self.wizard_vals)
+        wizard.action_find_records()
+        wizard.action_update_records()
+        new_fp = self.env["account.fiscal.position"].search(
+            [
+                ("name", "=", self.fp_template.name),
+                ("company_id", "=", self.company.id),
+            ]
+        )
+        self.assertEqual(new_fp.with_context(lang="en_US").note, self.fp_template.note)
+        self.assertEqual(new_fp.with_context(lang="es_ES").note, self.fp_template.note)
+        self.assertEqual(new_fp.with_context(lang="fr_FR").note, self.fp_template.note)

--- a/account_chart_update_multilang/wizards/wizard_chart_update.py
+++ b/account_chart_update_multilang/wizards/wizard_chart_update.py
@@ -31,8 +31,11 @@ class WizardUpdateChartsAccount(models.TransientModel):
             for key in self._diff_translate_fields(template, rec):
                 for lang in self._other_langs():
                     field = rec._fields[key]
-                    old_value = field._get_stored_translations(rec).get(
-                        rec.env.lang, "en_US"
+                    stored_translation_rec = field._get_stored_translations(rec)
+                    if not stored_translation_rec:
+                        continue
+                    old_value = (
+                        stored_translation_rec.get(rec.env.lang or "en_US") or ""
                     )
                     if old_value.startswith("<p>") and old_value.endswith("</p>"):
                         old_value = old_value[3:-4]


### PR DESCRIPTION
…tions may raise errors as its fetched by the wizard but has no translated value

This fix has been made in cases where there are differences in the translation but there is no prior definition in the field (e.g. the field was originally empty).

@moduon MT-8280

@EmilioPascual  @yajo @rafaelbn please review, if you can.