### PR TITLE
[18][account_asset_management] FIX first asset line creation in case of asset creation by import with a deprecated line

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -442,7 +442,9 @@ class AccountAsset(models.Model):
 
     def _create_first_asset_line(self):
         self.ensure_one()
-        if self.depreciation_base and not self.depreciation_line_ids:
+        if self.depreciation_base and not self.depreciation_line_ids.filtered(
+            lambda s: s.type == "create"
+        ):
             asset_line_obj = self.env["account.asset.line"]
             line_name = self._get_depreciation_entry_name(0)
             asset_line_vals = {


### PR DESCRIPTION
When you want to import some asset from another system, you may want to import a file to create these assets, with a depreciation line, having option init_entry=True and the amount already deprecated in the old system.

Currently, it does not work so well, because the "create" asset line is not created, when we do it this way.
This PR fixes this issue.

To reproduce : 
Create an asset profile named "TEST" and configure it.
Then, import the following xlsx file
[example-asset-import.xlsx](https://github.com/user-attachments/files/21670270/example-asset-import.xlsx)

Without the fix, the created asset have only one asset line, which type is deprecated.
With the fix, the created asset have 2 asset lines, the first one has the "create" type.

@sebastienbeau @alexis-via 