### PR TITLE
[16.0][FIX] account_asset_management: Avoid to skip tests when no CoA found

### DIFF
--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -7,9 +7,8 @@ import calendar
 import time
 from datetime import date, datetime
 
-from odoo import Command, fields
-from odoo.tests import tagged
-from odoo.tests.common import Form
+from odoo import SUPERUSER_ID, Command, api, fields, registry
+from odoo.tests import Form, get_db_name, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
@@ -17,8 +16,14 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 @tagged("post_install", "-at_install")
 class TestAssetManagement(AccountTestInvoicingCommon):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpClass(cls, chart_template_ref=None):
+        with registry(get_db_name()).cursor() as cr:
+            env = api.Environment(cr, SUPERUSER_ID, {})
+            if not env.ref("l10n_generic_coa.configurable_chart_template", False):
+                # Fallback for executing tests in any existing CoA
+                coa = env["account.chart.template"].search([("visible", "=", True)])[:1]
+                chart_template_ref = coa.get_external_id()[coa.id]
+        super().setUpClass(chart_template_ref=chart_template_ref)
         # ENVIRONMENTS
         cls.asset_model = cls.env["account.asset"]
         cls.asset_profile_model = cls.env["account.asset.profile"]

--- a/account_asset_management/tests/test_asset_management_xls.py
+++ b/account_asset_management/tests/test_asset_management_xls.py
@@ -2,8 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import time
 
-from odoo import fields
-from odoo.tests import tagged
+from odoo import SUPERUSER_ID, api, fields, registry
+from odoo.tests import get_db_name, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
@@ -11,8 +11,14 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 @tagged("post_install", "-at_install")
 class TestAssetManagementXls(AccountTestInvoicingCommon):
     @classmethod
-    def setUpClass(cls):
-        super(TestAssetManagementXls, cls).setUpClass()
+    def setUpClass(cls, chart_template_ref=None):
+        with registry(get_db_name()).cursor() as cr:
+            env = api.Environment(cr, SUPERUSER_ID, {})
+            if not env.ref("l10n_generic_coa.configurable_chart_template", False):
+                # Fallback for executing tests in any existing CoA
+                coa = env["account.chart.template"].search([("visible", "=", True)])[:1]
+                chart_template_ref = coa.get_external_id()[coa.id]
+        super().setUpClass(chart_template_ref=chart_template_ref)
 
         module = __name__.split("addons.")[1].split(".")[0]
         cls.xls_report_name = "{}.asset_report_xls".format(module)


### PR DESCRIPTION
Since odoo/odoo@d0342c8, default existing company is not getting a CoA automatically, provoking that these tests are skipped in this case.

We provide a default CoA between existing in that case, and for that, we have to populate a Odoo environment before calling super for gathering the needed information, as both the initialization and the skip is done in super method.

@Tecnativa 