### PR TITLE
[FIX][18.0] account_lock_to_date: evaluation of user_lock_date

### DIFF
--- a/account_lock_to_date/tests/test_account_lock_to_date_update.py
+++ b/account_lock_to_date/tests/test_account_lock_to_date_update.py
@@ -166,7 +166,12 @@ class TestAccountLockToDateUpdate(TransactionCase):
         self.company.purchase_lock_to_date = "2900-01-01"
         self.company.fiscalyear_lock_to_date = "2900-02-01"
         self.company.hard_lock_to_date = "2900-02-01"
+        # before: ?
         move = self.create_account_move("2800-01-01", self.bank_journal)
+        move.with_user(self.demo_user.id).action_post()
+        self.assertEqual(move.state, "posted")
+        # after
+        move = self.create_account_move("2901-01-01", self.bank_journal)
         move.with_user(self.demo_user.id).action_post()
         self.assertEqual(move.state, "posted")
 

--- a/account_lock_to_date/tests/test_account_lock_to_date_update.py
+++ b/account_lock_to_date/tests/test_account_lock_to_date_update.py
@@ -179,3 +179,34 @@ class TestAccountLockToDateUpdate(TransactionCase):
             self.company.purchase_lock_to_date = "2900-01-01"
             self.company.fiscalyear_lock_to_date = "2900-02-01"
             self.company.hard_lock_to_date = "2900-02-01"
+
+    def test_07_test_soft_lock(self):
+        self.company.fiscalyear_lock_to_date = "2900-01-29"
+        self.company.sale_lock_to_date = False
+        self.company.purchase_lock_to_date = False
+        self.company.hard_lock_to_date = "2900-04-01"
+        # create a super old exception
+        self.env["account.lock_exception"].create(
+            {
+                "state": "active",
+                "user_id": self.demo_user.id,
+                "lock_date_field": "fiscalyear_lock_to_date",
+                "lock_date": "2899-01-01",
+            }
+        )
+        move = self.create_account_move("2900-01-15", self.sale_journal)
+        move.with_user(self.demo_user.id).action_post()
+        self.assertEqual(move.state, "posted")
+        # now we create a current exception and verify it works
+        self.env["account.lock_exception"].create(
+            {
+                "state": "active",
+                "user_id": self.demo_user.id,
+                "lock_date_field": "fiscalyear_lock_to_date",
+                "lock_date": "2900-03-01",
+            }
+        )
+        # now we have an exception that should make this work, even if we are
+        # before soft_lock date
+        move = self.create_account_move("2900-02-01", self.sale_journal)
+        move.with_user(self.demo_user.id).action_post()


### PR DESCRIPTION
We ran into an issue that 2025 journal entries were triggering the error:

> You cannot add/modify entries posterior to and inclusive of: Sales Lock To Date (31/12/2024).

Because user_lock_to_date was set to 31-12-2024

Actually any user_lock_to_date even one far in the past would trigger a violation
