### PR TITLE
[18.0][FIX] account_chart_update: Use correct variable in group code comparison

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -907,7 +907,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 if code_prefix_end != account_group.code_prefix_end:
                     notes += (notes and "\n" or "") + _(
                         "Differences in these fields: %s."
-                    ) % r_data["code_prefix_end"]
+                    ) % code_prefix_end
                 if self.missing_xml_id(account_group, xmlid):
                     notes += (notes and "\n" or "") + _("Missing XML-ID.")
                 if notes:


### PR DESCRIPTION
Since the comparison code is calculated in the variable 'code_prefix_end', this is the variable that must be used when notifying the user.