### PR TITLE
[18.0][FIX] account_asset_transfer: correct view_mode from tree to list

### DIFF
--- a/account_asset_transfer/README.rst
+++ b/account_asset_transfer/README.rst
@@ -94,6 +94,10 @@ Contributors
   - Pimolnat Suntian <pimolnats@ecosoft.co.th>
   - Saran Lim. <saranl@ecosoft.co.th>
 
+- `NuoBiT <https://www.nuobit.com>`__:
+
+  - Deniz Gallo dgallo@nuobit.com
+
 Maintainers
 -----------
 

--- a/account_asset_transfer/models/account_asset.py
+++ b/account_asset_transfer/models/account_asset.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# Copyright 2025 NuoBiT Solutions - Deniz Gallo <dgallo@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -95,7 +96,7 @@ class AccountAsset(models.Model):
                 break
         return {
             "name": self.env._("Assets"),
-            "view_mode": "tree,form",
+            "view_mode": "list,form",
             "res_model": "account.asset",
             "view_id": False,
             "type": "ir.actions.act_window",

--- a/account_asset_transfer/readme/CONTRIBUTORS.md
+++ b/account_asset_transfer/readme/CONTRIBUTORS.md
@@ -2,3 +2,5 @@
   - Kitti U. \<<kittiu@ecosoft.co.th>\>
   - Pimolnat Suntian \<<pimolnats@ecosoft.co.th>\>
   - Saran Lim. \<<saranl@ecosoft.co.th>\>
+- [NuoBiT](https://www.nuobit.com):
+  - Deniz Gallo <dgallo@nuobit.com>

--- a/account_asset_transfer/static/description/index.html
+++ b/account_asset_transfer/static/description/index.html
@@ -439,6 +439,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Saran Lim. &lt;<a class="reference external" href="mailto:saranl&#64;ecosoft.co.th">saranl&#64;ecosoft.co.th</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.nuobit.com">NuoBiT</a>:<ul>
+<li>Deniz Gallo <a class="reference external" href="mailto:dgallo&#64;nuobit.com">dgallo&#64;nuobit.com</a></li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
<img width="1109" height="218" alt="Captura de pantalla de 2025-11-05 16-07-18" src="https://github.com/user-attachments/assets/81ee2afc-14fe-4cc2-b6ed-98cdc7341118" />

This PR fixes an issue that occurs when clicking the "Asset From" and "Asset To" buttons within the account_asset_management.account_asset_view_form view. When interacting with these buttons, the following error is generated:

<img width="1247" height="497" alt="Captura de pantalla de 2025-11-05 16-10-41" src="https://github.com/user-attachments/assets/474b6cb0-85e1-4031-8f90-5390aae65ca2" />
