### PR TITLE
[18.0][IMP] account_journal_restrict_mode: do not force hash on bank and cash journals

### DIFF
--- a/account_journal_restrict_mode/README.rst
+++ b/account_journal_restrict_mode/README.rst
@@ -29,24 +29,20 @@ Account Journal Restrict Mode
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module enables by default the setting *Lock Posted Entries with
-Hash* in all Journals and prevents the setting to be modified.
+Hash* in all Sales, Purchase and Miscellaneous Journals, and prevents
+the setting to be modified.
 
 The goal is to assure that all journal entries are locked when posted to
 prevent them to be modified.
+
+Bank and Cash journals can't be hashed as it conflicts with Odoo's logic
+when creating bank transactions
+(https://github.com/odoo/odoo/commit/9740189bc59658a62da6a624e166505841ac30a4).
 
 **Table of contents**
 
 .. contents::
    :local:
-
-Known issues / Roadmap
-======================
-
-- Odoo hides the setting *Lock Posted Entries with Hash* on Bank and
-  Cash Journals, but enabling it does not cause issues in the
-  reconciliation for now. If the Odoo logic changes at any point, the
-  module may need to be adapted to only force the setting on other types
-  of journals.
 
 Bug Tracker
 ===========
@@ -69,7 +65,7 @@ Authors
 Contributors
 ------------
 
-- Jordi Masvidal <jordi.masvidal@forgeflow.com>
+-  Jordi Masvidal <jordi.masvidal@forgeflow.com>
 
 Maintainers
 -----------

--- a/account_journal_restrict_mode/hooks.py
+++ b/account_journal_restrict_mode/hooks.py
@@ -5,6 +5,9 @@
 def post_init_hook(env):
     """Enable restrict mode on all journals"""
     journals_to_update = env["account.journal"].search(
-        [("restrict_mode_hash_table", "=", False)]
+        [
+            ("restrict_mode_hash_table", "=", False),
+            ("type", "in", ["sale", "purchase", "general"]),
+        ]
     )
     journals_to_update.write({"restrict_mode_hash_table": True})

--- a/account_journal_restrict_mode/models/account_journal.py
+++ b/account_journal_restrict_mode/models/account_journal.py
@@ -10,10 +10,10 @@ class AccountJournal(models.Model):
     _inherit = "account.journal"
 
     restrict_mode_hash_table = fields.Boolean(
-        default=lambda self: self._default_restrict_mode_hash_table(), readonly=True
+        compute="_compute_restrict_mode_hash_table", store=True, readonly=True
     )
 
-    @api.constrains("restrict_mode_hash_table")
+    @api.constrains("restrict_mode_hash_table", "type")
     def _check_journal_restrict_mode(self):
         test_condition = not config["test_enable"] or (
             config["test_enable"]
@@ -22,15 +22,24 @@ class AccountJournal(models.Model):
         if not test_condition:
             return
         for rec in self:
-            if not rec.restrict_mode_hash_table:
+            if not rec.restrict_mode_hash_table and rec.type in [
+                "sale",
+                "purchase",
+                "general",
+            ]:
                 raise UserError(
                     self.env._("Journal %s must have Lock Posted Entries enabled.")
                     % rec.name
                 )
 
-    def _default_restrict_mode_hash_table(self):
+    @api.depends("type")
+    def _compute_restrict_mode_hash_table(self):
         test_condition = not config["test_enable"] or (
             config["test_enable"]
             and self.env.context.get("test_account_journal_restrict_mode")
         )
-        return bool(test_condition)
+        for rec in self:
+            if not test_condition:
+                rec.restrict_mode_hash_table = False
+                continue
+            rec.restrict_mode_hash_table = rec.type in ["sale", "purchase", "general"]

--- a/account_journal_restrict_mode/readme/DESCRIPTION.md
+++ b/account_journal_restrict_mode/readme/DESCRIPTION.md
@@ -1,5 +1,9 @@
 This module enables by default the setting *Lock Posted Entries with
-Hash* in all Journals and prevents the setting to be modified.
+Hash* in all Sales, Purchase and Miscellaneous Journals, and prevents
+the setting to be modified.
 
 The goal is to assure that all journal entries are locked when posted to
 prevent them to be modified.
+
+Bank and Cash journals can't be hashed as it conflicts with Odoo's logic when
+creating bank transactions (https://github.com/odoo/odoo/commit/9740189bc59658a62da6a624e166505841ac30a4).

--- a/account_journal_restrict_mode/readme/ROADMAP.md
+++ b/account_journal_restrict_mode/readme/ROADMAP.md
@@ -1,5 +1,0 @@
-- Odoo hides the setting *Lock Posted Entries with Hash* on Bank and
-  Cash Journals, but enabling it does not cause issues in the
-  reconciliation for now. If the Odoo logic changes at any point, the
-  module may need to be adapted to only force the setting on other types
-  of journals.

--- a/account_journal_restrict_mode/static/description/index.html
+++ b/account_journal_restrict_mode/static/description/index.html
@@ -371,34 +371,27 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/account-financial-tools/tree/18.0/account_journal_restrict_mode"><img alt="OCA/account-financial-tools" src="https://img.shields.io/badge/github-OCA%2Faccount--financial--tools-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/account-financial-tools-18-0/account-financial-tools-18-0-account_journal_restrict_mode"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/account-financial-tools&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module enables by default the setting <em>Lock Posted Entries with
-Hash</em> in all Journals and prevents the setting to be modified.</p>
+Hash</em> in all Sales, Purchase and Miscellaneous Journals, and prevents
+the setting to be modified.</p>
 <p>The goal is to assure that all journal entries are locked when posted to
 prevent them to be modified.</p>
+<p>Bank and Cash journals can’t be hashed as it conflicts with Odoo’s logic
+when creating bank transactions
+(<a class="reference external" href="https://github.com/odoo/odoo/commit/9740189bc59658a62da6a624e166505841ac30a4">https://github.com/odoo/odoo/commit/9740189bc59658a62da6a624e166505841ac30a4</a>).</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-1">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
-<div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-1">Known issues / Roadmap</a></h1>
-<ul class="simple">
-<li>Odoo hides the setting <em>Lock Posted Entries with Hash</em> on Bank and
-Cash Journals, but enabling it does not cause issues in the
-reconciliation for now. If the Odoo logic changes at any point, the
-module may need to be adapted to only force the setting on other types
-of journals.</li>
-</ul>
-</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-financial-tools/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -406,21 +399,21 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
 <ul class="simple">
 <li>ForgeFlow S.L.</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
 <ul class="simple">
 <li>Jordi Masvidal &lt;<a class="reference external" href="mailto:jordi.masvidal&#64;forgeflow.com">jordi.masvidal&#64;forgeflow.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />


### PR DESCRIPTION
Forcing the hashing of bank and cash journals results in errors when creating bank transactions, due to the commit added in Odoo: https://github.com/odoo/odoo/commit/9740189bc59658a62da6a624e166505841ac30a4

We make the restrict mode field computed in order to force the value correctly based on the journal type.