### PR TITLE
[18.0][IMP] account_asset_profile: increase name field length

### DIFF
--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -13,7 +13,7 @@ class AccountAssetProfile(models.Model):
     _description = "Asset profile"
     _order = "name"
 
-    name = fields.Char(size=64, required=True, index=True)
+    name = fields.Char(required=True, index=True)
     note = fields.Text()
     account_asset_id = fields.Many2one(
         comodel_name="account.account",


### PR DESCRIPTION
Increase `name` field from 64 to 128 characters to support longer values.