### PR TITLE
[18.0][FIX] account_chart_update: Allow updating the length of the account numbers

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -554,7 +554,6 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             record_value, real_value = record_values[key], real[key]
             if real._name == "account.account" and key == "code":
                 record_value = self.padded_code(record_value)
-                real_value = self.padded_code(real_value)
             # Field ttype conditions
             if field.ttype == "many2many":
                 if isinstance(record_value, str):

--- a/account_chart_update/wizard/wizard_chart_update_view.xml
+++ b/account_chart_update/wizard/wizard_chart_update_view.xml
@@ -29,7 +29,7 @@
                 </div>
                 <group string="Chart of Accounts" invisible="state!='init'">
                     <field name="company_id" domain="[('parent_id', '=', False)]" />
-                    <field name="code_digits" invisible="1" />
+                    <field name="code_digits" />
                     <field name="chart_template" required="1" />
                 </group>
                 <notebook invisible="state!='init'">


### PR DESCRIPTION
In previous versions, when account.chart.template wasn't an AbstractModel, we could change the number of digits on the template before updating it, but now, that's not an option since there is no code_digits field anymore and adding it to the _get_es_pymes_template_data function won't work either.