### PR TITLE
[16.0][FIX] account_cash_deposit: Post-install test + fallback to load CoA

### DIFF
--- a/account_cash_deposit/README.rst
+++ b/account_cash_deposit/README.rst
@@ -40,9 +40,7 @@ Configuration
 
 First, for each currency of your cash boxes, you must define the bank notes and coin rolls for that currency (coin rolls are often standardised by the Central Bank). You can also definie the coins, but it's not useful if your bank only accept coin rolls and not coins.
 
-.. figure:: https://raw.githubusercontent.com/OCA/account-financial-tools/16.0/account_cash_deposit/static/description/currency_form_view.png
-   :scale: 100 %
-   :alt: Currency form view
+.. image:: https://raw.githubusercontent.com/OCA/account-financial-tools/16.0/account_cash_deposit/static/description/currency_form_view.png
 
 To save time for new users, this module provides the bank notes, coins and coin rolls for several currencies (EUR, USD, CAD, etc.). If it is not the case for your currency, it would be very nice of you to contribute it (you can use the file *account_cash_deposit/data/cash_unit_eur.xml* as an example).
 
@@ -58,9 +56,7 @@ To create a new cash **deposit**, go to the menu *Invoicing > Accounting > Misce
 * credits the cash account,
 * debits the inter-banks transfer account.
 
-.. figure:: https://raw.githubusercontent.com/OCA/account-financial-tools/16.0/account_cash_deposit/static/description/cash_deposit_form.png
-   :scale: 100 %
-   :alt: Cash Deposit form view
+.. image:: https://raw.githubusercontent.com/OCA/account-financial-tools/16.0/account_cash_deposit/static/description/cash_deposit_form.png
 
 The process is very similar when **ordering** cash but you have to use another menu entry: menu *Invoicing > Accounting > Miscellaneous > Cash Orders*. Select the currency, the cash box that will receive the cash and the bank account from which the bank will take the money. Create/edit lines to enter the details of your order (bank notes, coin rolls). Then, you can confirm the order and print a PDF report designed to be sent to your bank as a cash order. Eventually, when the bank delivers the cash to you, you should validate the cash order and Odoo will generate a journal entry in the cash journal that:
 

--- a/account_cash_deposit/readme/CONFIGURE.rst
+++ b/account_cash_deposit/readme/CONFIGURE.rst
@@ -1,8 +1,6 @@
 First, for each currency of your cash boxes, you must define the bank notes and coin rolls for that currency (coin rolls are often standardised by the Central Bank). You can also definie the coins, but it's not useful if your bank only accept coin rolls and not coins.
 
-.. figure:: static/description/currency_form_view.png
-   :scale: 100 %
-   :alt: Currency form view
+.. image:: ../static/description/currency_form_view.png
 
 To save time for new users, this module provides the bank notes, coins and coin rolls for several currencies (EUR, USD, CAD, etc.). If it is not the case for your currency, it would be very nice of you to contribute it (you can use the file *account_cash_deposit/data/cash_unit_eur.xml* as an example).
 

--- a/account_cash_deposit/readme/USAGE.rst
+++ b/account_cash_deposit/readme/USAGE.rst
@@ -3,9 +3,7 @@ To create a new cash **deposit**, go to the menu *Invoicing > Accounting > Misce
 * credits the cash account,
 * debits the inter-banks transfer account.
 
-.. figure:: static/description/cash_deposit_form.png
-   :scale: 100 %
-   :alt: Cash Deposit form view
+.. image:: ../static/description/cash_deposit_form.png
 
 The process is very similar when **ordering** cash but you have to use another menu entry: menu *Invoicing > Accounting > Miscellaneous > Cash Orders*. Select the currency, the cash box that will receive the cash and the bank account from which the bank will take the money. Create/edit lines to enter the details of your order (bank notes, coin rolls). Then, you can confirm the order and print a PDF report designed to be sent to your bank as a cash order. Eventually, when the bank delivers the cash to you, you should validate the cash order and Odoo will generate a journal entry in the cash journal that:
 

