### PR TITLE
[18.0][FIX] account_move_name_sequence: update made_sequence_gap after migration

### DIFF
--- a/account_move_name_sequence/migrations/18.0.2.0.2/pre-migration.py
+++ b/account_move_name_sequence/migrations/18.0.2.0.2/pre-migration.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Le Filament (https://www.le-filament.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    This migration script was added for handling made_sequence_gap added in v18
+    Openupgrade script initialize this value to True and the recompute it
+    based on sequence_number / sequence_prefix
+    (see https://github.com/OCA/OpenUpgrade/pull/5447)
+    Since these 2 fields are not used by this module (except when journal is in hashed
+    mode), we need to force all made_sequence_gap to False when these fields are not set
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move am
+        SET made_sequence_gap = False
+        FROM account_journal aj
+        WHERE am.journal_id = aj.id
+            AND aj.restrict_mode_hash_table IS NOT TRUE
+        """,
+    )

--- a/account_move_name_sequence/models/account_journal.py
+++ b/account_move_name_sequence/models/account_journal.py
@@ -118,7 +118,7 @@ class AccountJournal(models.Model):
             ("name", "!=", "/"),
         ]
         if self.refund_sequence:
-            #  Based on original Odoo behavior
+            # Based on original Odoo behavior
             if refund:
                 move_domain.append(("move_type", "in", ("out_refund", "in_refund")))
             else:

--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -11,9 +11,6 @@ class AccountMove(models.Model):
     # highest_name is not needed any more
     # -> compute=False to improve perf
     highest_name = fields.Char(compute=False)
-    # made_sequence_hole is not relevant anymore (since based on sequence_prefix/number)
-    # -> compute=False to improve perf and to avoid displaying warning
-    made_sequence_hole = fields.Boolean(compute=False)
 
     _sql_constraints = [
         (
@@ -28,7 +25,7 @@ class AccountMove(models.Model):
     def _compute_split_sequence(self):
         """
         Replace original compute function from Odoo account module
-        to compute sequend and prefix from name only if journal is
+        to compute sequence and prefix from name only if journal is
         in secured mode (restrict_mode_hash_table)
         Since both sequence_prefix and sequence_number are needed for
         computing hash since Odoo v18.0
@@ -97,6 +94,18 @@ class AccountMove(models.Model):
         self._compute_split_sequence()
         # Force compute of fields depending on name
         self._inverse_name()
+
+    @api.depends("journal_id", "sequence_number", "sequence_prefix", "state")
+    def _compute_made_sequence_gap(self):
+        """
+        Inherit default function from Odoo account module
+        If no sequence_number and sequence_prefix is defined on move
+        (= when we are using this module that would be only on non-hashed journal)
+        made_sequence_gap cannot be computed and is therefore set to False
+        """
+        moves = self.filtered("journal_id.restrict_mode_hash_table")
+        (self - moves).made_sequence_gap = False
+        return super(AccountMove, moves)._compute_made_sequence_gap()
 
     # We must by-pass this constraint of sequence.mixin
     def _constrains_date_sequence(self):


### PR DESCRIPTION
As per changes introduced on OpenUpgrade with https://github.com/OCA/OpenUpgrade/pull/5447
made_sequence_gap is created during migration to version 18.0 with value = True, then it is recomputed to False based on sequence_prefix and sequence_number.

Since these 2 fields are disabled by this module (except on hashed journals), all the moves will end up with made_sequence_gap = True causing all move lines to be displayed in red.

This PR proposes to recompute made_sequence_gap to False for all moves belonging to a journal which is not hashed. 