### PR TITLE
[18.0][FIX] account_asset_management: Don't copy move line asset_id

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -183,6 +183,7 @@ class AccountMoveLine(models.Model):
         string="Asset",
         ondelete="restrict",
         check_company=True,
+        copy=False,
     )
 
     @api.depends("account_id", "asset_id")


### PR DESCRIPTION
It makes no sense to duplicate the assets when a move is duplicated, plus it fails because of the check in `create()`