### PR TITLE
16.0[IMP] account_loan: Currency on loan not readonly + convert credit/debit for different currencies

### DIFF
--- a/account_loan/models/account_loan.py
+++ b/account_loan/models/account_loan.py
@@ -161,9 +161,7 @@ class AccountLoan(models.Model):
         help="When checked, the first payment will be on start date",
     )
     currency_id = fields.Many2one(
-        "res.currency",
-        compute="_compute_currency",
-        readonly=True,
+        "res.currency", compute="_compute_currency", readonly=False, store=True
     )
     journal_type = fields.Char(compute="_compute_journal_type")
     journal_id = fields.Many2one(

--- a/account_loan/models/account_loan_line.py
+++ b/account_loan/models/account_loan_line.py
@@ -249,17 +249,40 @@ class AccountLoanLine(models.Model):
         long_term_moves = self.move_ids.mapped("line_ids").filtered(
             lambda r: r.account_id == self.loan_id.long_term_loan_account_id
         )
-        self.interests_amount = sum(interests_moves.mapped("debit")) - sum(
+        interests_in_company_currency = sum(interests_moves.mapped("debit")) - sum(
             interests_moves.mapped("credit")
         )
-        self.long_term_principal_amount = sum(long_term_moves.mapped("debit")) - sum(
-            long_term_moves.mapped("credit")
+        self.interests_amount = self.loan_id.company_id.currency_id._convert(
+            from_amount=interests_in_company_currency,
+            to_currency=self.loan_id.currency_id,
+            company=self.loan_id.company_id,
+            date=self.date,
+            round=True,
         )
-        self.payment_amount = (
+
+        long_term_principal_amount_in_company_currency = sum(
+            long_term_moves.mapped("debit")
+        ) - sum(long_term_moves.mapped("credit"))
+        self.long_term_principal_amount = self.loan_id.company_id.currency_id._convert(
+            from_amount=long_term_principal_amount_in_company_currency,
+            to_currency=self.loan_id.currency_id,
+            company=self.loan_id.company_id,
+            date=self.date,
+            round=True,
+        )
+
+        payment_amount_in_company_currency = (
             sum(short_term_moves.mapped("debit"))
             - sum(short_term_moves.mapped("credit"))
-            + self.long_term_principal_amount
-            + self.interests_amount
+            + long_term_principal_amount_in_company_currency
+            + interests_in_company_currency
+        )
+        self.payment_amount = self.loan_id.company_id.currency_id._convert(
+            from_amount=payment_amount_in_company_currency,
+            to_currency=self.loan_id.currency_id,
+            company=self.loan_id.company_id,
+            date=self.date,
+            round=True,
         )
 
     def _move_vals(self, journal=False, account=False):
@@ -283,10 +306,19 @@ class AccountLoanLine(models.Model):
                 "account_id": (account and account.id)
                 or partner.property_account_payable_id.id,
                 "partner_id": partner.id,
-                "credit": self.payment_amount,
                 "debit": 0,
+                "currency_id": self.loan_id.currency_id.id,
+                "credit": self.loan_id.currency_id._convert(
+                    from_amount=self.payment_amount,
+                    to_currency=self.loan_id.company_id.currency_id,
+                    company=self.loan_id.company_id,
+                    date=self.date,
+                    round=True,
+                ),
+                "amount_currency": -self.payment_amount,
             }
         )
+
         return vals
 
     def _add_interests_values(self, vals):
@@ -295,7 +327,15 @@ class AccountLoanLine(models.Model):
             {
                 "account_id": self.loan_id.interest_expenses_account_id.id,
                 "credit": 0,
-                "debit": self.interests_amount,
+                "currency_id": self.loan_id.currency_id.id,
+                "debit": self.loan_id.currency_id._convert(
+                    from_amount=self.interests_amount,
+                    to_currency=self.loan_id.company_id.currency_id,
+                    company=self.loan_id.company_id,
+                    date=self.date,
+                    round=True,
+                ),
+                "amount_currency": self.interests_amount,
             }
         )
         return vals
@@ -306,7 +346,15 @@ class AccountLoanLine(models.Model):
             {
                 "account_id": self.loan_id.short_term_loan_account_id.id,
                 "credit": 0,
-                "debit": self.payment_amount - self.interests_amount,
+                "currency_id": self.loan_id.currency_id.id,
+                "debit": self.loan_id.currency_id._convert(
+                    from_amount=self.payment_amount - self.interests_amount,
+                    to_currency=self.loan_id.company_id.currency_id,
+                    company=self.loan_id.company_id,
+                    date=self.date,
+                    round=True,
+                ),
+                "amount_currency": self.payment_amount - self.interests_amount,
             }
         )
         return vals
@@ -317,15 +365,31 @@ class AccountLoanLine(models.Model):
             vals.append(
                 {
                     "account_id": self.loan_id.short_term_loan_account_id.id,
-                    "credit": self.long_term_principal_amount,
                     "debit": 0,
+                    "currency_id": self.loan_id.currency_id.id,
+                    "credit": self.loan_id.currency_id._convert(
+                        from_amount=self.long_term_principal_amount,
+                        to_currency=self.loan_id.company_id.currency_id,
+                        company=self.loan_id.company_id,
+                        date=self.date,
+                        round=True,
+                    ),
+                    "amount_currency": -self.long_term_principal_amount,
                 }
             )
             vals.append(
                 {
                     "account_id": self.long_term_loan_account_id.id,
                     "credit": 0,
-                    "debit": self.long_term_principal_amount,
+                    "currency_id": self.loan_id.currency_id.id,
+                    "debit": self.loan_id.currency_id._convert(
+                        from_amount=self.long_term_principal_amount,
+                        to_currency=self.loan_id.company_id.currency_id,
+                        company=self.loan_id.company_id,
+                        date=self.date,
+                        round=True,
+                    ),
+                    "amount_currency": self.long_term_principal_amount,
                 }
             )
         return vals

