### PR TITLE
[18][account_asset_management] FIX first depreciation line amount with prorata temporis and month

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -786,15 +786,43 @@ class AccountAsset(models.Model):
         if self.prorata:
             if firstyear:
                 depreciation_date_start = self.date_start
-                fy_date_stop = entry["date_stop"]
-                first_fy_asset_days = (fy_date_stop - depreciation_date_start).days + 1
-                first_fy_duration = self._get_fy_duration(fy, option="days")
+                if self.method_period == "month":
+                    # TODO manage quarter
+                    first_day_period = depreciation_date_start.replace(day=1)
+                    first_day_next_period = first_day_period + relativedelta(months=1)
+                    current_full_period_days = first_day_next_period - first_day_period
+                    current_partial_period_days = (
+                        first_day_next_period - depreciation_date_start
+                    )
+                    # compute a ratio of the first period of the asset
+                    # (example 14/07 would be 17/31=0.548)
+                    current_period_ratio = (
+                        current_partial_period_days / current_full_period_days
+                    )
+                    # get the number of period (month) until end of first fy
+                    # (not counting the first partial month)
+                    remaining_fy_duration = (
+                        (fy.date_to.year - first_day_next_period.year) * 12
+                        + (fy.date_to.month - first_day_next_period.month)
+                        + 1
+                    )
+                    first_fy_duration = self._get_fy_duration(fy, option="months")
+                    # ratio of first fiscal year using month
+                    duration_first_fy_ratio = (
+                        float(current_period_ratio + remaining_fy_duration)
+                        / first_fy_duration
+                    )
+                else:
+                    fy_date_stop = entry["date_stop"]
+                    first_fy_asset_days = (
+                        fy_date_stop - depreciation_date_start
+                    ).days + 1
+                    first_fy_duration = self._get_fy_duration(fy, option="days")
+                    duration_first_fy_ratio = (
+                        float(first_fy_asset_days) / first_fy_duration
+                    )
                 first_fy_year_factor = self._get_fy_duration(fy, option="years")
-                duration_factor = (
-                    float(first_fy_asset_days)
-                    / first_fy_duration
-                    * first_fy_year_factor
-                )
+                duration_factor = duration_first_fy_ratio * first_fy_year_factor
             else:
                 duration_factor = self._get_fy_duration(fy, option="years")
         else:

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -3,9 +3,8 @@
 # Copyright 2021 Tecnativa - João Marques
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import calendar
 import time
-from datetime import date, datetime
+from datetime import datetime
 
 from odoo import Command, fields
 from odoo.tests import Form, tagged
@@ -303,27 +302,13 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         )
         asset.compute_depreciation_board()
         asset.invalidate_recordset()
-        if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[1].amount, 46.44, places=2
-            )
-        else:
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[1].amount, 47.33, places=2
-            )
+        self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 44.8, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[4].amount, 55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[5].amount, 55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[6].amount, 55.55, places=2)
-        if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[-1].amount, 9.11, places=2
-            )
-        else:
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[-1].amount, 8.22, places=2
-            )
+        self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 10.75, places=2)
 
     def test_03_proprata_init_prev_year(self):
         """Prorata temporis depreciation with init value in prev year."""
@@ -358,26 +343,12 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         self.assertAlmostEqual(asset.value_depreciated, 325.08, places=2)
         # check computed values in the depreciation board
         self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55, places=2)
-        if calendar.isleap(date.today().year - 1):
-            # for leap years the first year depreciation amount of 325.08
-            # is too high and hence a correction is applied to the next
-            # entry of the table
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[2].amount, 54.66, places=2
-            )
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[3].amount, 55.55, places=2
-            )
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[-1].amount, 9.11, places=2
-            )
-        else:
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[2].amount, 55.55, places=2
-            )
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[-1].amount, 8.22, places=2
-            )
+        # depreciation amount of 325.08
+        # is too high and hence a correction is applied to the next
+        # entry of the table
+        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 53.02, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55, places=2)
+        self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 10.75, places=2)
 
     def test_04_prorata_init_cur_year(self):
         """Prorata temporis depreciation with init value in curent year."""
@@ -409,23 +380,10 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         # check the depreciated value is the initial value
         self.assertAlmostEqual(asset.value_depreciated, 279.44, places=2)
         # check computed values in the depreciation board
-        if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[2].amount, 44.75, places=2
-            )
-        else:
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[2].amount, 45.64, places=2
-            )
+        # compensate first period with the delta due to init_entry
+        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 43.11, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55, places=2)
-        if calendar.isleap(date.today().year):
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[-1].amount, 9.11, places=2
-            )
-        else:
-            self.assertAlmostEqual(
-                asset.depreciation_line_ids[-1].amount, 8.22, places=2
-            )
+        self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 10.75, places=2)
 
     def test_05_degressive_linear(self):
         """Degressive-Linear with annual and quarterly depreciation."""


### PR DESCRIPTION
With prorata temporis option, and a month period lenght, the first depreciation amount may be quite bad and confusing, mainly on first or last day of a period.

Example : fiscal year ending on 31/12 : 
<img width="1854" height="756" alt="december-fy-big-diff" src="https://github.com/user-attachments/assets/2c40db01-1fa0-4976-8dbc-f1be690f611b" />

Of even with negative amount (fiscal year ending on 31/03) : 
<img width="1846" height="746" alt="march-fy-negative" src="https://github.com/user-attachments/assets/1473809f-bd72-447a-9db9-ac9e66cba991" />

This is because the system compute a fixed period amount (1000 in the examples) but compute the first fiscalyear amount with a ratio, computed from the number of days of the first fiscal year.
So depending if the first partial fiscal year contains february or not for instance
If the first fiscal year contains January and february, it will be (28+31) / 365 instead of 2/12

This PR aims to fix this, doing the prorata of the first fiscal year using the period. 
For now, I just fix it for month which is a common case, but I guess the same problem happens using quarters.

Same cases after the fix : 

<img width="1851" height="639" alt="new-december-fy-no-diff" src="https://github.com/user-attachments/assets/01763e67-e190-4848-808f-e390785de573" />


<img width="1849" height="683" alt="new-march-fy" src="https://github.com/user-attachments/assets/f6788ddf-752f-4209-9293-efd12315f0c8" />


@sebastienbeau @alexis-via 