### PR TITLE
[17.0][FIX] account_chart_update: Create the accounting accounts with the appropriate code

### DIFF
--- a/account_chart_update/tests/test_account_chart_update.py
+++ b/account_chart_update/tests/test_account_chart_update.py
@@ -115,6 +115,7 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
         new_tax = self._get_record_for_xml_id(tax_data_key_0)
         self.assertTrue(new_tax)
         new_account = self._get_record_for_xml_id(account_data_key_0)
+        self.assertEqual(len(new_account.code), wizard.code_digits)
         self.assertTrue(new_account)
         wizard.unlink()
         # Update objects

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -1008,6 +1008,8 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             if wiz_account.type == "updated":
                 self.recreate_xml_id(account, xml_id)
                 data_item = self.diff_fields(t_data_item, account)
+            else:
+                data_item["code"] = self.padded_code(data_item["code"])
             data[key] = data_item
         self._load_data("account.account", data)
 


### PR DESCRIPTION
Create the accounting accounts with the appropriate code

Define the appropriate code (with the corresponding length -`code_digits`-) in the accounting accounts to be created

Please @sergio-teruel and @pedrobaeza can you review it?

@Tecnativa TT58069