### PR TITLE
[16.0][IMP] account_lock_to_date: Update the accounting block based on a number of days after today's date

### DIFF
--- a/account_lock_to_date/README.rst
+++ b/account_lock_to_date/README.rst
@@ -65,6 +65,7 @@ Authors
 ~~~~~~~
 
 * ForgeFlow
+* Innovyou
 
 Contributors
 ~~~~~~~~~~~~

--- a/account_lock_to_date/__manifest__.py
+++ b/account_lock_to_date/__manifest__.py
@@ -1,19 +1,21 @@
 # Copyright 2019 ForgeFlow S.L.
 # Copyright 2023 Simone Rubino - Aion Tech
+# Copyright 2025 Innovyou
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": "Account Lock To Date",
     "summary": """
         Allows to set an account lock date in the future.""",
-    "version": "16.0.1.0.0",
+    "version": "16.0.2.0.0",
     "license": "AGPL-3",
-    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "author": "ForgeFlow, Innovyou, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-financial-tools",
     "installable": True,
     "depends": ["account"],
     "data": [
         "security/ir.model.access.csv",
         "wizards/account_update_lock_to_date.xml",
+        "data/cron.xml",
     ],
 }

--- a/account_lock_to_date/data/cron.xml
+++ b/account_lock_to_date/data/cron.xml
@@ -1,0 +1,13 @@
+<odoo>
+    <record id="ir_cron_account_lock_to_date_periodic" model="ir.cron">
+        <field name="name">Account Lock To Date Periodic</field>
+        <field name="model_id" ref="base.model_res_company" />
+        <field name="state">code</field>
+        <field name="code">model.update_lock_to_date_periodic()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field name="doall">False</field>
+        <field name="active">True</field>
+    </record>
+</odoo>

--- a/account_lock_to_date/models/res_company.py
+++ b/account_lock_to_date/models/res_company.py
@@ -27,6 +27,31 @@ class ResCompany(models.Model):
         help="No users, including Advisers, can edit accounts after "
         "this date. Use it for fiscal year locking for example.",
     )
+    is_lock_to_date_periodic = fields.Boolean(
+        string="Lock Date Periodic", default=False
+    )
+    lock_to_date_periodicity_advisers = fields.Integer(
+        string="Periodicity for Advisers",
+        default="15",
+        help="Number of days after which all users, including advisers, "
+        "cannot write in accounting.",
+    )
+    lock_to_date_periodicity = fields.Integer(
+        string="Periodicity for Non-Advisers",
+        default="15",
+        help="Number of days after which non-advisers cannot write in accounting.",
+    )
+
+    def update_lock_to_date_periodic(self):
+        company_ids = self.env["res.company"].search([])
+        for company in company_ids:
+            if company.is_lock_to_date_periodic:
+                company.fiscalyear_lock_to_date = datetime.now() + relativedelta(
+                    days=company.lock_to_date_periodicity_advisers + 1
+                )
+                company.period_lock_to_date = datetime.now() + relativedelta(
+                    days=company.lock_to_date_periodicity + 1
+                )
 
     def write(self, vals):
         # fiscalyear_lock_date can't be set to a prior date

--- a/account_lock_to_date/static/description/index.html
+++ b/account_lock_to_date/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -407,6 +408,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
 <ul class="simple">
 <li>ForgeFlow</li>
+<li>Innovyou</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -426,7 +428,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_lock_to_date/wizards/account_update_lock_to_date.py
+++ b/account_lock_to_date/wizards/account_update_lock_to_date.py
@@ -1,6 +1,8 @@
 # Copyright 2019 ForgeFlow S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import datetime, timedelta
+
 from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -27,6 +29,22 @@ class AccountUpdateLockToDate(models.TransientModel):
         "inclusive of this date. Use it for fiscal year locking for "
         "example.",
     )
