### PR TITLE
[FIX] account_check_deposit - fix stacktrace when no account_journal_payment_debit_account found

### DIFF
--- a/account_check_deposit/models/account_check_deposit.py
+++ b/account_check_deposit/models/account_check_deposit.py
@@ -242,22 +242,22 @@ class AccountCheckDeposit(models.Model):
         total_debit = self.company_id.currency_id.round(total_debit)
         total_amount_currency = self.currency_id.round(total_amount_currency)
 
-        counterpart_account_id = False
+        counterpart_account = False
         for line in self.bank_journal_id.inbound_payment_method_line_ids:
             if line.payment_method_id.code == "manual" and line.payment_account_id:
-                counterpart_account_id = line.payment_account_id.id
+                counterpart_account = line.payment_account_id
                 break
         # inspired by _get_outstanding_account() on account.payment
-        if not counterpart_account_id:
+        if not counterpart_account:
             chart_template = self.with_context(
                 allowed_company_ids=self.company_id.root_id.ids
             ).env["account.chart.template"]
-            counterpart_account_id = chart_template.ref(
+            counterpart_account = chart_template.ref(
                 "account_journal_payment_debit_account_id", raise_if_not_found=False
-            ).id
-        if not counterpart_account_id:
-            counterpart_account_id = self.company_id.transfer_account_id.id
-        if not counterpart_account_id:
+            )
+        if not counterpart_account:
+            counterpart_account = self.company_id.transfer_account_id
+        if not counterpart_account:
             raise UserError(
                 _("Missing 'Internal Transfer' account on the company '%s'.")
                 % self.company_id.display_name
@@ -284,7 +284,7 @@ class AccountCheckDeposit(models.Model):
                     0,
                     0,
                     {
-                        "account_id": counterpart_account_id,
+                        "account_id": counterpart_account.id,
                         "partner_id": False,
                         "debit": total_debit,
                         "currency_id": self.currency_id.id,


### PR DESCRIPTION
```
  File "/odoo/lib/python3.12/site-packages/odoo/addons/account_check_deposit/models/account_check_deposit.py", line 301, in validate_deposit
    move = am_obj.create(deposit._prepare_move_vals())
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/lib/python3.12/site-packages/odoo/addons/account_check_deposit/models/account_check_deposit.py", line 257, in _prepare_move_vals
    ).id
      ^^
AttributeError: 'NoneType' object has no attribute 'id'
```
We get this stacktrace in account_check_deposit. Couldn't reproduce but I believe this code should fix the stacktrace and let us fallback on company_id.transfer_account_id.