--- a/account_loan/tests/test_loan.py
+++ b/account_loan/tests/test_loan.py
@@ -617,3 +617,30 @@ class TestLoan(TransactionCase):
         )
         loan.compute_lines()
         return loan
+
+    def test_change_currency(self):
+        loan = self.create_loan("fixed-annuity", 500000, 1, 60)
+        eur_currency = self.env.ref("base.EUR")
+        usd_currency = self.env.ref("base.USD")
+        loan.journal_id.currency_id = eur_currency
+        loan.currency_id = eur_currency
+        loan.company_id.currency_id = usd_currency
+        self.assertEqual(loan.currency_id, loan.journal_id.currency_id)
+        loan.compute_lines()
+        for line in loan.line_ids:
+            self.assertEqual(line.currency_id, loan.currency_id)
+
+        line = fields.first(loan.line_ids)
+        line.view_process_values()
+
+        move_lines = line.mapped("move_ids.line_ids")
+        # Credit/Debit lines should be in USD, while amount_currency is in EUR
+        self.assertAlmostEqual(
+            move_lines[0].credit, -move_lines[0].amount_currency / eur_currency.rate, 2
+        )
+        self.assertAlmostEqual(
+            move_lines[1].debit, move_lines[1].amount_currency / eur_currency.rate, 2
+        )
+        self.assertAlmostEqual(
+            move_lines[2].debit, move_lines[2].amount_currency / eur_currency.rate, 2
+        )

--- a/account_loan/views/account_loan_view.xml
+++ b/account_loan/views/account_loan_view.xml
@@ -159,7 +159,10 @@
                                         attrs="{'invisible': ['|', ('is_leasing', '=', False), ('long_term_loan_account_id', '=', False)]}"
                                     />
                                     <field name="interest_expenses_account_id" />
-                                    <field name="currency_id" invisible="1" />
+                                    <field
+                                        name="currency_id"
+                                        groups="base.group_multi_currency"
+                                    />
                                 </group>
                             </group>
                         </page>

--- a/account_loan/wizards/account_loan_post.py
+++ b/account_loan/wizards/account_loan_post.py
@@ -48,18 +48,35 @@ class AccountLoanPost(models.TransientModel):
                 "name": self.loan_id.name,
                 "partner_id": partner.id,
                 "credit": 0,
-                "debit": line.pending_principal_amount,
+                "currency_id": self.loan_id.currency_id.id,
+                "amount_currency": line.pending_principal_amount,
+                "debit": self.loan_id.currency_id._convert(
+                    from_amount=line.pending_principal_amount,
+                    to_currency=self.loan_id.company_id.currency_id,
+                    company=self.loan_id.company_id,
+                    date=self.loan_id.start_date,
+                    round=True,
+                ),
             }
         )
         if line.pending_principal_amount - line.long_term_pending_principal_amount > 0:
             res.append(
                 {
                     "account_id": self.loan_id.short_term_loan_account_id.id,
-                    "credit": (
+                    "debit": 0,
+                    "currency_id": self.loan_id.currency_id.id,
+                    "amount_currency": -(
                         line.pending_principal_amount
                         - line.long_term_pending_principal_amount
                     ),
-                    "debit": 0,
+                    "credit": self.loan_id.currency_id._convert(
+                        from_amount=line.pending_principal_amount
+                        - line.long_term_pending_principal_amount,
+                        to_currency=self.loan_id.company_id.currency_id,
+                        company=self.loan_id.company_id,
+                        date=self.loan_id.start_date,
+                        round=True,
+                    ),
                 }
             )
         if (
@@ -69,8 +86,16 @@ class AccountLoanPost(models.TransientModel):
             res.append(
                 {
                     "account_id": self.loan_id.long_term_loan_account_id.id,
-                    "credit": line.long_term_pending_principal_amount,
                     "debit": 0,
+                    "currency_id": self.loan_id.currency_id.id,
+                    "amount_currency": -line.long_term_pending_principal_amount,
+                    "credit": self.loan_id.currency_id._convert(
+                        from_amount=line.long_term_pending_principal_amount,
+                        to_currency=self.loan_id.company_id.currency_id,
+                        company=self.loan_id.company_id,
+                        date=self.loan_id.start_date,
+                        round=True,
+                    ),
                 }
             )
 


### PR DESCRIPTION
Business case: 

- Need to change the currency on a loan if different from the one on the journal/company
- If the journal on the loan is - for instance - in EUR, the loan also in EUR, but the company in USD, when we create the moves the debit/credit on lines stays in EUR. 
When we create move lines from a journal entry, if the journal is in EUR but the company in USD, the credit/debit is in USD and amount_currency is filled in EUR. 
For the loans, we wanted the same behavior : when creating the move lines from the loan line, the credit/debit should be in the currency of the company while the  amount_currency is filled with the value in the journal currency