### PR TITLE
[18.0][FIX] account_move_name_sequence: set sequence prefix and number

### DIFF
--- a/account_move_name_sequence/README.rst
+++ b/account_move_name_sequence/README.rst
@@ -37,16 +37,16 @@ the same journal is computed by a complex piece of code that guesses the
 format of the journal entry number from the number of the journal entry
 which was manually entered by the user. It has several drawbacks:
 
-- the available options for the sequence are limited,
-- it is not possible to configure the sequence in advance before the
-  deployment in production,
-- as it is error-prone, they added a *Resequence* wizard to re-generate
-  the journal entry numbers, which can be considered as illegal in many
-  countries,
-- the `piece of
-  code <https://github.com/odoo/odoo/blob/14.0/addons/account/models/sequence_mixin.py>`__
-  that handles this is not easy to understand and quite difficult to
-  debug.
+-  the available options for the sequence are limited,
+-  it is not possible to configure the sequence in advance before the
+   deployment in production,
+-  as it is error-prone, they added a *Resequence* wizard to re-generate
+   the journal entry numbers, which can be considered as illegal in many
+   countries,
+-  the `piece of
+   code <https://github.com/odoo/odoo/blob/14.0/addons/account/models/sequence_mixin.py>`__
+   that handles this is not easy to understand and quite difficult to
+   debug.
 
 Using this module, you can configure what kind of documents the gap
 sequence may be relaxed And even if you must use no-gap in your company
@@ -114,18 +114,18 @@ Authors
 Contributors
 ------------
 
-- `Akretion <https://www.akretion.com>`__:
+-  `Akretion <https://www.akretion.com>`__:
 
-  - Alexis de Lattre <alexis.delattre@akretion.com>
+   -  Alexis de Lattre <alexis.delattre@akretion.com>
 
-- `Vauxoo <https://www.vauxoo.com>`__:
+-  `Vauxoo <https://www.vauxoo.com>`__:
 
-  - Moisés López <moylop260@vauxoo.com>
-  - Francisco Luna <fluna@vauxoo.com>
+   -  Moisés López <moylop260@vauxoo.com>
+   -  Francisco Luna <fluna@vauxoo.com>
 
-- `Factor Libre <https://www.factorlibre.com>`__:
+-  `Factor Libre <https://www.factorlibre.com>`__:
 
-  - Rodrigo Bonilla Martinez <rodrigo.bonilla@factorlibre.com>
+   -  Rodrigo Bonilla Martinez <rodrigo.bonilla@factorlibre.com>
 
 Maintainers
 -----------

--- a/account_move_name_sequence/__manifest__.py
+++ b/account_move_name_sequence/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Account Move Number Sequence",
-    "version": "18.0.1.0.1",
+    "version": "18.0.2.0.0",
     "category": "Accounting",
     "license": "AGPL-3",
     "summary": "Generate journal entry number from sequence",

--- a/account_move_name_sequence/migrations/18.0.2.0.0/post-migration.py
+++ b/account_move_name_sequence/migrations/18.0.2.0.0/post-migration.py
@@ -1,0 +1,45 @@
+# Copyright 2025 Le Filament (https://www.le-filament.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import re
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    for journal in env["account.journal"].search(
+        [("restrict_mode_hash_table", "=", True)]
+    ):
+        journal_moves = env["account.move"].search(
+            [
+                ("state", "=", "posted"),
+                ("journal_id", "=", journal.id),
+                "|",
+                ("sequence_prefix", "=", False),
+                "|",
+                ("sequence_number", "=", False),
+                ("sequence_number", "=", 0),
+            ]
+        )
+        for (move_type, year), moves in journal_moves.grouped(
+            lambda m: (m.move_type, m.date.year)
+        ).items():
+            if (
+                move_type in ["in_refund", "out_refund"]
+                and journal.refund_sequence
+                and journal.refund_sequence_id
+            ):
+                sequence = journal.refund_sequence_id
+            else:
+                sequence = journal.sequence_id
+            prefix, suffix = sequence._get_prefix_suffix(
+                date=f"{year}-01-01", date_range=f"{year}-01-01"
+            )
+            pattern = re.compile(f"{prefix}[0-9]{{{sequence.padding}}}{suffix}")
+            filtered_moves = moves.filtered(lambda move: pattern.match(move.name))  # noqa: B023
+            filtered_moves.sequence_prefix = prefix
+            for move in filtered_moves:
+                move.sequence_number = int(
+                    move.name[len(prefix) : len(move.name) - len(suffix)]
+                )
+            filtered_moves._compute_made_sequence_gap()

--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Akretion France (http://www.akretion.com/)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
 from odoo import api, fields, models
 
 
@@ -9,11 +8,9 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     name = fields.Char(compute="_compute_name_by_sequence")
-    # highest_name, sequence_prefix, sequence_number are not needed any more
+    # highest_name is not needed any more
     # -> compute=False to improve perf
     highest_name = fields.Char(compute=False)
-    sequence_prefix = fields.Char(compute=False)
-    sequence_number = fields.Integer(compute=False)
     # made_sequence_hole is not relevant anymore (since based on sequence_prefix/number)
     # -> compute=False to improve perf and to avoid displaying warning
     made_sequence_hole = fields.Boolean(compute=False)
@@ -26,6 +23,48 @@ class AccountMove(models.Model):
             "Check the journal sequence, please",
         ),
     ]
