### PR TITLE
[16.0][IMP] account_journal_general_sequence: Add ending date renumber wizard

### DIFF
--- a/account_journal_general_sequence/tests/test_numbering.py
+++ b/account_journal_general_sequence/tests/test_numbering.py
@@ -1,5 +1,7 @@
 # Copyright 2022 Moduon
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from datetime import date
+
 from freezegun import freeze_time
 
 from odoo.fields import Command
@@ -83,6 +85,36 @@ class RenumberCase(TestAccountReconciliationCommon):
         self.assertEqual(old_invoice.entry_number, "2022/00000002")
         self.assertEqual(new_invoice.entry_number, "2022/00000003")
         self.assertEqual(next_year_invoice.entry_number, "2023/00000001")
+
+    @users("test_manager")
+    def test_renumber_with_ending_date(self):
+        # Post invoices in wrong order to mess up entry numbers
+        invoice_jun = self._create_invoice(
+            date_invoice="2022-06-15", auto_validate=True
+        )
+        invoice_jun.flush_recordset(["entry_number"])
+        invoice_may = self._create_invoice(
+            date_invoice="2022-05-10", auto_validate=True
+        )
+        invoice_may.flush_recordset(["entry_number"])
+        invoice_apr = self._create_invoice(
+            date_invoice="2022-04-30", auto_validate=True
+        )
+        invoice_apr.flush_recordset(["entry_number"])
+        # Store the original number of the June invoice, which should not be renumbered
+        original_june_number = invoice_jun.entry_number
+        self.assertLess(invoice_may.entry_number, invoice_apr.entry_number)
+        # Renumber only up to May 31st, starting from 4
+        wiz_f = Form(self.env["account.move.renumber.wizard"])
+        wiz_f.ending_date = date(2022, 5, 31)
+        wiz_f.starting_number = 4
+        wiz = wiz_f.save()
+        wiz.action_renumber()
+        # Check that invoices within the date range are now correctly ordered
+        self.assertEqual(invoice_apr.entry_number, "2022/00000004")
+        self.assertEqual(invoice_may.entry_number, "2022/00000005")
+        # Check that the invoice outside the date range keeps its original number
+        self.assertEqual(invoice_jun.entry_number, original_june_number)
 
     @users("test_invoicer")
     def test_install_no_entry_number(self):

--- a/account_journal_general_sequence/wizards/account_move_renumber_wizard.py
+++ b/account_journal_general_sequence/wizards/account_move_renumber_wizard.py
@@ -15,6 +15,10 @@ class AccountMoveRenumberWizard(models.TransientModel):
         default=lambda self: self._default_starting_date(),
         help="Renumber account moves starting this day.",
     )
+    ending_date = fields.Date(
+        help="Renumber account moves up to this day (inclusive). "
+        "If empty, all moves after starting date are renumbered.",
+    )
     starting_number = fields.Integer(
         default=1, help="Reset sequence to this number before starting."
     )
@@ -63,23 +67,24 @@ class AccountMoveRenumberWizard(models.TransientModel):
         Makes sure moves exist. Sorts them. Resets sequences. Renumbers them.
         """
         # Find posted moves that match wizard criteria
-        moves = self.env["account.move"].search(
-            [
-                ("state", "=", "posted"),
-                ("date", ">=", self.starting_date),
-                ("journal_id.entry_number_sequence_id", "=", self.sequence_id.id),
-            ],
-            order="date, id",
-        )
+        moves_domain = [
+            ("state", "=", "posted"),
+            ("date", ">=", self.starting_date),
+            ("journal_id.entry_number_sequence_id", "=", self.sequence_id.id),
+        ]
+        if self.ending_date:
+            moves_domain.append(("date", "<=", self.ending_date))
+        moves = self.env["account.move"].search(moves_domain, order="date, id")
         if not moves:
             raise exceptions.UserError(_("No account moves found."))
         # Reset sequence
-        future_ranges = self.env["ir.sequence.date_range"].search(
-            [
-                ("date_from", ">", self.starting_date),
-                ("sequence_id", "=", self.sequence_id.id),
-            ]
-        )
+        ranges_domain = [
+            ("date_from", ">", self.starting_date),
+            ("sequence_id", "=", self.sequence_id.id),
+        ]
+        if self.ending_date:
+            ranges_domain.append(("date_to", "<=", self.ending_date))
+        future_ranges = self.env["ir.sequence.date_range"].search(ranges_domain)
         # Safe `sudo` calls; wizard only available for accounting managers
         future_ranges.sudo().unlink()
         current_range = self.sequence_id._get_current_sequence(self.starting_date)

--- a/account_journal_general_sequence/wizards/account_move_renumber_wizard_views.xml
+++ b/account_journal_general_sequence/wizards/account_move_renumber_wizard_views.xml
@@ -11,6 +11,7 @@
                 <sheet>
                     <group colspan="4">
                         <field name="starting_date" />
+                        <field name="ending_date" />
                         <field name="starting_number" />
                         <field name="available_sequence_ids" invisible="1" />
                         <field name="sequence_id" />


### PR DESCRIPTION
Add new field ending_date to a more precise filter on account moves.