### PR TITLE
[18.0][FIX] account_chart_update: Define the appropriate translation value if the value is null in the database

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -30,11 +30,22 @@ class _OverwritingTranslationImporter(TranslationImporter):
                 if not callable(self.env[mname]._fields[fname].translate):
                     continue
                 for xml_id, langs in xml_ids.items():
-                    src = str(self.env.ref(xml_id).with_context(lang="en_US")[fname])
+                    src_value = self.env.ref(xml_id).with_context(lang="en_US")[fname]
+                    src = str(src_value) if src_value else False
                     for lang, translation in langs.items():
-                        self.model_terms_translations[mname][fname][xml_id][src][
-                            lang
-                        ] = translation
+                        # We should only use model_terms_translations if there is a
+                        # value (src), otherwise the translation of this field will
+                        # not be saved.
+                        # If the data is empty in the database (null), the value will
+                        # be defined directly.
+                        if src:
+                            self.model_terms_translations[mname][fname][xml_id][src][
+                                lang
+                            ] = translation
+                        else:
+                            self.env.ref(xml_id).with_context(lang=lang)[fname] = (
+                                translation
+                            )
 
         return super().save(overwrite=True, force_overwrite=True)
 


### PR DESCRIPTION
Define the appropriate translation value if the value is null in the database

Example use case:
- Install l10n_es
- Activate es_ES language
- Disable the en_US language
- Change the description field of an account.tax record to False: This will leave the value of that record in the database as null
- Run the account_chart_update for taxes only
- The value of the description field of the corresponding account.tax record will have been updated

Related to https://github.com/OCA/account-financial-tools/pull/2166

Please @pedrobaeza can you review it?

@Tecnativa TT60737