### PR TITLE
[17.0][FIX] account_chart_update: unlink pos.payment.method before deleting journals in tests

### DIFF
--- a/account_chart_update/tests/test_account_chart_update.py
+++ b/account_chart_update/tests/test_account_chart_update.py
@@ -58,9 +58,18 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
         values = [f"account.account,{a_id}" for a_id in accounts.ids]
         ip.search([("value_reference", "in", values)]).unlink()
         journals = self.env["account.journal"].search(domain)
+        # Empty accounts references in journals, allowing to unlink them
+        # later without FK error
+        journals.write(
+            {
+                "default_account_id": False,
+                "suspense_account_id": False,
+                "profit_account_id": False,
+                "loss_account_id": False,
+            }
+        )
         values = [f"account.journal,{j_id}" for j_id in journals.ids]
         ip.search([("value_reference", "in", values)]).unlink()
-        journals.unlink()
         accounts.unlink()
         self.env["account.fiscal.position"].search(domain).unlink()
         self.env["account.group"].search(domain).unlink()


### PR DESCRIPTION
When running `test_chart_update_01` against a database with POS installed and configured, the test fails with a `RestrictViolation` because journals are referenced by external models (e.g. `pos.payment.method`, `pos.config`) via `RESTRICT` foreign key constraints. 

This fix clears the account references from the journals before deleting the accounts.
@Tecnativa TT61341
@christian-ramos-tecnativa @pedrobaeza 