### PR TITLE
[16.0][IMP]account_invoice_constraint_chronology: imp domain in raise

### DIFF
--- a/account_invoice_constraint_chronology/model/account_move.py
+++ b/account_invoice_constraint_chronology/model/account_move.py
@@ -128,10 +128,22 @@ class AccountMove(models.Model):
     def _raise_sequence_order_conflicting_previously_validated(self):
         self.ensure_one()
         before_inv = self.search(
-            self._conflicting_inv_after_sequence_before_inv_date_domain(), limit=1
+            expression.AND(
+                [
+                    self._get_conflicting_invoices_domain(),
+                    self._conflicting_inv_after_sequence_before_inv_date_domain(),
+                ]
+            ),
+            limit=1,
         )
         after_inv = self.search(
-            self._conflicting_inv_before_sequence_after_inv_date_domain(), limit=1
+            expression.AND(
+                [
+                    self._get_conflicting_invoices_domain(),
+                    self._conflicting_inv_before_sequence_after_inv_date_domain(),
+                ]
+            ),
+            limit=1,
         )
         if after_inv:
             time = "before"


### PR DESCRIPTION
When there is a chronological error in account.move, and when displaying the message, the method _raise_sequence_order_conflicting_previously_validated searches for the first invoice it finds with a sequence conflict. However, it only takes into account the invoice date and the sequence—not the journal or the move type—so it shows sequences that are actually not incompatible with the current one.

This pull request includes changes to the `account_invoice_constraint_chronology/model/account_move.py` file to improve the search functionality by combining multiple domain expressions using the `expression.AND` method. The most important change is the modification of the `_raise_sequence_order_conflicting_previously_validated` method to use more comprehensive domain expressions.

Improvements to search functionality:

* [`account_invoice_constraint_chronology/model/account_move.py`](diffhunk://#diff-c16df72e6466e95b283d62a76c23b1e5b7e6df7678fb0c877ce0b91b7225beceL131-R142): Modified the `_raise_sequence_order_conflicting_previously_validated` method to combine domain expressions using `expression.AND` for more accurate search results.