### PR TITLE
[FIX] account_asset_management: Carry analytic_distribution from Asset Profile to Asset on creation from Vendor Bill

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -112,12 +112,10 @@ class AccountMove(models.Model):
                     setattr(asset_form, key, val)
                 asset = asset_form.save()
                 if not aml.analytic_distribution and asset.analytic_distribution:
-                    asset.write(
-                        {'analytic_distribution': asset.analytic_distribution})
+                    asset.write({"analytic_distribution": asset.analytic_distribution})
                 # Otherwise, override with the Vendor Bill's value
                 elif aml.analytic_distribution:
-                    asset.write(
-                        {'analytic_distribution': aml.analytic_distribution})
+                    asset.write({"analytic_distribution": aml.analytic_distribution})
                 aml.with_context(
                     allow_asset=True, allow_asset_removal=True
                 ).asset_id = asset.id

--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -111,7 +111,13 @@ class AccountMove(models.Model):
                 for key, val in vals.items():
                     setattr(asset_form, key, val)
                 asset = asset_form.save()
-                asset.analytic_distribution = aml.analytic_distribution
+                if not aml.analytic_distribution and asset.analytic_distribution:
+                    asset.write(
+                        {'analytic_distribution': asset.analytic_distribution})
+                # Otherwise, override with the Vendor Bill's value
+                elif aml.analytic_distribution:
+                    asset.write(
+                        {'analytic_distribution': aml.analytic_distribution})
                 aml.with_context(
                     allow_asset=True, allow_asset_removal=True
                 ).asset_id = asset.id

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -89,11 +89,20 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         cls.analytic_account = cls.env["account.analytic.account"].create(
             {"name": "test_analytic_account", "plan_id": cls.default_plan.id}
         )
+        cls.analytic_account_2 = cls.env["account.analytic.account"].create(
+            {"name": "test_analytic_account_2", "plan_id": cls.default_plan.id}
+        )
 
         cls.distribution = cls.env["account.analytic.distribution.model"].create(
             {
                 "partner_id": cls.partner.id,
                 "analytic_distribution": {cls.analytic_account.id: 100},
+            }
+        )
+        cls.distribution_2 = cls.env["account.analytic.distribution.model"].create(
+            {
+                "partner_id": cls.partner.id,
+                "analytic_distribution": {cls.analytic_account_2.id: 100},
             }
         )
 
@@ -979,3 +988,76 @@ class TestAssetManagement(AccountTestInvoicingCommon):
             }
         )
         self.assertEqual(asset.salvage_value, 5)
+
+    def test_22_asset_distribution_from_vendor_bill(self):
+        """
+        Test that an asset created from a vendor bill line
+        inherits the analytic distribution defined on the asset profile
+        when no analytic distribution is set directly on the invoice line.
+
+        Steps:
+            - Create a vendor bill with an invoice line referencing an asset
+              profile that has an analytic distribution set.
+            - Do not set any analytic distribution on the invoice line itself.
+            - Validate the vendor bill.
+            - Ensure that the created asset has the analytic distribution
+              from the asset profile.
+        """
+        all_asset = self.env["account.asset"].search([])
+        invoice = self.invoice
+        asset_profile = self.car5y  # has analytic_distribution
+        self.assertTrue(len(invoice.invoice_line_ids) > 0)
+        line = invoice.invoice_line_ids[0]
+        self.assertTrue(line.price_unit > 0.0)
+        # invoice line has asset_profile but no analytic_distribution
+        invoice.invoice_line_ids[0].write(
+            {"asset_profile_id": asset_profile.id}
+        )
+        invoice.action_post()
+        # get all assets after invoice validation
+        current_asset = self.env["account.asset"].search([])
+        # get the new asset
+        new_asset = current_asset - all_asset
+        # check that the new asset has the analytic_distribution from the
+        # profile
+        self.assertEqual(new_asset.analytic_distribution,
+                            asset_profile.analytic_distribution,
+                            "Asset should have analytic_distribution from the profile")
+
+    def test_23_asset_distribution_override_from_vendor_bill_line(self):
+        """
+        Test that an asset created from a vendor bill line
+        inherits the analytic distribution from the vendor bill line itself
+        when both the asset profile and the vendor bill line have analytic
+        distributions defined.
+
+        Steps:
+            - Create a vendor bill with an invoice line referencing an asset
+              profile that has an analytic distribution set.
+            - Set an overriding analytic distribution directly on the invoice line.
+            - Validate the vendor bill.
+            - Ensure that the created asset has the analytic distribution
+              from the vendor bill line (not the asset profile).
+        """
+        all_asset = self.env["account.asset"].search([])
+        invoice = self.invoice
+        asset_profile = self.car5y  # has analytic_distribution
+        overriding_distribution = self.distribution_2
+        self.assertTrue(len(invoice.invoice_line_ids) > 0)
+        line = invoice.invoice_line_ids[0]
+        self.assertTrue(line.price_unit > 0.0)
+        # invoice line has asset_profile AND analytic_distribution
+        invoice.invoice_line_ids[0].write(
+            {"asset_profile_id": asset_profile.id,
+             "analytic_distribution": overriding_distribution.analytic_distribution}
+        )
+        invoice.action_post()
+        # get all assets after invoice validation
+        current_asset = self.env["account.asset"].search([])
+        # get the new asset
+        new_asset = current_asset - all_asset
+        # check that the new asset has the overriding analytic_distribution
+        # from the Vendor Bill line
+        self.assertTrue(
+            new_asset.analytic_distribution == overriding_distribution.analytic_distribution,
+            "Manual override from the Vendor Bill should take precedence")

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -1010,9 +1010,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         line = invoice.invoice_line_ids[0]
         self.assertTrue(line.price_unit > 0.0)
         # invoice line has asset_profile but no analytic_distribution
