### PR TITLE
[15.0][FIX] account_journal_lock_date: avoid calling check on empty values

### DIFF
--- a/account_journal_lock_date/models/account_move.py
+++ b/account_journal_lock_date/models/account_move.py
@@ -14,7 +14,8 @@ class AccountMove(models.Model):
 
     def write(self, values):
         res = super().write(values)
-        self._check_fiscalyear_lock_date()
+        if values:
+            self._check_fiscalyear_lock_date()
         return res
 
     def _check_fiscalyear_lock_date(self):


### PR DESCRIPTION
Can't register partial payment when lockdate > some payment

Step to test:
1. Install module `account_journal_lock_date` and `account_lock_date_update`
2. Create bill on date **01 Jan 2024** (without lockdate)
3. Register payment with partial reconcile on date **02 Jan 2024**
![Selection_005](https://github.com/user-attachments/assets/f5b4f421-25ef-4d08-8a61-c7ac53db3781)

4. Lock Date on **03 Jan 2024**
![Selection_006](https://github.com/user-attachments/assets/82ca7686-e121-4dd3-98f3-3a5571f7cbc5)

5. Register Payment on **04 Jan 2024** with full payment. it will error
![Selection_007](https://github.com/user-attachments/assets/ff08cb2c-418e-49e7-928f-6afb7a5f4a5f)
