### PR TITLE
[17.0][ENH] account_asset_management: default salvage value on profile

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -57,6 +57,9 @@ class AccountAsset(models.Model):
         "\nPurchase Value - Salvage Value.",
     )
     salvage_value = fields.Monetary(
+        compute="_compute_salvage_value",
+        store=True,
+        readonly=False,
         help="The estimated value that an asset will realize upon "
         "its sale at the end of its useful life.\n"
         "This value is used to determine the depreciation amounts.",
@@ -261,6 +264,18 @@ class AccountAsset(models.Model):
                 asset.depreciation_line_ids.filtered("move_id")
             )
 
+    def _get_salvage_value_profile(self):
+        self.ensure_one()
+        salvage_value = self.profile_id.salvage_value
+        if self.profile_id.salvage_type == "percent":
+            salvage_value = (salvage_value / 100) * self.purchase_value
+        return salvage_value
+
+    @api.depends("profile_id")
+    def _compute_salvage_value(self):
+        for asset in self:
+            asset.salvage_value = asset._get_salvage_value_profile()
+
     @api.depends("purchase_value", "salvage_value", "method")
     def _compute_depreciation_base(self):
         for asset in self:
@@ -404,13 +419,7 @@ class AccountAsset(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         asset_ids = super().create(vals_list)
-        create_asset_from_move_line = self.env.context.get(
-            "create_asset_from_move_line"
-        )
         for asset_id in asset_ids:
-            if create_asset_from_move_line:
-                # Trigger compute of depreciation_base
-                asset_id.salvage_value = 0.0
             asset_id._create_first_asset_line()
         return asset_ids
 

--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -74,6 +74,15 @@ class AccountAssetProfile(models.Model):
         check_company=True,
         string="Asset Groups",
     )
+    salvage_value = fields.Float(
+        digits="Account",
+        help="The estimated value that an asset will realize upon "
+        "its sale at the end of its useful life.\n"
+        "This value is used to determine the depreciation amounts.",
+    )
+    salvage_type = fields.Selection(
+        selection=[("fixed", "Fixed"), ("percent", "Percentage of Price")]
+    )
     method = fields.Selection(
         selection=lambda self: self._selection_method(),
         string="Computation Method",

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -952,3 +952,30 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         last_line.create_move()
         self.assertEqual(asset.value_residual, 0)
         self.assertEqual(asset.state, "close")
+
+    def test_21_asset_profile_salvage_value(self):
+        """Compute salvage value from asset profile."""
+        # Case percent
+        self.car5y.salvage_type = "percent"
+        self.car5y.salvage_value = 5
+        asset = self.asset_model.create(
+            {
+                "name": "test asset",
+                "profile_id": self.car5y.id,
+                "purchase_value": 1000,
+                "date_start": time.strftime("%Y-07-07"),
+            }
+        )
+        self.assertEqual(asset.salvage_value, 50)
+        # Case fixed amount
+        self.car5y.salvage_type = "fixed"
+        self.car5y.salvage_value = 5
+        asset = self.asset_model.create(
+            {
+                "name": "test asset",
+                "profile_id": self.car5y.id,
+                "purchase_value": 1000,
+                "date_start": time.strftime("%Y-07-07"),
+            }
+        )
+        self.assertEqual(asset.salvage_value, 5)

--- a/account_asset_management/views/account_asset_profile.xml
+++ b/account_asset_management/views/account_asset_profile.xml
@@ -20,6 +20,22 @@
                     </div>
                     <group>
                         <group>
+                            <label for="salvage_value" />
+                            <div>
+                                <field
+                                    name="salvage_value"
+                                    class="oe_inline"
+                                    nolabel="1"
+                                />
+                                <span
+                                    class="o_form_label oe_inline"
+                                    invisible="salvage_type != 'percent'"
+                                >%</span>
+                            </div>
+                            <field
+                                name="salvage_type"
+                                required="salvage_value != 0.0"
+                            />
                             <field name="company_id" invisible="1" />
                             <field name="group_ids" widget="many2many_tags" />
                             <field name="asset_product_item" />


### PR DESCRIPTION
This PR enables the configuration of salvage value in the asset profile. Users can configure it with a fixed amount or a percentage of the salvage value.

Forward port of  https://github.com/OCA/account-financial-tools/pull/1820
Adapt attrs according changes in V17

TT54054
@Tecnativa @pedrobaeza @victoralmau @Saran440 could you please review this?