### PR TITLE
[18.0][IMP] account_journal_lock_date: Optional restriction on draft movement creation

### DIFF
--- a/account_journal_lock_date/README.rst
+++ b/account_journal_lock_date/README.rst
@@ -49,22 +49,28 @@ To configure this module, you need to:
 
 1. Go to *Invoicing > Configuration > Journals*
 2. Open a Journal and set the 'Lock Date' and the 'Lock Date for
-   Non-Advisers' in the' Advanced Settings' tab of the form view or
-   select several Journals in the list view and click on the action menu
-   'Update journals lock dates' to update those dates for the selected
-   journals at the same time.
+   Non-Advisers' in the' Advanced Settings' tab of the form view. You
+   can also toggle 'Restrict Creation on Lock Dates' to decide whether
+   draft creation is blocked on or before those dates.
+3. Optionally, select several Journals in the list view and click on the
+   action menu 'Update journals lock dates' to update those dates for
+   the selected journals at the same time.
 
 Usage
 =====
 
-If the logged-in user has the access group 'Adviser', he/she will not be
-able to create a journal entry if the 'Lock Date' of the journal is
-greater than or equal to the journal entry.
+When 'Restrict Creation on Lock Dates' is enabled, a logged-in user with
+the access group 'Adviser' will not be able to create or modify a
+journal entry if the 'Lock Date' of the journal is greater than or equal
+to the journal entry date.
 
-If the logged-in user has not the access group 'Adviser', he/she will
-not be able to create a journal entry if the 'Lock Date for
-Non-Advisers' of the journal is greater than or equal to the journal
-entry.
+When 'Restrict Creation on Lock Dates' is enabled and the logged-in user
+does not have the access group 'Adviser', he/she will not be able to
+create or modify a journal entry if the 'Lock Date for Non-Advisers' of
+the journal is greater than or equal to the journal entry date.
+
+Creation checks can be disabled per journal by unticking 'Restrict
+Creation on Lock Dates'.
 
 Known issues / Roadmap
 ======================
@@ -109,6 +115,10 @@ Contributors
 - `Factor Libre <https://www.factorlibre.com>`__:
 
   - Rodrigo Bonilla Martinez <rodrigo.bonilla@factorlibre.com>
+
+- `Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>`__
+
+  - Bhavesh Heliconia
 
 Maintainers
 -----------

--- a/account_journal_lock_date/models/account_journal.py
+++ b/account_journal_lock_date/models/account_journal.py
@@ -7,6 +7,12 @@ from odoo import fields, models
 class AccountJournal(models.Model):
     _inherit = "account.journal"
 
+    lock_date_restrict_creation = fields.Boolean(
+        string="Restrict Creation on Lock Dates",
+        default=False,
+        help="When enabled, draft journal entries cannot be created "
+        "on or before the lock dates for this journal.",
+    )
     fiscalyear_lock_date = fields.Date(
         string="Lock Date",
         help="No users, including Advisers, can edit accounts prior "

--- a/account_journal_lock_date/models/account_move.py
+++ b/account_journal_lock_date/models/account_move.py
@@ -1,7 +1,7 @@
 # Copyright 2017 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools.misc import format_date
 
@@ -42,4 +42,12 @@ class AccountMove(models.Model):
                         journal_date=lock_date,
                     )
                 raise UserError(message)
+        return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        res.filtered(
+            lambda x: x.journal_id.lock_date_restrict_creation
+        )._check_fiscal_lock_dates()
         return res

--- a/account_journal_lock_date/readme/CONFIGURE.md
+++ b/account_journal_lock_date/readme/CONFIGURE.md
@@ -2,7 +2,9 @@ To configure this module, you need to:
 
 1.  Go to *Invoicing \> Configuration \> Journals*
 2.  Open a Journal and set the 'Lock Date' and the 'Lock Date for
