### PR TITLE
[18.0][FIX] account_move_line_sale_info: use cogs_origin_id for COGS propagation

### DIFF
--- a/account_move_line_sale_info/__manifest__.py
+++ b/account_move_line_sale_info/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Account Move Line Sale Info",
     "summary": "Introduces the purchase order line to the journal items",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "author": "ForgeFlow S.L., " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-financial-tools",
     "category": "Generic",

--- a/account_move_line_sale_info/models/account_move.py
+++ b/account_move_line_sale_info/models/account_move.py
@@ -8,15 +8,26 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     def _stock_account_prepare_anglo_saxon_out_lines_vals(self):
+        # Resolve each COGS val dict back to its originating invoice line via
+        # the ``cogs_origin_id`` FK written by core stock_account. This
+        # replaces a product_id + quantity heuristic that silently dropped
+        # propagation whenever two invoice lines on the same document shared
+        # the same product and quantity -- e.g. credit notes with a refund
+        # line and a free replacement line both at qty=-1.
         res = super()._stock_account_prepare_anglo_saxon_out_lines_vals()
-        for i, vals in enumerate(res):
-            am = self.env["account.move"].browse(vals["move_id"])
-            sale_line_id = am.invoice_line_ids.filtered(
-                lambda il, vs=vals: il.product_id.id == vs["product_id"]
-                and il.quantity == vs["quantity"]
-            ).mapped("sale_line_ids")
-            if sale_line_id and len(sale_line_id) == 1:
-                res[i]["sale_line_id"] = sale_line_id.id
+        origin_ids = {
+            vals["cogs_origin_id"] for vals in res if vals.get("cogs_origin_id")
+        }
+        if not origin_ids:
+            return res
+        origins = self.env["account.move.line"].browse(origin_ids)
+        sale_line_by_origin = {
+            line.id: line.sale_line_id.id for line in origins if line.sale_line_id
+        }
+        for vals in res:
+            sol_id = sale_line_by_origin.get(vals.get("cogs_origin_id"))
+            if sol_id:
+                vals["sale_line_id"] = sol_id
         return res
 
 

--- a/account_move_line_sale_info/tests/test_account_move_line_sale_info.py
+++ b/account_move_line_sale_info/tests/test_account_move_line_sale_info.py
@@ -261,3 +261,35 @@ class TestAccountMoveLineSaleInfo(common.TransactionCase):
                     "sale Order line has not been copied "
                     "from the invoice to the credit note.",
                 )
+
+    def test_04_same_product_same_quantity_collision(self):
+        """Regression: when two invoice lines share the same product_id and
+        quantity (e.g. a credit note with a refund line + a free replacement
+        line both at qty=-1), the previous product_id + quantity heuristic
+        with a ``len == 1`` guard silently skipped sale_line_id propagation
+        on the generated COGS lines. Resolving via ``cogs_origin_id``
+        correctly attributes each COGS leg to its own originating invoice
+        line.
+        """
+        self.company.anglo_saxon_accounting = True
+        sale = self._create_sale([(self.product, 1), (self.product, 1)])
+        sale.action_confirm()
+        for picking in sale.picking_ids:
+            picking.move_ids.write({"quantity": 1.0, "picked": True})
+            picking.button_validate()
+        sale._create_invoices()
+        invoice = sale.invoice_ids[0]
+        invoice._post()
+
+        cogs = invoice.line_ids.filtered(lambda line: line.display_type == "cogs")
+        self.assertEqual(
+            len(cogs), 4, "Two invoice lines should produce two COGS pairs"
+        )
+        for cogs_line in cogs:
+            self.assertIn(cogs_line.sale_line_id, sale.order_line)
+            self.assertEqual(
+                cogs_line.sale_line_id,
+                cogs_line.cogs_origin_id.sale_line_id,
+                "COGS sale_line_id should match its originating invoice "
+                "line's sale_line_id",
+            )


### PR DESCRIPTION
The propagation of sale_line_id to COGS (anglo-saxon) journal items matched each COGS val dict back to an invoice line by product_id + quantity and only assigned sale_line_id when exactly one sale line was found. When a document has two invoice lines sharing the same product and quantity -- e.g. a credit note with a refund line and a free replacement line both at qty=-1 -- the filter returns multiple matches and propagation is silently skipped for all affected COGS lines. This shows up as sale_line_id / sale_order_id being NULL on the COGS leg even though the originating invoice line has them set, which breaks downstream reconciliation and reports keyed on the sale.

When this module was first written (Odoo 13/14), the COGS val dicts produced by ``_stock_account_prepare_anglo_saxon_out_lines_vals`` had no back-reference to the originating invoice line, so a product + quantity heuristic was the only option. Since Odoo 17 that core method sets ``cogs_origin_id: line.id`` directly on each generated val (see addons/stock_account/models/account_move.py), which gives us a deterministic FK lookup with no value comparisons and no len == 1 guard. Using it fixes the collision case while remaining fully equivalent to the old behaviour for the common single-line case.

Includes a regression test covering the same-product / same-quantity invoice collision.