### PR TITLE
[16.0][FIX] account_journal_general_sequence: use standard sequence implementation

### DIFF
--- a/account_journal_general_sequence/__manifest__.py
+++ b/account_journal_general_sequence/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "General sequence in account journals",
     "summary": "Add configurable sequence to account moves, per journal",
-    "version": "16.0.2.1.0",
+    "version": "16.0.2.2.0",
     "category": "Accounting/Accounting",
     "website": "https://github.com/OCA/account-financial-tools",
     "author": "Moduon, Odoo Community Association (OCA)",

--- a/account_journal_general_sequence/migrations/16.0.2.2.0/pre-migration.py
+++ b/account_journal_general_sequence/migrations/16.0.2.2.0/pre-migration.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Pol Reig
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """Switch entry number sequences from no_gap to standard.
+
+    no_gap uses FOR UPDATE NOWAIT which conflicts with the savepoint retry
+    loop in account_sequence._set_next_sequence(), causing LockNotAvailable
+    errors when importing bank statements with multiple lines.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    seqs = env["ir.sequence"].search([
+        ("code", "=", "account_journal_general_sequence.default"),
+        ("implementation", "=", "no_gap"),
+    ])
+    for seq in seqs:
+        seq.write({"implementation": "standard"})
+        # After switching to standard, Odoo creates the PostgreSQL sequence
+        # starting from 1. We need to restore the correct next value for each
+        # date range, otherwise already-used numbers would be reassigned.
+        for date_range in seq.date_range_ids:
+            date_range.number_next_actual = date_range.number_next

--- a/account_journal_general_sequence/models/account_journal.py
+++ b/account_journal_general_sequence/models/account_journal.py
@@ -43,7 +43,7 @@ class AccountJournal(models.Model):
                         ),
                         "code": "account_journal_general_sequence.default",
                         "company_id": one.company_id.id,
-                        "implementation": "no_gap",
+                        "implementation": "standard",
                         "prefix": "%(range_year)s/",
                         "padding": 8,
                         "use_date_range": True,


### PR DESCRIPTION
## Problem

When `account_journal_general_sequence` and `account_sequence` are both installed,
importing a bank statement with multiple lines fails with:

    psycopg2.errors.LockNotAvailable: could not obtain lock on row in relation
    "ir_sequence_date_range"

## Root cause

`account_sequence._set_next_sequence()` uses a `while True` retry loop with
savepoints to handle duplicate `account.move.name`. Before entering the savepoint
it calls `flush_recordset()`, which triggers `_compute_entry_number()` from this
module. Because the sequence uses `no_gap`, that compute executes
`FOR UPDATE NOWAIT` on the `ir_sequence_date_range` row.

When the savepoint is rolled back due to a name collision and the loop retries,
`_compute_entry_number` is scheduled again. The next `flush_recordset()` attempts
`FOR UPDATE NOWAIT` on the same row, which is still locked by the outer
transaction, and fails immediately.

## Fix

Switch the default sequence implementation from `no_gap` to `standard`.
`standard` uses PostgreSQL's `nextval()`, which does not lock rows and is
unaffected by savepoint rollbacks.

`entry_number` is an internal ordering reference, not a legal sequence number,
so occasional gaps have no fiscal implications.

A pre-migration script migrates existing sequences and restores the correct
`number_next` for each date range, since switching to `standard` would otherwise
reset the PostgreSQL sequence to 1 and cause duplicate number errors.
