### PR TITLE
[16.0][FIX] Do not create asset for CABA moves

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -91,7 +91,7 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         ret_val = super()._post(soft=soft)
         for move in self:
-            if move.tax_cash_basis_origin_move_id: 
+            if move.tax_cash_basis_origin_move_id:
                 continue
             for aml in move.line_ids.filtered(
                 lambda line: line.asset_profile_id and not line.tax_line_id

--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -91,6 +91,8 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         ret_val = super()._post(soft=soft)
         for move in self:
+            if move.tax_cash_basis_origin_move_id: 
+                continue
             for aml in move.line_ids.filtered(
                 lambda line: line.asset_profile_id and not line.tax_line_id
             ):

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -997,7 +997,12 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         prev_assets = len(self.env["account.asset"].search([]))
         move = self.env["account.move"].create(
             {
+                "name": "Test move",
                 "move_type": "entry",
+                "journal_id": self.env["account.journal"]
+                .search([("company_id", "=", self.company.id)], limit=1)
+                .id,
+                "date": fields.Date.today(),
                 "tax_cash_basis_origin_move_id": self.invoice,
                 "line_ids": [
                     (

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -1000,7 +1000,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
                 "name": "Test move",
                 "move_type": "entry",
                 "journal_id": self.env["account.journal"]
-                .search([("company_id", "=", self.company.id)], limit=1)
+                .search([("company_id", "=", self.company_data["company"].id)], limit=1)
                 .id,
                 "date": fields.Date.today(),
                 "tax_cash_basis_origin_move_id": self.invoice,

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -1011,7 +1011,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
                         {
                             "name": "1 CABA product line",
                             "account_id": self.company_data[
-                                "default_account_revenue"
+                                "default_account_expense"
                             ].id,
                             "asset_profile_id": self.car5y.id,
                             "debit": 0.0,
@@ -1024,7 +1024,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
                         {
                             "name": "2 CABA product line",
                             "account_id": self.company_data[
-                                "default_account_revenue"
+                                "default_account_expense"
                             ].id,
                             "asset_profile_id": self.car5y.id,
                             "debit": 100.0,

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -1003,7 +1003,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
                 .search([("company_id", "=", self.company_data["company"].id)], limit=1)
                 .id,
                 "date": fields.Date.today(),
-                "tax_cash_basis_origin_move_id": self.invoice,
+                "tax_cash_basis_origin_move_id": self.invoice.id,
                 "line_ids": [
                     (
                         0,

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -992,3 +992,46 @@ class TestAssetManagement(AccountTestInvoicingCommon):
             }
         )
         self.assertEqual(asset.salvage_value, 5)
+
+    def test_22_CABA_move_ignored(self):
+        prev_assets = len(self.env["account.asset"].search([]))
+        move = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "tax_cash_basis_origin_move_id": self.invoice,
+                "line_ids": [
+                    (
+                        0,
+                        None,
+                        {
+                            "name": "1 CABA product line",
+                            "account_id": self.company_data[
+                                "default_account_revenue"
+                            ].id,
+                            "asset_profile_id": self.car5y.id,
+                            "debit": 0.0,
+                            "credit": 100.0,
+                        },
+                    ),
+                    (
+                        0,
+                        None,
+                        {
+                            "name": "2 CABA product line",
+                            "account_id": self.company_data[
+                                "default_account_revenue"
+                            ].id,
+                            "asset_profile_id": self.car5y.id,
+                            "debit": 100.0,
+                            "credit": 0.0,
+                        },
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        new_assets = len(self.env["account.asset"].search([]))
+        # No new assets created
+        self.assertEqual(new_assets, prev_assets)
+        # posted move
+        self.assertEqual(move.state, "posted")


### PR DESCRIPTION
When an invoice is reconciled on a Cash Basis environment new move with the same lines of the Invoice is created. All content on lines is copied, asset_profile_id too.

As far as asset have been created by invoice this second move don't have to create a second asset. This change allows to ignore asset creation when a CABA move is posted.