### PR TITLE
[18][account_asset_management] : improve the removal wizard

### DIFF
--- a/account_asset_low_value/tests/test_asset_low_value.py
+++ b/account_asset_low_value/tests/test_asset_low_value.py
@@ -64,7 +64,9 @@ class TestAssetLowValue(AccountTestInvoicingCommon):
         self.assertEqual(asset.value_residual, 0)
         self.assertEqual(asset.state, "open")
         asset.remove()
-        remove_model = self.env["account.asset.remove"].with_context(active_id=asset.id)
+        remove_model = self.env["account.asset.remove"].with_context(
+            active_id=asset.id, active_model="account.asset"
+        )
         with Form(remove_model) as f:
             f.posting_regime = "residual_value"
         remove = f.save()

--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -197,7 +197,8 @@ class AccountMoveLine(models.Model):
     @api.onchange("asset_profile_id")
     def _onchange_asset_profile_id(self):
         if (
-            self.asset_profile_id.account_asset_id
+            self.move_id.move_type == "in_invoice"
+            and self.asset_profile_id.account_asset_id
             and self.asset_profile_id.account_asset_id != self.account_id
         ):
             self.account_id = self.asset_profile_id.account_asset_id

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -549,7 +549,11 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         )
         asset.compute_depreciation_board()
         asset.validate()