-    Non-Advisers' in the' Advanced Settings' tab of the form view or
-    select several Journals in the list view and click on the action
-    menu 'Update journals lock dates' to update those dates for the
-    selected journals at the same time.
+    Non-Advisers' in the' Advanced Settings' tab of the form view. You
+    can also toggle 'Restrict Creation on Lock Dates' to decide whether
+    draft creation is blocked on or before those dates.
+3.  Optionally, select several Journals in the list view and click on
+    the action menu 'Update journals lock dates' to update those dates
+    for the selected journals at the same time.

--- a/account_journal_lock_date/readme/CONTRIBUTORS.md
+++ b/account_journal_lock_date/readme/CONTRIBUTORS.md
@@ -8,3 +8,5 @@
   - Ernesto Tejeda
 - [Factor Libre](https://www.factorlibre.com):
   - Rodrigo Bonilla Martinez \<<rodrigo.bonilla@factorlibre.com>\>
+- [Heliconia Solutions Pvt. Ltd.](https://www.heliconia.io)
+  - Bhavesh Heliconia

--- a/account_journal_lock_date/readme/USAGE.md
+++ b/account_journal_lock_date/readme/USAGE.md
@@ -1,8 +1,12 @@
-If the logged-in user has the access group 'Adviser', he/she will not be
-able to create a journal entry if the 'Lock Date' of the journal is
-greater than or equal to the journal entry.
+When 'Restrict Creation on Lock Dates' is enabled, a logged-in user with
+the access group 'Adviser' will not be able to create or modify a
+journal entry if the 'Lock Date' of the journal is greater than or equal
+to the journal entry date.
 
-If the logged-in user has not the access group 'Adviser', he/she will
-not be able to create a journal entry if the 'Lock Date for
-Non-Advisers' of the journal is greater than or equal to the journal
-entry.
+When 'Restrict Creation on Lock Dates' is enabled and the logged-in user
+does not have the access group 'Adviser', he/she will not be able to
+create or modify a journal entry if the 'Lock Date for Non-Advisers' of
+the journal is greater than or equal to the journal entry date.
+
+Creation checks can be disabled per journal by unticking 'Restrict
+Creation on Lock Dates'.

--- a/account_journal_lock_date/static/description/index.html
+++ b/account_journal_lock_date/static/description/index.html
@@ -397,21 +397,26 @@ time.</p>
 <ol class="arabic simple">
 <li>Go to <em>Invoicing &gt; Configuration &gt; Journals</em></li>
 <li>Open a Journal and set the ‘Lock Date’ and the ‘Lock Date for
-Non-Advisers’ in the’ Advanced Settings’ tab of the form view or
-select several Journals in the list view and click on the action menu
-‘Update journals lock dates’ to update those dates for the selected
-journals at the same time.</li>
+Non-Advisers’ in the’ Advanced Settings’ tab of the form view. You
+can also toggle ‘Restrict Creation on Lock Dates’ to decide whether
+draft creation is blocked on or before those dates.</li>
+<li>Optionally, select several Journals in the list view and click on the
+action menu ‘Update journals lock dates’ to update those dates for
+the selected journals at the same time.</li>
 </ol>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
-<p>If the logged-in user has the access group ‘Adviser’, he/she will not be
-able to create a journal entry if the ‘Lock Date’ of the journal is
-greater than or equal to the journal entry.</p>
-<p>If the logged-in user has not the access group ‘Adviser’, he/she will
-not be able to create a journal entry if the ‘Lock Date for
-Non-Advisers’ of the journal is greater than or equal to the journal
-entry.</p>
+<p>When ‘Restrict Creation on Lock Dates’ is enabled, a logged-in user with
+the access group ‘Adviser’ will not be able to create or modify a
+journal entry if the ‘Lock Date’ of the journal is greater than or equal
+to the journal entry date.</p>
+<p>When ‘Restrict Creation on Lock Dates’ is enabled and the logged-in user
+does not have the access group ‘Adviser’, he/she will not be able to
+create or modify a journal entry if the ‘Lock Date for Non-Advisers’ of
+the journal is greater than or equal to the journal entry date.</p>
+<p>Creation checks can be disabled per journal by unticking ‘Restrict
+Creation on Lock Dates’.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
@@ -454,6 +459,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.factorlibre.com">Factor Libre</a>:<ul>
 <li>Rodrigo Bonilla Martinez &lt;<a class="reference external" href="mailto:rodrigo.bonilla&#64;factorlibre.com">rodrigo.bonilla&#64;factorlibre.com</a>&gt;</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.heliconia.io">Heliconia Solutions Pvt. Ltd.</a><ul>
+<li>Bhavesh Heliconia</li>
 </ul>
 </li>
 </ul>

--- a/account_journal_lock_date/tests/test_journal_lock_date.py
+++ b/account_journal_lock_date/tests/test_journal_lock_date.py
@@ -171,3 +171,77 @@ class TestJournalLockDate(common.AccountTestInvoicingCommon):
             }
         )
         move2.action_post()
