### PR TITLE
[18.0][FIX] account_asset_management: asset_report

### DIFF
--- a/account_asset_management/report/account_asset_report_xls.py
+++ b/account_asset_management/report/account_asset_report_xls.py
@@ -719,8 +719,6 @@ class AssetReportXlsx(models.AbstractModel):
                     reason = self.env._("Undetermined error")
                 row_pos += 1
                 err_msg = self.env._("Assets to be corrected") + ": "
-                err_msg += "%s" % [
-                    x[1] for x in [(error_dict[k].id, error_dict[k].display_name)]
-                ]
+                err_msg += "{}".format(", ".join(error_dict[k].mapped("display_name")))
                 err_msg += " - " + self.env._("Reason") + ": " + reason
                 ws.write_string(row_pos, 0, err_msg, FORMATS["format_left_bold"])

--- a/account_asset_management/report/account_asset_report_xls.py
+++ b/account_asset_management/report/account_asset_report_xls.py
@@ -719,6 +719,6 @@ class AssetReportXlsx(models.AbstractModel):
                     reason = self.env._("Undetermined error")
                 row_pos += 1
                 err_msg = self.env._("Assets to be corrected") + ": "
-                err_msg += "{}".format(", ".join(error_dict[k].mapped("display_name")))
+                err_msg += ", ".join(error_dict[k].mapped("display_name"))
                 err_msg += " - " + self.env._("Reason") + ": " + reason
                 ws.write_string(row_pos, 0, err_msg, FORMATS["format_left_bold"])


### PR DESCRIPTION
A stack trace happens when more than 1 assets is involved in error message shown at the end of first page in asset xls report because .id is applied to more than one asset.