### PR TITLE
[18][FIX] account_asset_management : Avoid recomputation loop in invoice line if an account is linked to multiple profiles

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -195,7 +195,10 @@ class AccountMoveLine(models.Model):
 
     @api.onchange("asset_profile_id")
     def _onchange_asset_profile_id(self):
-        if self.asset_profile_id.account_asset_id:
+        if (
+            self.asset_profile_id.account_asset_id
+            and self.asset_profile_id.account_asset_id != self.account_id
+        ):
             self.account_id = self.asset_profile_id.account_asset_id
 
     @api.model_create_multi


### PR DESCRIPTION
To reproduce the bug : 
Create 2 asset profiles for a same asset account (example : "profile 2 years" and "profile 5 years")
Set one of these 2 profile as a default profile on the account, example "profile 2 years".

Then create a supplier invoice and choose the asset account. Odoo set the asset profile "profile 2 years" by default.
Now, try to change the asset  profile for the other one "profile 5 years" : you can't.
This is because changing the profile triggers the `_onchange_asset_profile_id` method, which set the asset account on the line. And setting the asset account triggers the recompute of the profile with `_compute_asset_profile`, which reset the default profile.

@bguillot  @pedrobaeza Would you mind to review this "easy" one ?