+    is_lock_to_date_periodic = fields.Boolean(
+        string="Express the interval as number of days.",
+        help="Express the interval as number of days.",
+        default=False,
+    )
+    lock_to_date_periodicity_advisers = fields.Integer(
+        string="Periodicity for Advisers",
+        default="30",
+        help="Number of days after which all users, including advisers, "
+        "cannot write in accounting.",
+    )
+    lock_to_date_periodicity = fields.Integer(
+        string="Periodicity for Non-Advisers",
+        default="15",
+        help="Number of days after which non-advisers cannot write in accounting.",
+    )
 
     @api.model
     def default_get(self, field_list):
@@ -35,8 +53,11 @@ class AccountUpdateLockToDate(models.TransientModel):
         res.update(
             {
                 "company_id": company.id,
+                "is_lock_to_date_periodic": company.is_lock_to_date_periodic,
                 "period_lock_to_date": company.period_lock_to_date,
                 "fiscalyear_lock_to_date": company.fiscalyear_lock_to_date,
+                "lock_to_date_periodicity_advisers": company.lock_to_date_periodicity_advisers,
+                "lock_to_date_periodicity": company.lock_to_date_periodicity,
             }
         )
         return res
@@ -50,9 +71,32 @@ class AccountUpdateLockToDate(models.TransientModel):
     def execute(self):
         self.ensure_one()
         self._check_execute_allowed()
-        self.company_id.sudo().write(
-            {
-                "period_lock_to_date": self.period_lock_to_date,
-                "fiscalyear_lock_to_date": self.fiscalyear_lock_to_date,
-            }
-        )
+        if self.is_lock_to_date_periodic:
+            if (
+                not self.lock_to_date_periodicity_advisers
+                or not self.lock_to_date_periodicity
+            ):
+                raise ValidationError(
+                    _("Please input a number of days for the lock to date.")
+                )
+            self.company_id.sudo().write(
+                {
+                    "is_lock_to_date_periodic": self.is_lock_to_date_periodic,
+                    "lock_to_date_periodicity": self.lock_to_date_periodicity,
+                    "lock_to_date_periodicity_advisers": self.lock_to_date_periodicity_advisers,
+                    "period_lock_to_date": datetime.now().date()
+                    + timedelta(days=self.lock_to_date_periodicity),
+                    "fiscalyear_lock_to_date": datetime.now().date()
+                    + timedelta(days=self.lock_to_date_periodicity_advisers),
+                }
+            )
+        else:
+            self.company_id.sudo().write(
+                {
+                    "is_lock_to_date_periodic": self.is_lock_to_date_periodic,
+                    "lock_to_date_periodicity": self.lock_to_date_periodicity,
+                    "lock_to_date_periodicity_advisers": self.lock_to_date_periodicity_advisers,
+                    "period_lock_to_date": self.period_lock_to_date,
+                    "fiscalyear_lock_to_date": self.fiscalyear_lock_to_date,
+                }
+            )

--- a/account_lock_to_date/wizards/account_update_lock_to_date.xml
+++ b/account_lock_to_date/wizards/account_update_lock_to_date.xml
@@ -15,8 +15,23 @@
                             options="{'no_create': True}"
                             groups="base.group_multi_company"
                         />
-                        <field name="period_lock_to_date" />
-                        <field name="fiscalyear_lock_to_date" />
+                        <field name="is_lock_to_date_periodic" />
+                        <field
+                            name="lock_to_date_periodicity"
+                            attrs="{'invisible': [('is_lock_to_date_periodic', '=', False)]}"
+                        />
+                        <field
+                            name="lock_to_date_periodicity_advisers"
+                            attrs="{'invisible': [('is_lock_to_date_periodic', '=', False)]}"
+                        />
+                        <field
+                            name="period_lock_to_date"
+                            attrs="{'invisible': [('is_lock_to_date_periodic', '=', True)]}"
+                        />
+                        <field
+                            name="fiscalyear_lock_to_date"
+                            attrs="{'invisible': [('is_lock_to_date_periodic', '=', True)]}"
+                        />
                     </group>
                 </sheet>
                 <footer>


### PR DESCRIPTION
These changes improve the date-based accounting lock wizard. 
Now a number of days from today on which blocks will be implemented can be selected.
A cron takes care of updating the date each day.