### PR TITLE
[16][account_asset_management] Only block modification on depreciatlion line related aml

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -227,7 +227,12 @@ class AccountMoveLine(models.Model):
             linked_asset = False
             for move_line in self.filtered(lambda r: not r.move_id.is_sale_document()):
                 linked_asset = move_line.asset_id
-                if linked_asset:
+                if linked_asset and self.env["account.asset.line"].sudo().search(
+                    [
+                        ("move_id", "=", move_line.move_id.id),
+                        ("type", "=", "depreciate"),
+                    ]
+                ):
                     raise UserError(
                         _(
                             "You cannot change an accounting item "


### PR DESCRIPTION
To be consistent with error message. Also, if you manage to create an asset from an accounting entry (instead of a supplier bill), it is possible to change stuff on the link asset, it should also be possible to update the accounting entry

This actually does not change anything for the module since AFAIK, the only way to have an asset linked to an accounting entry which is not a depreciation line is with purchase bills, that can already be modified as long as they are in draft.

The use case is if we create asset from something else. Let's say you produce something and later on, you need to create the asset, you'll then have a misc entry linked to your asset
The module allow to change the asset, it should also allow to update the related accounting entry to make it consistent.

It is far from perfect, this could/should be improved to have more checks, maybe propagate change from asset to accountring entry or the contrary, but in the meantime, it seems fine to just allow the change.