### PR TITLE
[17.0][IMP] account_loan: Editable table draft, or in posted if no moves exist, manual rate compute.

### DIFF
--- a/account_loan/models/account_loan.py
+++ b/account_loan/models/account_loan.py
@@ -207,21 +207,32 @@ class AccountLoan(models.Model):
         ("name_uniq", "unique(name, company_id)", "Loan name must be unique"),
     ]
 
+    @api.onchange("rate")
+    def _onchange_rate_warning(self):
+        if self.state != "draft":
+            return {
+                "warning": {
+                    "title": _("Rate Change"),
+                    "message": _(
+                        "You have modified the interest rate. Click the Compute items button to update the lines. Please note that if you have manually edited these lines, those changes will be lost upon computation."
+                    ),
+                }
+            }
+
     @api.onchange("line_ids")
     def _onchange_line_ids_draft_manual(self):
-        if self.state == "draft":
-            self.line_ids = self.line_ids.sorted(key=lambda line: line.sequence)
-            previous_pending_principal = 0
-            previous_principal_amount = 0
-            for line in self.line_ids:
-                if line.sequence == 1:
-                    line.pending_principal_amount = line.loan_id.loan_amount
-                else:
-                    line.pending_principal_amount = (
-                        previous_pending_principal - previous_principal_amount
-                    )
-                previous_pending_principal = line.pending_principal_amount
-                previous_principal_amount = line.principal_amount
+        self.line_ids = self.line_ids.sorted(key=lambda line: line.sequence)
+        previous_pending_principal = 0
+        previous_principal_amount = 0
+        for line in self.line_ids:
+            if line.sequence == 1:
+                line.pending_principal_amount = line.loan_id.loan_amount
+            else:
+                line.pending_principal_amount = (
+                    previous_pending_principal - previous_principal_amount
+                )
+            previous_pending_principal = line.pending_principal_amount
+            previous_principal_amount = line.principal_amount
 
     @api.depends("move_ids")
     def _compute_move_count(self):

--- a/account_loan/models/account_loan_line.py
+++ b/account_loan/models/account_loan_line.py
@@ -136,9 +136,10 @@ class AccountLoanLine(models.Model):
     @api.depends("rate")
     def _compute_interests_amount(self):
         for record in self:
-            record.interests_amount = (
-                record.pending_principal_amount * record.rate
-            ) / 100
+            if record.interests_amount and record.pending_principal_amount:
+                record.interests_amount = (
+                    record.pending_principal_amount * record.rate
+                ) / 100
 
     @api.depends("move_ids")
     def _compute_has_moves(self):

--- a/account_loan/models/account_move.py
+++ b/account_loan/models/account_move.py
@@ -26,7 +26,6 @@ class AccountMove(models.Model):
             if loan_line_id:
                 record.loan_id = loan_line_id.loan_id
                 record.loan_line_id._check_move_amount()
-                record.loan_line_id.loan_id._compute_posted_lines()
                 if record.loan_line_id.sequence == record.loan_id.periods:
                     record.loan_id.close()
         return res

--- a/account_loan/views/account_loan_lines_view.xml
+++ b/account_loan/views/account_loan_lines_view.xml
@@ -7,27 +7,35 @@
         <field name="priority">99</field>
         <field name="arch" type="xml">
             <tree editable="bottom">
-                <field name="sequence" readonly="false" widget="handle" />
-                <field name="sequence" readonly="false" />
-                <field name="date" readonly="false" />
-                <field name="rate" />
-                <field name="pending_principal_amount" readonly="True" force_save="1" />
-                <field name="payment_amount" sum="Total payments" />
+                <field
+                    name="sequence"
+                    readonly="has_moves or has_invoices"
+                    widget="handle"
+                />
+                <field name="sequence" readonly="has_moves or has_invoices" />
+                <field name="date" readonly="has_moves or has_invoices" />
+                <field name="rate" readonly="has_moves or has_invoices" />
+                <field name="pending_principal_amount" readonly="True" />
+                <field name="payment_amount" sum="Total payments" readonly="True" />
                 <field
                     name="principal_amount"
                     sum="principal_amount"
-                    readonly="false"
+                    readonly="has_moves or has_invoices"
                 />
-                <field name="interests_amount" sum="Total interests" />
+                <field
+                    name="interests_amount"
+                    sum="Total interests"
+                    readonly="has_moves or has_invoices"
+                />
                 <field
                     name="long_term_pending_principal_amount"
                     column_invisible="not parent.long_term_loan_account_id"
-                    readonly="false"
+                    readonly="has_moves or has_invoices"
                 />
                 <field
                     name="long_term_principal_amount"
                     column_invisible="not parent.long_term_loan_account_id"
-                    readonly="false"
+                    readonly="has_moves or has_invoices"
                 />
                 <field name="long_term_loan_account_id" column_invisible="True" />
                 <field name="loan_state" column_invisible="True" />

--- a/account_loan/views/account_loan_view.xml
+++ b/account_loan/views/account_loan_view.xml
@@ -151,7 +151,7 @@
                             <field
                                 name="line_ids"
                                 context="{'tree_view_ref': 'account_loan.account_loan_line_tree'}"
-                                readonly="state != 'draft'"
+                                readonly="state in ['canlcelled', 'closed']"
                             />
                         </page>
                         <page string="Accounts" id="accounting">


### PR DESCRIPTION
I have added functionality so that the table is also editable when the loan is posted, but when the lines are not posted, to avoid recalculating every time a line is processed, it is not necessary to do it each time a line is processed. However, when changing the rate, it will give us a warning, and even so, we will still have the option to run compute_lines, avoiding changing the logic but without doing it unnecessarily. What do you think?

@tecnativa TT55459
@pedrobaeza @etobella