+
+    def test_journal_lock_date_restrict_creation(self):
+        """Test the new 'Restrict Creation on Lock Dates' feature."""
+        # Set lock dates in the future
+        lock_date = date.today() + timedelta(days=5)
+        self.journal.write(
+            {
+                "period_lock_date": lock_date,
+                "fiscalyear_lock_date": lock_date,
+            }
+        )
+
+        # 1. With restriction disabled (default), creation should be allowed
+        self.journal.lock_date_restrict_creation = False
+        move = self.account_move_obj.create(
+            {
+                "date": date.today(),
+                "journal_id": self.journal.id,
+                "line_ids": [
+                    Command.create(
+                        {"account_id": self.account.id, "credit": 100.0, "name": "c"}
+                    ),
+                    Command.create(
+                        {"account_id": self.account2.id, "debit": 100.0, "name": "d"}
+                    ),
+                ],
+            }
+        )
+        self.assertTrue(move.id)
+
+        # 2. With restriction enabled, creation <= lock date should be blocked
+        self.journal.lock_date_restrict_creation = True
+        with self.assertRaisesRegex(
+            UserError, ".*prior to and inclusive of the lock date.*"
+        ):
+            self.account_move_obj.create(
+                {
+                    "date": date.today(),
+                    "journal_id": self.journal.id,
+                    "line_ids": [
+                        Command.create(
+                            {
+                                "account_id": self.account.id,
+                                "credit": 100.0,
+                                "name": "c",
+                            }
+                        ),
+                        Command.create(
+                            {
+                                "account_id": self.account2.id,
+                                "debit": 100.0,
+                                "name": "d",
+                            }
+                        ),
+                    ],
+                }
+            )
+
+        # 3. With restriction enabled, creation > lock date should be allowed
+        move_ok = self.account_move_obj.create(
+            {
+                "date": lock_date + timedelta(days=1),
+                "journal_id": self.journal.id,
+                "line_ids": [
+                    Command.create(
+                        {"account_id": self.account.id, "credit": 100.0, "name": "c"}
+                    ),
+                    Command.create(
+                        {"account_id": self.account2.id, "debit": 100.0, "name": "d"}
+                    ),
+                ],
+            }
+        )
+        self.assertTrue(move_ok.id)

--- a/account_journal_lock_date/views/account_journal.xml
+++ b/account_journal_lock_date/views/account_journal.xml
@@ -11,6 +11,7 @@
             <field name="account_control_ids" position="after">
                 <field name="fiscalyear_lock_date" />
                 <field name="period_lock_date" />
+                <field name="lock_date_restrict_creation" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This pull request introduces an improvement to the account_journal_lock_date module by adding a configurable restriction for draft journal entries.

### Key Changes:
- New Configuration: Added the lock_date_restrict_creation field to Journals.
- Draft Creation Control: When enabled, the module now prevents the creation of draft journal entries on or before the specified lock dates.
- Improved Flexibility: Users can now choose whether the lock dates should only affect posting (standard Odoo/module behavior) or if they should also block the initial draft creation.