+
+    @api.depends("name")
+    def _compute_split_sequence(self):
+        """
+        Replace original compute function from Odoo account module
+        to compute sequend and prefix from name only if journal is
+        in secured mode (restrict_mode_hash_table)
+        Since both sequence_prefix and sequence_number are needed for
+        computing hash since Odoo v18.0
+        """
+        moves = self.filtered(
+            lambda move: move.name
+            and move.name != "/"
+            and move.journal_id
+            and move.move_type
+            and move.restrict_mode_hash_table
+        )
+        # Handle moves grouped by journal / move_type and year
+        for (journal, move_type, year), grouped_moves in moves.grouped(
+            lambda m: (m.journal_id, m.move_type, m.date.year)
+        ).items():
+            # Get the correct sequence in case there is a specific
+            # one for refund configured on journal
+            if (
+                move_type in ["in_refund", "out_refund"]
+                and journal.refund_sequence
+                and journal.refund_sequence_id
+            ):
+                sequence = journal.refund_sequence_id
+            else:
+                sequence = journal.sequence_id
+            # Retrieve prefix and suffix to extract number
+            prefix, suffix = sequence._get_prefix_suffix(
+                date=f"{year}-01-01", date_range=f"{year}-01-01"
+            )
+            # Set prefix
+            grouped_moves.sequence_prefix = prefix
+            for move in grouped_moves:
+                # Get number for each move
+                move.sequence_number = int(
+                    move.name[len(prefix) : len(move.name) - len(suffix)]
+                )
 
     @api.depends("state", "journal_id", "date")
     def _compute_name_by_sequence(self):
@@ -54,6 +93,9 @@ class AccountMove(models.Model):
                 # which applies on ir.sequence.date_range selection AND prefix
                 name = seq.with_context(ir_sequence_date=move.date).next_by_id()
             move.name = name
+        # Force compute of sequence_prefix and sequence_number
+        self._compute_split_sequence()
+        # Force compute of fields depending on name
         self._inverse_name()
 
     # We must by-pass this constraint of sequence.mixin

--- a/account_move_name_sequence/tests/__init__.py
+++ b/account_move_name_sequence/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_account_move_name_seq
+from . import test_account_move_name_seq_hashed_journal
 from . import test_sequence_concurrency
 from . import test_account_incoming_supplier_invoice

--- a/account_move_name_sequence/tests/test_account_incoming_supplier_invoice.py
+++ b/account_move_name_sequence/tests/test_account_incoming_supplier_invoice.py
@@ -1,5 +1,7 @@
 import json
 
+from markupsafe import Markup
+
 from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -86,7 +88,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
         )
         self.assertEqual(
             message_ids.body,
-            "<p>Vendor Bill Created</p>",
+            Markup("<p>Vendor Bill Created</p>"),
             "Only the invoice creation should be posted",
         )
 

--- a/account_move_name_sequence/tests/test_account_move_name_seq_hashed_journal.py
+++ b/account_move_name_sequence/tests/test_account_move_name_seq_hashed_journal.py
@@ -1,0 +1,66 @@
+# Copyright 2025 Le Filament (https://le-filament.com)
+# @author: Rémi - Le Filament <remi-filament>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from freezegun import freeze_time
+
+from odoo.tests import tagged
+
+from odoo.addons.account_move_name_sequence.tests.test_account_move_name_seq import (
+    TestAccountMoveNameSequence,
+)
+
+
+@tagged("post_install", "-at_install")
+class TestAccountMoveNameSequenceHashedJournal(TestAccountMoveNameSequence):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.sales_journal.restrict_mode_hash_table = True
+
+    def test_account_move_hashed(self):
+        seq = self.sales_journal.sequence_id
+        seq.prefix = "TEST-%(range_year)s-"
+        with freeze_time("2022-05-31"):
+            move = self.env["account.move"].create(
+                {
+                    "journal_id": self.sales_journal.id,
+                    "partner_id": self.env.ref("base.res_partner_3").id,
+                    "move_type": "out_invoice",
+                    "invoice_line_ids": self.invoice_line,
+                }
+            )
+            move2 = move.copy()
+            move.action_post()
+            move2.action_post()
+        self.assertEqual(move.name, "TEST-2022-0001")
+        self.assertEqual(move2.name, "TEST-2022-0002")
+        self.assertEqual(move.sequence_prefix, "TEST-2022-")
+        self.assertEqual(move2.sequence_prefix, "TEST-2022-")
+        self.assertEqual(move.sequence_number, 1)
+        self.assertEqual(move2.sequence_number, 2)
+
+    def test_account_move_hashed_suffix(self):
+        seq = self.sales_journal.sequence_id
+        seq.prefix = "TEST-%(range_year)s-"
+        seq.suffix = "-TEST_SUFFIX"
+        with freeze_time("2022-05-31"):
+            move = self.env["account.move"].create(
+                {
+                    "journal_id": self.sales_journal.id,
+                    "partner_id": self.env.ref("base.res_partner_3").id,
+                    "move_type": "out_invoice",
+                    "invoice_line_ids": self.invoice_line,
+                }
+            )
+            move2 = move.copy()
+            move.action_post()
+            move2.action_post()
+        self.assertEqual(move.name, "TEST-2022-0001-TEST_SUFFIX")
+        self.assertEqual(move2.name, "TEST-2022-0002-TEST_SUFFIX")
+        self.assertEqual(move.sequence_prefix, "TEST-2022-")
+        self.assertEqual(move2.sequence_prefix, "TEST-2022-")
+        self.assertEqual(move.sequence_number, 1)
+        self.assertEqual(move2.sequence_number, 2)


### PR DESCRIPTION
Since v18, Odoo relies on sequence_prefix and sequence_number for hashing moves.
Since these fields are not set anymore with this module, you cannot post invoices (after the first one).

Solves #2133 