### PR TITLE
[IMP] account_usability: Make group_id searchable

### DIFF
--- a/account_usability/models/__init__.py
+++ b/account_usability/models/__init__.py
@@ -1,3 +1,4 @@
+from . import account_account
 from . import account_group
 from . import account_tag
 from . import account_tax_group

--- a/account_usability/models/account_account.py
+++ b/account_usability/models/account_account.py
@@ -1,0 +1,58 @@
+from odoo import api, fields, models
+
+
+class Account(models.Model):
+    _inherit = "account.account"
+
+    group_id = fields.Many2one(search="_search_group_id")
+
+    def _search_group_id(self, operator, value):
+        if operator not in ("in", "="):
+            raise NotImplementedError
+
+        # Browse groups because value can be an odoo.tools.query.Query
+        groups = self.env["account.group"].browse(value)
+
+        if not groups:
+            return [("id", "=", 0)]
+
+        query = """
+            SELECT
+                a.id
+            FROM
+                account_account a
+            JOIN
+                account_group g
+                ON g.code_prefix_start <= LEFT(
+                    (a.code_store::json ->> %(company_id)s),
+                    char_length(g.code_prefix_start)
+                )
+                AND g.code_prefix_end >= LEFT(
+                    (a.code_store::json ->> %(company_id)s),
+                    char_length(g.code_prefix_end)
+                )
+                AND g.company_id = %(company_id)s
+            WHERE g.id IN %(group_ids)s
+        """
+        self.env.cr.execute(
+            query,
+            {
+                "group_ids": tuple(groups.ids),
+                "company_id": str(self.env.company.root_id.id),
+            },
+        )
+        account_ids = [row[0] for row in self.env.cr.fetchall()]
+        return [("id", "in", account_ids)]
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        res.mapped("group_id").invalidate_recordset()
+        return res
+
+    def write(self, vals):
+        groups = self.mapped("group_id")
+        res = super().write(vals)
+        if "code" in vals:
+            (self.mapped("group_id") | groups).invalidate_recordset()
+        return res

--- a/account_usability/tests/__init__.py
+++ b/account_usability/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_group

--- a/account_usability/tests/test_account_group.py
+++ b/account_usability/tests/test_account_group.py
@@ -1,0 +1,71 @@
+from odoo.tests.common import TransactionCase
+
+
+class AccountGroupTest(TransactionCase):
+    def test_group_accounts(self):
+        group = self.env["account.group"].create(
+            {
+                "name": "Test Group",
+                "code_prefix_start": "1000",
+                "code_prefix_end": "1999",
+            }
+        )
+
+        account = self.env["account.account"].create(
+            {"code": "1001", "name": "Test Account"}
+        )
+        account_2 = self.env["account.account"].create(
+            {"code": "2000", "name": "Test Account"}
+        )
+
+        self.assertIn(account.id, group.account_ids.ids)
+        self.assertNotIn(account_2.id, group.account_ids.ids)
+
+        account_3 = self.env["account.account"].create(
+            {"code": "1002", "name": "Test Account 2"}
+        )
+        self.assertIn(account_3.id, group.account_ids.ids)
+
+        account_3.write({"code": "2001"})
+        self.assertNotIn(account_3.id, group.account_ids.ids)
+        self.assertIn(account.id, group.account_ids.ids)
+
+    def test_search_accounts_on_group(self):
+        group = self.env["account.group"].create(
+            {
+                "name": "Test Group",
+                "code_prefix_start": "1000",
+                "code_prefix_end": "1999",
+            }
+        )
+
+        account = self.env["account.account"].create(
+            {"code": "1001", "name": "Test Account"}
+        )
+        account_2 = self.env["account.account"].create(
+            {"code": "2000", "name": "Test Account"}
+        )
+
+        accounts_by_group = self.env["account.account"].search(
+            [("group_id", "=", group.id)]
+        )
+
+        self.assertIn(account.id, accounts_by_group.ids)
+        self.assertNotIn(account_2.id, accounts_by_group.ids)
+
+        account_3 = self.env["account.account"].create(
+            {"code": "1002", "name": "Test Account 2"}
+        )
+        accounts_by_group = self.env["account.account"].search(
+            [("group_id", "=", group.id)]
+        )
+        self.assertIn(account_3.id, accounts_by_group.ids)
+        self.assertIn(account.id, accounts_by_group.ids)
+        self.assertNotIn(account_2.id, accounts_by_group.ids)
+
+        accounts_by_group = self.env["account.account"].search(
+            [("group_id.code_prefix_start", "=", "1000")]
+        )
+        self.assertIn(account_3.id, accounts_by_group.ids)
+        self.assertNotIn(account_2.id, accounts_by_group.ids)
+        self.assertIn(account.id, accounts_by_group.ids)


### PR DESCRIPTION
Currently the account_ids is related but group_id is computed.
This prevents the error message "Non-stored field account.account.group_id cannot be searched."