### PR TITLE
[16.0][IMP] account_usability: display fiscalyear_last_day and fiscalyear_last_month on accounting config page

### DIFF
--- a/account_usability/models/res_config_settings.py
+++ b/account_usability/models/res_config_settings.py
@@ -15,3 +15,9 @@ class ResConfigSettings(models.TransientModel):
             "invoiced to a final customer."
         ),
     )
+    fiscalyear_last_day = fields.Integer(
+        related="company_id.fiscalyear_last_day", readonly=False
+    )
+    fiscalyear_last_month = fields.Selection(
+        related="company_id.fiscalyear_last_month", readonly=False
+    )

--- a/account_usability/readme/DESCRIPTION.rst
+++ b/account_usability/readme/DESCRIPTION.rst
@@ -24,3 +24,6 @@ that are hidden and available only on EE version.
    to fit with the EE terms.
 
 4) Rename the main menu 'Billing' into 'Accounting' to fit with EE naming.
+
+5) Allow to configure ``fiscalyear_last_day`` and ``fiscalyear_last_month``
+   fields on accounting configuration page.

--- a/account_usability/views/res_config_settings_views.xml
+++ b/account_usability/views/res_config_settings_views.xml
@@ -28,6 +28,33 @@
                     </div>
                 </div>
             </div>
+            <div id="accounting_reports" position="after">
+                    <div
+                    class="row mt16 o_settings_container"
+                    id="fiscalyear_last_day_month"
+                >
+                            <div class="o_setting_left_pane" />
+                            <div class="o_setting_right_pane">
+                                    <label
+                            string="Fiscal Year Last Day"
+                            for="fiscalyear_last_day"
+                        />
+                                    <div>
+                                            <field
+                                name="fiscalyear_last_day"
+                                class="oe_inline"
+                            />
+                                            <field
+                                name="fiscalyear_last_month"
+                                class="oe_inline"
+                            />
+                                    </div>
+                                    <div class="text-muted">
+                                            Type the day and select the month of the last day of the company's fiscal year.
+                                    </div>
+                                </div>
+                    </div>
+            </div>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
This PR adds the 2 fields fiscalyear_last_day and fiscalyear_last_month on accounting config page defined in the "account" (cf https://github.com/odoo/odoo/blob/16.0/addons/account/models/company.py#L44):

![acc_page](https://github.com/user-attachments/assets/a3feb177-bf8a-4e91-822b-bee054cba62c)
