### PR TITLE
[FIX] account_asset_force_account: Fixed asset_account_id computation

### DIFF
--- a/account_asset_force_account/models/account_asset.py
+++ b/account_asset_force_account/models/account_asset.py
@@ -11,6 +11,7 @@ class AccountAsset(models.Model):
         string="Asset Account",
         compute="_compute_account_asset_id",
         help="The account used to record the value of the asset.",
+        store=True,
     )
 
     account_depreciation_id = fields.Many2one(
@@ -37,6 +38,7 @@ class AccountAsset(models.Model):
             self.account_expense_depreciation_id = (
                 self.profile_id.account_expense_depreciation_id
             )
+            self._compute_account_asset_id()
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -51,10 +53,19 @@ class AccountAsset(models.Model):
                     ] = profile.account_expense_depreciation_id.id
         return super().create(vals_list)
 
+    @api.depends("account_move_line_ids", "profile_id")
     def _compute_account_asset_id(self):
-        if len(self.account_move_line_ids.account_id) != 0:
-            self.account_asset_id = self.account_move_line_ids.sorted(
-                lambda line: line.create_date
-            ).account_id[0]
-            return
-        self.account_asset_id = self.profile_id.account_asset_id
+        for record in self:
+            # Cannot update the account_asset_id if the asset is not in draft state
+            if record.state != "draft":
+                continue
+            # Looks if the asset comes from an invoice, if so, takes the account from the invoice
+            if len(record.account_move_line_ids.account_id) != 0:
+                invoice_line = record.account_move_line_ids.filtered(
+                    lambda line: line.move_id.move_type == "in_invoice"
+                )
+                if invoice_line:
+                    record.account_asset_id = invoice_line.account_id
+                    continue
+            # If not, takes the account from the profile
+            record.account_asset_id = record.profile_id.account_asset_id


### PR DESCRIPTION
This fixes a bug when assets where not generated from an invoice, wich when the first move from the asset where created changes the asset_account_id for the depreciation account

cc https://github.com/APSL 3927

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review