### PR TITLE
[18.0][FIX] account_move_name_sequence: Registry cleanup

### DIFF
--- a/account_move_name_sequence/tests/test_sequence_concurrency.py
+++ b/account_move_name_sequence/tests/test_sequence_concurrency.py
@@ -59,6 +59,7 @@ class TestSequenceConcurrency(TransactionCase):
             # Set a 10-second timeout to avoid waiting too long for release locks
             cr.execute("SET LOCAL statement_timeout = '10s'")
         cls.registry.enter_test_mode(cls.cursor(cls))
+        cls.addClassCleanup(cls.registry.leave_test_mode)
         cls.last_existing_move = cls.env["account.move"].search(
             [], limit=1, order="id desc"
         )


### PR DESCRIPTION
Call leave_test_mode once tests where enter_test_mode has been explicitly called are done.

Note we still need to isolate this module in test runs (see commit
8da2b375a503692cb1b549907904858458016f50) as other tests in this repo
(namely those in purchase_unreconciled) rely on default sequences.