-        wiz_ctx = {"active_id": asset.id, "early_removal": True}
+        wiz_ctx = {
+            "active_id": asset.id,
+            "early_removal": True,
+            "active_model": "account.asset",
+        }
         wiz = self.remove_model.with_context(**wiz_ctx).create(
             {
                 "date_remove": "2019-01-31",
@@ -995,7 +999,7 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         self.assertNotIn("early_removal", action["context"])
         wizard_form = Form(
             self.remove_model.with_context(
-                **action["context"],
+                **action["context"], active_model="account.asset"
             )
         )
         wizard_form.posting_regime = "gain_loss_on_sale"

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -15,12 +15,14 @@ class AccountAssetRemove(models.TransientModel):
     _check_company_auto = True
     _check_company_domain = models.check_company_domain_parent_of
 
+    asset_id = fields.Many2one(
+        "account.asset", readonly=True, required=True, check_company=True
+    )
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
         readonly=True,
         required=True,
-        default=lambda self: self._default_company_id(),
     )
     currency_id = fields.Many2one(
         related="company_id.currency_id", string="Company Currency"
@@ -33,42 +35,35 @@ class AccountAssetRemove(models.TransientModel):
         "in case of early removal",
     )
     force_date = fields.Date(string="Force accounting date")
-    sale_value = fields.Monetary(
-        default=lambda self: self._default_sale_value(),
-    )
+    sale_value = fields.Monetary()
     account_sale_id = fields.Many2one(
         comodel_name="account.account",
         string="Asset Sale Account",
         domain=[("deprecated", "=", False)],
         check_company=True,
-        default=lambda self: self._default_account_sale_id(),
     )
     account_plus_value_id = fields.Many2one(
         comodel_name="account.account",
         string="Plus-Value Account",
         domain=[("deprecated", "=", False)],
         check_company=True,
-        default=lambda self: self._default_account_plus_value_id(),
     )
     account_min_value_id = fields.Many2one(
         comodel_name="account.account",
         string="Min-Value Account",
         domain=[("deprecated", "=", False)],
         check_company=True,
-        default=lambda self: self._default_account_min_value_id(),
     )
     account_residual_value_id = fields.Many2one(
         comodel_name="account.account",
         string="Residual Value Account",
         domain=[("deprecated", "=", False)],
         check_company=True,
-        default=lambda self: self._default_account_residual_value_id(),
     )
     posting_regime = fields.Selection(
         selection=lambda self: self._selection_posting_regime(),
         string="Removal Entry Policy",
         required=True,
-        default=lambda self: self._get_posting_regime(),
         help="Removal Entry Policy \n"
         "  * Residual Value: The non-depreciated value will be "
         "posted on the 'Residual Value Account' \n"
@@ -83,59 +78,44 @@ class AccountAssetRemove(models.TransientModel):
             raise ValidationError(self.env._("The Sale Value must be positive!"))
 
     @api.model
-    def _default_company_id(self):
-        asset_id = self.env.context.get("active_id")
-        asset = self.env["account.asset"].browse(asset_id)
-        return asset.company_id
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        assert self.env.context.get("active_model") == "account.asset"
+        asset = self.env["account.asset"].browse(self.env.context.get("active_id"))
+        country_code = asset.company_id.country_id.code or False
+        if country_code in self._residual_value_regime_countries():
+            res["posting_regime"] = "residual_value"
+        else:
+            res["posting_regime"] = "gain_loss_on_sale"
+        sale_vals = self._get_sale(asset)
+        residual_value_account_id = asset.profile_id.account_residual_value_id.id
+        res.update(
+            {
+                "asset_id": asset.id,
+                "sale_value": sale_vals.get("sale_value"),
+                "account_sale_id": sale_vals.get("account_sale_id"),
+                "company_id": asset.company_id.id,
+                "account_min_value_id": asset.profile_id.account_min_value_id.id,
+                "account_plus_value_id": asset.profile_id.account_plus_value_id.id,
+                "account_residual_value_id": residual_value_account_id,
+            }
+        )
+        return res
 
-    @api.model
-    def _default_sale_value(self):
-        return self._get_sale()["sale_value"]
-
-    @api.model
-    def _default_account_sale_id(self):
-        return self._get_sale()["account_sale_id"]
-
-    def _get_sale(self):
-        asset_id = self.env.context.get("active_id")
+    def _get_sale(self, asset):
         sale_value = 0.0
         account_sale_id = False
         inv_lines = self.env["account.move.line"].search(
             [
-                ("asset_id", "=", asset_id),
+                ("asset_id", "=", asset.id),
                 ("move_id.move_type", "in", ("out_invoice", "out_refund")),
+                ("company_id", "=", asset.company_id.id),
             ]
         )
         for line in inv_lines:
-            inv = line.move_id
-            comp_curr = inv.currency_id
-            inv_curr = inv.currency_id
-            if line.move_id.payment_state == "paid" or line.parent_state == "draft":
-                account_sale_id = line.account_id.id
-                amount_inv_cur = line.price_subtotal
-                amount_comp_cur = inv_curr._convert(
-                    amount_inv_cur, comp_curr, inv.company_id, inv.date
-                )
-                sale_value += amount_comp_cur
+            account_sale_id = line.account_id.id
+            sale_value -= line.balance
         return {"sale_value": sale_value, "account_sale_id": account_sale_id}
-
-    @api.model
-    def _default_account_plus_value_id(self):
-        asset_id = self.env.context.get("active_id")
-        asset = self.env["account.asset"].browse(asset_id)
-        return asset.profile_id.account_plus_value_id
-
-    @api.model
-    def _default_account_min_value_id(self):
-        asset_id = self.env.context.get("active_id")
-        asset = self.env["account.asset"].browse(asset_id)
-        return asset.profile_id.account_min_value_id
-
-    @api.model
-    def _default_account_residual_value_id(self):
-        asset_id = self.env.context.get("active_id")
-        asset = self.env["account.asset"].browse(asset_id)
-        return asset.profile_id.account_residual_value_id
 
     @api.model
     def _selection_posting_regime(self):
@@ -145,15 +125,6 @@ class AccountAssetRemove(models.TransientModel):
         ]
 
     @api.model
-    def _get_posting_regime(self):
-        asset_obj = self.env["account.asset"]
-        asset = asset_obj.browse(self.env.context.get("active_id"))
-        country = asset and asset.company_id.country_id.code or False
-        if country in self._residual_value_regime_countries():
-            return "residual_value"
-        else:
-            return "gain_loss_on_sale"
-
     def _residual_value_regime_countries(self):
         return ["FR"]
 
@@ -225,12 +196,11 @@ class AccountAssetRemove(models.TransientModel):
 
         return {
             "name": self.env._("Asset '%s' Removal Journal Entry", asset_ref),
-            "view_mode": "list,form",
+            "view_mode": "form,list",
             "res_model": "account.move",
-            "view_id": False,
             "type": "ir.actions.act_window",
             "context": self.env.context,
-            "domain": [("id", "=", move.id)],
+            "res_id": move.id,
         }
 
     def _prepare_early_removal(self, asset):

--- a/account_asset_management/wizard/account_asset_remove.xml
+++ b/account_asset_management/wizard/account_asset_remove.xml
@@ -5,10 +5,11 @@
         <field name="model">account.asset.remove</field>
         <field name="arch" type="xml">
             <form>
-                <group>
-                    <group>
-                        <field name="company_id" invisible="1" />
+                <group name="main">
+                    <group name="main_left">
                         <field name="company_id" groups="base.group_multi_company" />
+                        <field name="currency_id" invisible="1"/>
+                        <field name="asset_id" />
                         <field name="date_remove" />
                         <field name="force_date" />
                         <field name="sale_value" />
@@ -18,7 +19,7 @@
                             required="sale_value > 0.0"
                         />
                     </group>
-                    <group>
+                    <group name="main_right">
                         <field
                             name="account_plus_value_id"
                             invisible="posting_regime == 'residual_value'"
@@ -41,8 +42,6 @@
                     <separator string="Notes" colspan="4" />
                     <field name="note" nolabel="1" colspan="4" />
                 </group>
-                <newline />
-                <separator colspan="4" />
                 <footer>
                     <button
                         string="Generate Removal entries"


### PR DESCRIPTION
- Some code cleaning on removal wizard and view
- display the currency of the sale amount in the wizard
Come from https://github.com/OCA/account-financial-tools/pull/1815
- Fix the onchange that set the invoice line account from a profile where you have 2 asset profile for a same account.
In this case, when you select the account on the invoice line, Odoo take the default profile.
Then if you select the other profile (linked to the same account), odoo will rewrite the same account on the invoice line, which will re-trigger the change on the default profile. So you can never choose the secondary profile of this account.

@matthieusaison @alexis-via @sebastienbeau @clementmbr 
