### PR TITLE
[16.0][FIX] account_spread_cost_revenue - fix automatic spreads on refunds

### DIFF
--- a/account_spread_cost_revenue/models/account_spread_template.py
+++ b/account_spread_cost_revenue/models/account_spread_template.py
@@ -118,7 +118,9 @@ class AccountSpreadTemplate(models.Model):
     def _onchange_user_invoice_line_account(self):
         self.exp_rev_account_id = False
 
-    def _prepare_spread_from_template(self, spread_account_id=False):
+    def _prepare_spread_from_template(
+        self, spread_account_id=False, invoice_type=False
+    ):
         self.ensure_one()
         company = self.company_id
         spread_vals = {
@@ -131,11 +133,11 @@ class AccountSpreadTemplate(models.Model):
         }
 
         account_id = spread_account_id or self.spread_account_id.id
-        if self.spread_type == "sale":
-            invoice_type = "out_invoice"
+        if not invoice_type:
+            invoice_type = "out_invoice" if self.spread_type == "sale" else "in_invoice"
+        if invoice_type in ("out_invoice", "in_refund"):
             spread_vals["debit_account_id"] = account_id
         else:
-            invoice_type = "in_invoice"
             spread_vals["credit_account_id"] = account_id
 
         if self.period_number:

--- a/account_spread_cost_revenue/wizards/account_spread_invoice_line_link_wizard.py
+++ b/account_spread_cost_revenue/wizards/account_spread_invoice_line_link_wizard.py
@@ -195,7 +195,7 @@ class AccountSpreadInvoiceLineLinkWizard(models.TransientModel):
                     spread_account_id = self.invoice_line_id.account_id.id
 
                 spread_vals = self.template_id._prepare_spread_from_template(
-                    spread_account_id=spread_account_id
+                    spread_account_id=spread_account_id, invoice_type=self.invoice_type
                 )
                 date_invoice = self.invoice_id.invoice_date
                 date_invoice = date_invoice or self.template_id.start_date


### PR DESCRIPTION
When creating an automatic spread from a template, the `_prepare_spread_from_template()` method of `account.spread.template` model does not have enough information to correctly place the debit or credit count.