### PR TITLE
[18.0][IMP] account_asset_management: Improve readability of long record names

### DIFF
--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -55,7 +55,6 @@
                         <h1>
                             <field
                                 name="name"
-                                class="oe_inline"
                                 readonly="state in ['open', 'close', 'removed']"
                             />
                         </h1>


### PR DESCRIPTION
This PR improves the display name format for records with long names to make them easier to read.
No functional changes.

**Before**
<img width="1637" height="530" alt="selection_034" src="https://github.com/user-attachments/assets/bbf3d53c-a056-4b91-97b2-9bd3f1ff23c7" />

**After**
<img width="1625" height="593" alt="selection_033" src="https://github.com/user-attachments/assets/5338ea96-051e-40ac-984f-20c7825f1a5b" />
