### PR TITLE
[IMP] change menu 'Invoicing' -> 'Accounting'

### DIFF
--- a/account_usability/i18n/de.po
+++ b/account_usability/i18n/de.po
@@ -125,8 +125,3 @@ msgstr "Vorlagen"
 #: model:ir.model.fields,field_description:account_usability.field_res_config_settings__anglo_saxon_accounting
 msgid "Use anglo-saxon accounting"
 msgstr "Anglo-amerikanische Buchführung verwenden"
-
-#. module: account
-#: model:ir.ui.menu,name:account.menu_finance
-msgid "Accounting"
-msgstr "Buchhaltung"


### PR DESCRIPTION
We can also change the Settings-menus "Invoicing" to "Accounting"

<img width="307" height="218" alt="menu_settings_accounting" src="https://github.com/user-attachments/assets/cf086af4-f66f-4ae2-9e63-5d9ac7ecb442" />
 