### PR TITLE
account_asset_management: fix reversal compatibility

### DIFF
--- a/account_asset_management/wizard/wiz_asset_move_reverse.py
+++ b/account_asset_management/wizard/wiz_asset_move_reverse.py
@@ -40,7 +40,11 @@ class WizAssetMoveReverse(models.TransientModel):
         move = self.line_id.move_id
         move_reversal = (
             self.env["account.move.reversal"]
-            .with_context(active_model="account.move", active_ids=move.ids)
+            .with_context(
+                active_model="account.move",
+                active_ids=move.ids,
+                active_id=move.id,
+            )
             .create(
                 {
                     "date": self.date_reversal,


### PR DESCRIPTION
Some OCA module like account_invoice_refund_line_selection expect to have the keywork "active_id"
as odoo native pass it, we have to pass it here


@alexis-via 

@florian-dacosta can you port it to 18 ?