### PR TITLE
[17.0][FIX] account_loan: Always set the correct date to avoid incorrect values

### DIFF
--- a/account_loan/models/account_loan.py
+++ b/account_loan/models/account_loan.py
@@ -388,15 +388,16 @@ class AccountLoan(models.Model):
             date = self.start_date
         else:
             date = datetime.today().date()
+        initial_date = date
         delta = relativedelta(months=self.method_period)
         if not self.payment_on_first_period:
-            date += delta
+            date = initial_date + delta
         for i in range(1, self.periods + 1):
             line = self.env["account.loan.line"].create(
                 self._new_line_vals(i, date, amount)
             )
             line._check_amount()
-            date += delta
+            date = initial_date + delta * i
             amount -= line.payment_amount - line.interests_amount
         if self.long_term_loan_account_id:
             self._check_long_term_principal_amount()

--- a/account_loan/tests/test_loan.py
+++ b/account_loan/tests/test_loan.py
@@ -87,6 +87,39 @@ class TestLoan(BaseCommon):
         self.assertEqual(loan, self.env[action["res_model"]].search(action["domain"]))
 
     @mute_logger("odoo.models.unlink")
+    @freeze_time("2025-01-31")
+    def test_loan_lines_custom_day(self):
+        loan = self.create_loan("fixed-annuity", 500000, 1, 60)
+        loan.long_term_loan_account_id = self.lt_loan_account
+        loan.compute_lines()
+        dates_by_sequence = {}
+        for line in loan.line_ids:
+            dates_by_sequence[line.sequence] = line.date
+        self.assertEqual(dates_by_sequence[1], fields.Date.from_string("2025-01-31"))
+        self.assertEqual(dates_by_sequence[2], fields.Date.from_string("2025-02-28"))
+        self.assertEqual(dates_by_sequence[3], fields.Date.from_string("2025-03-31"))
+        self.assertEqual(dates_by_sequence[4], fields.Date.from_string("2025-04-30"))
+        self.assertEqual(dates_by_sequence[5], fields.Date.from_string("2025-05-31"))
+        self.assertEqual(dates_by_sequence[6], fields.Date.from_string("2025-06-30"))
+        self.assertEqual(dates_by_sequence[7], fields.Date.from_string("2025-07-31"))
+        self.assertEqual(dates_by_sequence[8], fields.Date.from_string("2025-08-31"))
+        self.assertEqual(dates_by_sequence[9], fields.Date.from_string("2025-09-30"))
+        self.assertEqual(dates_by_sequence[10], fields.Date.from_string("2025-10-31"))
+        self.assertEqual(dates_by_sequence[11], fields.Date.from_string("2025-11-30"))
+        self.assertEqual(dates_by_sequence[12], fields.Date.from_string("2025-12-31"))
+        self.assertEqual(dates_by_sequence[13], fields.Date.from_string("2026-01-31"))
+        line_1 = loan.line_ids.filtered(lambda x: x.sequence == 1)
+        self.assertEqual(line_1.long_term_pending_principal_amount, 401989.15)
+        self.assertAlmostEqual(line_1.long_term_principal_amount, 8211.88)
+        line_2 = loan.line_ids.filtered(lambda x: x.sequence == 2)
+        self.assertEqual(line_2.long_term_pending_principal_amount, 393777.27)
+        line_13 = loan.line_ids.filtered(lambda x: x.sequence == 13)
+        self.assertEqual(line_13.pending_principal_amount, 401989.15)
+        self.assertEqual(
+            line_1.long_term_pending_principal_amount, line_13.pending_principal_amount
+        )
+
+    @mute_logger("odoo.models.unlink")
     def test_round_on_end(self):
         loan = self.create_loan("fixed-annuity", 500000, 1, 60)
         loan.round_on_end = True


### PR DESCRIPTION
Always set the correct date to avoid incorrect values

**Before**
![antes](https://github.com/user-attachments/assets/3ba5d86e-ad8d-4a7b-acc6-2b72746123db)

**After**
![despues](https://github.com/user-attachments/assets/4f7c4030-e287-4cef-9f84-647fea01d97d)

Please @pedrobaeza can you review it?

@Tecnativa TT55750