### PR TITLE
[16.0][FIX] account_loan: Make long term in a better way

### DIFF
--- a/account_loan/models/account_loan.py
+++ b/account_loan/models/account_loan.py
@@ -173,6 +173,12 @@ class AccountLoan(models.Model):
         readonly=True,
         states={"draft": [("readonly", False)]},
     )
+    long_term_journal_id = fields.Many2one(
+        "account.journal",
+        domain="[('company_id', '=', company_id),('type', '=', 'general')]",
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )
     short_term_loan_account_id = fields.Many2one(
         "account.account",
         domain="[('company_id', '=', company_id)]",

--- a/account_loan/models/account_loan_line.py
+++ b/account_loan/models/account_loan_line.py
@@ -412,7 +412,8 @@ class AccountLoanLine(models.Model):
             "loan_id": self.loan_id.id,
             "date": self.date,
             "ref": self.name,
-            "journal_id": self.loan_id.journal_id.id,
+            "journal_id": self.loan_id.long_term_journal_id.id
+            or self.loan_id.journal_id.id,
             "line_ids": [
                 Command.create(vals) for vals in self._get_long_term_move_line_vals()
             ],

--- a/account_loan/views/account_loan_view.xml
+++ b/account_loan/views/account_loan_view.xml
@@ -144,6 +144,10 @@
                                 </group>
                                 <group>
                                     <field name="long_term_loan_account_id" />
+                                    <field
+                                        name="long_term_journal_id"
+                                        attrs="{'invisible': ['|', ('is_leasing', '=', False), ('long_term_loan_account_id', '=', False)]}"
+                                    />
                                     <field name="interest_expenses_account_id" />
                                     <field name="currency_id" invisible="1" />
                                 </group>


### PR DESCRIPTION
Right now, if you are using long term, a second move is created but it is of type entry on a purchase kind journal. It doesn't make sense.

We should use a specific journal for this.

This only makes sense on leasings.