### PR TITLE
[16.0][FIX] account_move_template: Payment Term Error

### DIFF
--- a/account_move_template/wizard/account_move_template_run.py
+++ b/account_move_template/wizard/account_move_template_run.py
@@ -210,8 +210,12 @@ Valid dictionary to overwrite template lines:
     def _prepare_move_line(self, line, amount):
         date_maturity = False
         if line.payment_term_id:
-            pterm_list = line.payment_term_id.compute(value=1, date_ref=self.date)
-            date_maturity = max(line[0] for line in pterm_list)
+            date_maturity = max(
+                [
+                    line._get_due_date(self.date)
+                    for line in line.payment_term_id.line_ids
+                ]
+            )
         debit = line.move_line_type == "dr"
         values = {
             "name": line.name,


### PR DESCRIPTION
Partially back-ports commit 4bfa622 (18.0) so that creating an Account Move from a template containing a payment term no longer crashes on 16.0.

```
  File "/opt/odoo/auto/addons/account_move_template/wizard/account_move_template_run.py", line 182, in generate_move
    Command.create(self._prepare_move_line(line, amount))
  File "/opt/odoo/auto/addons/account_move_template/wizard/account_move_template_run.py", line 213, in _prepare_move_line
    pterm_list = line.payment_term_id.compute(value=1, date_ref=self.date)
AttributeError: 'account.payment.term' object has no attribute 'compute'
```