### PR TITLE
[18.0] [IMP] account_asset_management: Compute Assets multi-company

### DIFF
--- a/account_asset_management/wizard/account_asset_compute.py
+++ b/account_asset_management/wizard/account_asset_compute.py
@@ -16,10 +16,16 @@ class AccountAssetCompute(models.TransientModel):
         " posted",
     )
     note = fields.Text()
+    company_ids = fields.Many2many(
+        "res.company", string="Companies", default=lambda self: self.env.companies
+    )
 
     def _get_domain_asset_to_compute(self):
         self.ensure_one()
-        return [("state", "=", "open")]
+        domain = [("state", "=", "open")]
+        if self.company_ids:
+            domain += [("company_id", "in", [False] + self.company_ids.ids)]
+        return domain
 
     def asset_compute(self):
         assets = self.env["account.asset"].search(self._get_domain_asset_to_compute())

--- a/account_asset_management/wizard/account_asset_compute.xml
+++ b/account_asset_management/wizard/account_asset_compute.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <form>
                 <group>
+                    <field name="company_ids" widget="many2many_tags" groups="base.group_multi_company" />
                     <field
                         name="date_end"
                         options="{'no_create': True, 'no_open': True}"


### PR DESCRIPTION
Avoid computing assets on unexpected companies by mistake.

Before this PR, the use of the widget "Compute Assets" would compute assets on every companies accessible to the user, even if they are not activated.