### PR TITLE
[IMP] product_category_tax: set category taxes for multi-company

### DIFF
--- a/product_category_tax/models/product_product.py
+++ b/product_category_tax/models/product_product.py
@@ -19,10 +19,5 @@ class ProductProduct(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             if vals.get("categ_id"):
-                if "taxes_id" not in vals:
-                    categ = self.env["product.category"].browse(vals["categ_id"])
-                    vals["taxes_id"] = [(6, 0, categ.taxes_id.ids)]
-                if "supplier_taxes_id" not in vals:
-                    categ = self.env["product.category"].browse(vals["categ_id"])
-                    vals["supplier_taxes_id"] = [(6, 0, categ.supplier_taxes_id.ids)]
+                vals = self.env["product.template"]._prepare_taxes_from_category(vals)
         return super().create(vals_list)

--- a/product_category_tax/models/product_template.py
+++ b/product_category_tax/models/product_template.py
@@ -24,20 +24,31 @@ class ProductTemplate(models.Model):
         for categ, records in records_by_categ.items():
             records.write(
                 {
-                    "taxes_id": [(6, 0, categ.taxes_id.ids)],
-                    "supplier_taxes_id": [(6, 0, categ.supplier_taxes_id.ids)],
+                    "taxes_id": [(6, 0, categ.sudo().taxes_id.ids)],
+                    "supplier_taxes_id": [(6, 0, categ.sudo().supplier_taxes_id.ids)],
                 }
             )
         return True
+
+    @api.model
+    def _prepare_taxes_from_category(self, vals):
+        existing_taxes = supplier_existing_taxes = set()
+        categ = self.env["product.category"].browse(vals["categ_id"])
+        if "taxes_id" in vals:
+            existing_taxes = set(vals["taxes_id"][0][2])
+        taxes = existing_taxes | set(categ.sudo().taxes_id.ids)
+        vals["taxes_id"] = [(6, 0, taxes)]
+        if "supplier_taxes_id" in vals:
+            supplier_existing_taxes = set(vals["supplier_taxes_id"][0][2])
+        supplier_taxes = supplier_existing_taxes | set(
+            categ.sudo().supplier_taxes_id.ids
+        )
+        vals["supplier_taxes_id"] = [(6, 0, supplier_taxes)]
+        return vals
 
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
             if vals.get("categ_id"):
-                if "taxes_id" not in vals:
-                    categ = self.env["product.category"].browse(vals["categ_id"])
-                    vals["taxes_id"] = [(6, 0, categ.taxes_id.ids)]
-                if "supplier_taxes_id" not in vals:
-                    categ = self.env["product.category"].browse(vals["categ_id"])
-                    vals["supplier_taxes_id"] = [(6, 0, categ.supplier_taxes_id.ids)]
+                vals = self._prepare_taxes_from_category(vals)
         return super().create(vals_list)

--- a/product_category_tax/tests/test_product_category_tax.py
+++ b/product_category_tax/tests/test_product_category_tax.py
@@ -162,3 +162,74 @@ class ProductCategoryTax(common.SavepointCase):
         )
         self.assertFalse(product.taxes_id, False)
         self.assertEqual(product.supplier_taxes_id, self.tax_purchase2)
+
+    def test_05_multicompany_category_taxes(self):
+        """Test multicompany: taxes from all companies are added if user has only one active company"""
+        company_a = self.env["res.company"].create({"name": "Company A"})
+        company_b = self.env["res.company"].create({"name": "Company B"})
+
+        tax_a = self.tax_model.create(
+            {
+                "name": "Tax A",
+                "type_tax_use": "sale",
+                "amount": 10.0,
+                "company_id": company_a.id,
+            }
+        )
+        tax_b = self.tax_model.create(
+            {
+                "name": "Tax B",
+                "type_tax_use": "sale",
+                "amount": 20.0,
+                "company_id": company_b.id,
+            }
+        )
+        purchase_tax_a = self.tax_model.create(
+            {
+                "name": "Purchase Tax A",
+                "type_tax_use": "purchase",
+                "amount": 5.0,
+                "company_id": company_a.id,
+            }
+        )
+        purchase_tax_b = self.tax_model.create(
+            {
+                "name": "Purchase Tax B",
+                "type_tax_use": "purchase",
+                "amount": 15.0,
+                "company_id": company_b.id,
+            }
+        )
+
+        # Create category with taxes from both companies
+        category = self.categ_obj.create(
+            {
+                "name": "MultiCompany Category",
+                "taxes_id": [(6, 0, [tax_a.id, tax_b.id])],
+                "supplier_taxes_id": [(6, 0, [purchase_tax_a.id, purchase_tax_b.id])],
+            }
+        )
+
+        # Set user to only one active company
+        user = self.env.user
+        user.company_ids = [(6, 0, [company_a.id])]
+        user.company_id = company_a.id
+
+        product = self.product_obj.create(
+            {
+                "name": "MultiCompany Product",
+                "categ_id": category.id,
+            }
+        )
+        self.assertIn(tax_a, product.taxes_id)
+        self.assertIn(tax_b, product.taxes_id)
+        self.assertIn(purchase_tax_a, product.supplier_taxes_id)
+        self.assertIn(purchase_tax_b, product.supplier_taxes_id)
+
+        # Remove taxes and "Apply on Products" from category
+        product.write({"taxes_id": [(6, 0, [])], "supplier_taxes_id": [(6, 0, [])]})
+        product.set_tax_from_category()
+        self.assertIn(tax_a, product.taxes_id)
+        self.assertIn(tax_b, product.taxes_id)
+        self.assertIn(purchase_tax_a, product.supplier_taxes_id)
+        self.assertIn(purchase_tax_b, product.supplier_taxes_id)


### PR DESCRIPTION
Previously, category taxes where not properly handled in multi-company set up. Method set_tax_from_category was depending on active companies to set category taxes to products. Default value for taxes_id on products was taken from account_sale_tax_id company field, so in the products creation, the taxes from the category were ignored if account_sale_tax_id was present. In the product creation have been included taxes from vals, and the ones from the product category.