--- a/account_cash_deposit/static/description/index.html
+++ b/account_cash_deposit/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -388,9 +388,7 @@ ul.auto-toc {
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
 <p>First, for each currency of your cash boxes, you must define the bank notes and coin rolls for that currency (coin rolls are often standardised by the Central Bank). You can also definie the coins, but it’s not useful if your bank only accept coin rolls and not coins.</p>
-<div class="figure">
-<img alt="Currency form view" src="https://raw.githubusercontent.com/OCA/account-financial-tools/16.0/account_cash_deposit/static/description/currency_form_view.png" />
-</div>
+<img alt="https://raw.githubusercontent.com/OCA/account-financial-tools/16.0/account_cash_deposit/static/description/currency_form_view.png" src="https://raw.githubusercontent.com/OCA/account-financial-tools/16.0/account_cash_deposit/static/description/currency_form_view.png" />
 <p>To save time for new users, this module provides the bank notes, coins and coin rolls for several currencies (EUR, USD, CAD, etc.). If it is not the case for your currency, it would be very nice of you to contribute it (you can use the file <em>account_cash_deposit/data/cash_unit_eur.xml</em> as an example).</p>
 <p>To save time when encoding the cash deposits/orders, you can set the parameter <em>Auto Create</em> on the bank notes and/or coin rolls that you use very often.</p>
 <p>On the Accounting configuration page, in the section <em>Bank &amp; Cash</em>, the <em>Inter-Banks Transfer Account</em> must be configured.</p>
@@ -402,9 +400,7 @@ ul.auto-toc {
 <li>credits the cash account,</li>
 <li>debits the inter-banks transfer account.</li>
 </ul>
-<div class="figure">
-<img alt="Cash Deposit form view" src="https://raw.githubusercontent.com/OCA/account-financial-tools/16.0/account_cash_deposit/static/description/cash_deposit_form.png" />
-</div>
+<img alt="https://raw.githubusercontent.com/OCA/account-financial-tools/16.0/account_cash_deposit/static/description/cash_deposit_form.png" src="https://raw.githubusercontent.com/OCA/account-financial-tools/16.0/account_cash_deposit/static/description/cash_deposit_form.png" />
 <p>The process is very similar when <strong>ordering</strong> cash but you have to use another menu entry: menu <em>Invoicing &gt; Accounting &gt; Miscellaneous &gt; Cash Orders</em>. Select the currency, the cash box that will receive the cash and the bank account from which the bank will take the money. Create/edit lines to enter the details of your order (bank notes, coin rolls). Then, you can confirm the order and print a PDF report designed to be sent to your bank as a cash order. Eventually, when the bank delivers the cash to you, you should validate the cash order and Odoo will generate a journal entry in the cash journal that:</p>
 <ul class="simple">
 <li>debits the cash account,</li>
@@ -436,7 +432,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_cash_deposit/tests/test_cash_deposit.py
+++ b/account_cash_deposit/tests/test_cash_deposit.py
@@ -4,37 +4,49 @@
 
 from datetime import date, timedelta
 
+from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
+@tagged("-at_install", "post_install")
 class TestAccountCashDeposit(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.company = self.env.ref("base.main_company")
-        self.currency = self.company.currency_id
-        self.cash_journal = self.env["account.journal"].search(
-            [("type", "=", "cash"), ("company_id", "=", self.company.id)], limit=1
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
+        cls.company = cls.env.company
+        cls.currency = cls.company.currency_id
+        cls.cash_journal = cls.env["account.journal"].search(
+            [("type", "=", "cash"), ("company_id", "=", cls.company.id)], limit=1
         )
-        self.bank_journal = self.env["account.journal"].search(
-            [("type", "=", "bank"), ("company_id", "=", self.company.id)], limit=1
+        cls.bank_journal = cls.env["account.journal"].search(
+            [("type", "=", "bank"), ("company_id", "=", cls.company.id)], limit=1
         )
-        self.cash_unit_note = self.env["cash.unit"].search(
-            [("currency_id", "=", self.currency.id), ("cash_type", "=", "note")],
+        cls.cash_unit_note = cls.env["cash.unit"].search(
+            [("currency_id", "=", cls.currency.id), ("cash_type", "=", "note")],
             limit=1,
         )
-        self.cash_unit_coinroll = self.env["cash.unit"].search(
-            [("currency_id", "=", self.currency.id), ("cash_type", "=", "coinroll")],
+        cls.cash_unit_coinroll = cls.env["cash.unit"].search(
+            [("currency_id", "=", cls.currency.id), ("cash_type", "=", "coinroll")],
             limit=1,
         )
-        self.all_cash_units = self.env["cash.unit"].search(
-            [("currency_id", "=", self.currency.id)]
+        cls.all_cash_units = cls.env["cash.unit"].search(
+            [("currency_id", "=", cls.currency.id)]
         )
-        self.date = date.today()
-        self.yesterday = date.today() - timedelta(days=1)
-        self.deposit_seq = self.env["ir.sequence"].search(
+        cls.date = date.today()
+        cls.yesterday = date.today() - timedelta(days=1)
+        cls.deposit_seq = cls.env["ir.sequence"].search(
             [("code", "=", "account.cash.deposit")]
         )
-        self.order_seq = self.env["ir.sequence"].search(
+        cls.order_seq = cls.env["ir.sequence"].search(
             [("code", "=", "account.cash.order")]
         )
 


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa