### PR TITLE
[17.0][FIX] account_move_line_purchase_info: name_get is deprecated

### DIFF
--- a/account_move_line_purchase_info/models/purchase_order_line.py
+++ b/account_move_line_purchase_info/models/purchase_order_line.py
@@ -1,18 +1,18 @@
 # Copyright 2019-2020 ForgeFlow S.L.
 #   (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-from odoo import models
+from odoo import api, models
 
 
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
-    def name_get(self):
-        result = []
-        orig_name = dict(super().name_get())
+    @api.depends("name", "order_id.name", "order_id.state")
+    @api.depends_context("po_line_info")
+    def _compute_display_name(self):
+        if not self.env.context.get("po_line_info", False):
+            return super()._compute_display_name()
         for line in self:
-            name = orig_name[line.id]
-            if self.env.context.get("po_line_info", False):
-                name = f"[{line.order_id.name}] {name} ({line.order_id.state})"
-            result.append((line.id, name))
-        return result
+            line.display_name = (
+                f"[{line.order_id.name}] {line.name} ({line.order_id.state})"
+            )


### PR DESCRIPTION
Use _compute_display_name instead.

![Selection_4324](https://github.com/user-attachments/assets/6034c36a-4faa-4e64-a52f-d4a4bf071cfa)
