### PR TITLE
[18.0][FIX] account_asset_management: Raise UserError when an asset has no creation line

### DIFF
--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -183,8 +183,16 @@ class AccountAssetRemove(models.TransientModel):
         else:
             create_dl = asset_line_obj.search(
                 [("asset_id", "=", asset.id), ("type", "=", "create")]
-            )[0]
-            last_date = create_dl.line_date
+            )
+            if create_dl:
+                last_date = create_dl[0].line_date
+            else:
+                raise UserError(
+                    self.env._(
+                        "There are no depreciation lines for this asset. "
+                        "Please compute the depreciation board first."
+                    )
+                )
 
         if self.date_remove < last_date:
             raise UserError(


### PR DESCRIPTION
### FIX

This PR fixes an `IndexError` in the `remove` method of the `account.asset.remove` wizard in the `account_asset_management` module.

The error occurred when trying to remove an asset that had no associated creation line (`type: 'create'`) in its accounting history. In this situation, the search for the creation line returned an empty recordset, and the code attempted to access the first element (`[0]`), which caused the crash.

### Solution

A check has been added to the code to ensure that the search for the creation line returns a valid result. If it's not found, a `UserError` with a clear message is raised to the user, preventing the operation from failing unexpectedly.

### Tests Performed

1.  Create a new asset with an asset profile.
2.  From the asset form, click "Remove Asset".
3.  Attempt to remove the asset.
4.  Verify that the `IndexError` no longer occurs, and instead, a clear `UserError` is displayed if the creation line does not exist.

Error crashed

<img width="1150" height="875" alt="Captura de pantalla de 2025-08-20 11-49-12" src="https://github.com/user-attachments/assets/e934d72a-050a-4cce-b20d-1baa56c1be8a" />
