### PR TITLE
[15.0][FIX]account_spread_cost_revenue: Total amount different currency

### DIFF
--- a/account_spread_cost_revenue/README.rst
+++ b/account_spread_cost_revenue/README.rst
@@ -203,6 +203,7 @@ Contributors
 * Andrea Stirpe <a.stirpe@onestein.nl>
 * Kitti U. <kittiu@ecosoft.co.th>
 * Saran Lim. <saranl@ecosoft.co.th>
+* Manuel Regidor <manuel.regidor@sygel.es>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/account_spread_cost_revenue/models/account_spread.py
+++ b/account_spread_cost_revenue/models/account_spread.py
@@ -191,7 +191,7 @@ class AccountSpread(models.Model):
             posted_amount = sum(spread_line.amount for spread_line in lines_posted)
             total_amount = spread.estimated_amount
             if spread.invoice_line_id:
-                total_amount = spread.invoice_line_id.currency_id._convert(
+                total_amount = spread.invoice_line_id.company_currency_id._convert(
                     spread.invoice_line_id.balance,
                     spread.currency_id,
                     spread.company_id,

--- a/account_spread_cost_revenue/readme/CONTRIBUTORS.rst
+++ b/account_spread_cost_revenue/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Andrea Stirpe <a.stirpe@onestein.nl>
 * Kitti U. <kittiu@ecosoft.co.th>
 * Saran Lim. <saranl@ecosoft.co.th>
+* Manuel Regidor <manuel.regidor@sygel.es>

--- a/account_spread_cost_revenue/static/description/index.html
+++ b/account_spread_cost_revenue/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -551,6 +550,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Andrea Stirpe &lt;<a class="reference external" href="mailto:a.stirpe&#64;onestein.nl">a.stirpe&#64;onestein.nl</a>&gt;</li>
 <li>Kitti U. &lt;<a class="reference external" href="mailto:kittiu&#64;ecosoft.co.th">kittiu&#64;ecosoft.co.th</a>&gt;</li>
 <li>Saran Lim. &lt;<a class="reference external" href="mailto:saranl&#64;ecosoft.co.th">saranl&#64;ecosoft.co.th</a>&gt;</li>
+<li>Manuel Regidor &lt;<a class="reference external" href="mailto:manuel.regidor&#64;sygel.es">manuel.regidor&#64;sygel.es</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">


### PR DESCRIPTION
**Before this fix**

A new vendor bill is created using a different currency (EUR) from the company's currency (USD):
![spread_1](https://github.com/user-attachments/assets/2c0cc631-e58f-45b4-ba80-e36a0b9ea703)

The exchange rate is as follows
![spread_2](https://github.com/user-attachments/assets/1010edac-48c3-4505-ae39-47f3b2ce57b5)

so the journal items are as follows:
![spread_3](https://github.com/user-attachments/assets/d2df214a-2591-4c3f-9471-cbaef617cc7a)

The invoice line is linked to a new spread board using the wizard:
![spread_4](https://github.com/user-attachments/assets/e26f5503-a7f3-4202-ae8c-800f68a40ac4)

"Total Amount" in the spread board does not match the value of the journal item, as the exchange rate is applied twice:
![spread_5](https://github.com/user-attachments/assets/59783701-c627-4879-8c7a-7375728f7e22)
![spread_6](https://github.com/user-attachments/assets/4e176cfa-47a3-4c5e-b2d8-e3bd04681a93)

**After this fix**

This fix sorts that issue out, as it can be seen in the followin screenshot:
![spread_7](https://github.com/user-attachments/assets/29b037a0-62c7-4dd8-9cdd-a59532d8e689)

I-6788