-        invoice.invoice_line_ids[0].write(
-            {"asset_profile_id": asset_profile.id}
-        )
+        invoice.invoice_line_ids[0].write({"asset_profile_id": asset_profile.id})
         invoice.action_post()
         # get all assets after invoice validation
         current_asset = self.env["account.asset"].search([])
@@ -1020,9 +1018,11 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         new_asset = current_asset - all_asset
         # check that the new asset has the analytic_distribution from the
         # profile
-        self.assertEqual(new_asset.analytic_distribution,
-                            asset_profile.analytic_distribution,
-                            "Asset should have analytic_distribution from the profile")
+        self.assertEqual(
+            new_asset.analytic_distribution,
+            asset_profile.analytic_distribution,
+            "Asset should have analytic_distribution from the profile",
+        )
 
     def test_23_asset_distribution_override_from_vendor_bill_line(self):
         """
@@ -1048,8 +1048,10 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         self.assertTrue(line.price_unit > 0.0)
         # invoice line has asset_profile AND analytic_distribution
         invoice.invoice_line_ids[0].write(
-            {"asset_profile_id": asset_profile.id,
-             "analytic_distribution": overriding_distribution.analytic_distribution}
+            {
+                "asset_profile_id": asset_profile.id,
+                "analytic_distribution": overriding_distribution.analytic_distribution,
+            }
         )
         invoice.action_post()
         # get all assets after invoice validation
@@ -1059,5 +1061,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         # check that the new asset has the overriding analytic_distribution
         # from the Vendor Bill line
         self.assertTrue(
-            new_asset.analytic_distribution == overriding_distribution.analytic_distribution,
-            "Manual override from the Vendor Bill should take precedence")
+            new_asset.analytic_distribution
+            == overriding_distribution.analytic_distribution,
+            "Manual override from the Vendor Bill should take precedence",
+        )


### PR DESCRIPTION
### Description of the issue/feature this PR addresses

When creating an asset from a vendor bill, if the selected Asset Profile has an analytic_distribution set, this distribution was not being carried over to the new asset record. As a result, the analytic distribution would be missing on the asset, even though it was set on the profile, which is inconsistent with the intended behavior.

### Current behavior before PR

- User selects an Asset Profile on a vendor bill line, and the profile has an analytic_distribution defined.
- After posting the bill, a new Asset is created, but the asset’s analytic_distribution is not set (remains empty), unless an analytic distribution was manually set on the vendor bill line.

### Desired behavior after PR is merged
When an Asset is created from a vendor bill line, and the selected Asset Profile has an analytic_distribution, the new Asset’s analytic_distribution will be set to the value from the profile, unless a distribution is explicitly set on the vendor bill line (in which case that override is respected).

### Technical summary
In account_move.py, the asset creation logic in action_post is updated to:

- Assign the Asset Profile’s analytic distribution to the Asset when appropriate.
- If the vendor bill line specifies an analytic_distribution, it will override the profile.

### Steps to reproduce (before and after PR)

1. Create an Asset Profile with an analytic distribution (e.g., 100% “Warehouse Equipment”).
2. Create a vendor bill, add a line, and select the Asset Profile. Do not specify an analytic distribution on the bill line.
3. Post the bill and open the created Asset.
- **Before PR:** The asset’s analytic distribution is empty.
- **After PR:** The asset’s analytic distribution matches the profile’s distribution.

### Related issues or PRs

This PR addresses the issue described above.
A follow-up issue will be opened to discuss analytic entry logic when the analytic distribution is overridden on the vendor bill line.
