### PR TITLE
[19.0] [IMP] account_chart_update: richer diffs and accurate drift detection

### DIFF
--- a/account_chart_update/tests/test_account_chart_update.py
+++ b/account_chart_update/tests/test_account_chart_update.py
@@ -364,3 +364,739 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
             result,
             "Reordered m2m values must not be flagged as a diff",
         )
+
+    def test_08_tag_ids_post_loop_drift(self):
+        """Template drops empty cells — tag drift on an account must still
+        be detected via the synthetic post-loop and result in a cleared
+        tag_ids after update.
+        """
+        account = self._get_record_for_xml_id(
+            list(self.chart_template_data["account.account"])[0]
+        )
+        tag = self.env["account.account.tag"].create(
+            {"name": "Wizard test tag", "applicability": "accounts"}
+        )
+        account.tag_ids = [Command.set(tag.ids)]
+        # diff_fields should synthesize "" for the missing template value.
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        result = wizard.diff_fields(
+            self.chart_template_data["account.account"][
+                list(self.chart_template_data["account.account"])[0]
+            ],
+            account,
+        )
+        self.assertIn("tag_ids", result)
+        self.assertEqual(result["tag_ids"], "")
+
+    def test_09_boolean_drift_uses_field_default(self):
+        """A boolean absent from the template compares to the field default,
+        not blindly to False."""
+        fp = self._get_record_for_xml_id("template_generic_domestic_fiscal_position")
+        # vat_required defaults to False; flip it to True to simulate drift.
+        fp.vat_required = True
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        # Template data for this fp omits vat_required (empty cell in CSV).
+        t_vals = self.chart_template_data["account.fiscal.position"][
+            "template_generic_domestic_fiscal_position"
+        ]
+        self.assertNotIn("vat_required", t_vals)
+        result = wizard.diff_fields(t_vals, fp)
+        self.assertIn("vat_required", result)
+        self.assertEqual(bool(result["vat_required"]), False)
+        # And: when the DB already matches the default, no drift.
+        fp.vat_required = False
+        result = wizard.diff_fields(t_vals, fp)
+        self.assertNotIn("vat_required", result)
+
+    def test_10_readonly_and_computed_skipped_in_post_loop(self):
+        """Inverse/readonly m2m (replacing_tax_ids) and computed-editable
+        (use_in_tax_closing) must not be flagged by the synthetic post-loop."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        # sale_export_tax_template replaces sale_tax_template → the latter
+        # gets a non-empty `replacing_tax_ids` by construction.
+        src_tax = self._get_record_for_xml_id("sale_tax_template")
+        self.assertTrue(src_tax.replacing_tax_ids)
+        t_vals = self.chart_template_data["account.tax"]["sale_tax_template"]
+        result = wizard.diff_fields(t_vals, src_tax)
+        self.assertNotIn("replacing_tax_ids", result)
+        # And a stored-computed-editable boolean must not be flagged either.
+        rep_line = src_tax.repartition_line_ids.filtered(
+            lambda r: r.repartition_type == "tax"
+        )[:1]
+        self.assertTrue(rep_line)
+        # Pass a template dict that doesn't mention use_in_tax_closing.
+        result_rep = wizard.diff_fields({"repartition_type": "tax"}, rep_line)
+        self.assertNotIn("use_in_tax_closing", result_rep)
+
+    def test_11_m2m_command_list_diff_detected(self):
+        """Previously the ORM-command-list branch compared `.sort() != .sort()`
+        (both None), silently hiding every diff. A real tag drift must now
+        be flagged."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        # Synthesize a template dict whose tag_ids value is a command list
+        # (that's what _deref_account_tags produces for the chart template).
+        tag_a = self.env["account.account.tag"].create(
+            {"name": "A", "applicability": "taxes"}
+        )
+        tag_b = self.env["account.account.tag"].create(
+            {"name": "B", "applicability": "taxes"}
+        )
+        rep_line = self._get_record_for_xml_id(
+            "sale_tax_template"
+        ).repartition_line_ids.filtered(lambda r: r.repartition_type == "tax")[:1]
+        self.assertTrue(rep_line)
+        rep_line.tag_ids = [Command.set(tag_a.ids)]
+        # Template expects [tag_b] (different from what the DB has).
+        result = wizard.diff_fields({"tag_ids": [Command.set(tag_b.ids)]}, rep_line)
+        self.assertIn("tag_ids", result)
+
+    def test_12_missing_xml_id_note_format(self):
+        """The 'Missing XML-ID' note must include both the expected xmlid
+        and the ones currently attached."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        tax = self._get_record_for_xml_id("sale_tax_template")
+        # Attach a foreign xmlid and drop the canonical one.
+        model_data = self._get_model_data(tax)
+        model_data.unlink()
+        self.env["ir.model.data"].create(
+            {
+                "module": "base",
+                "model": "account.tax",
+                "name": "wizard_test_probe_xmlid",
+                "res_id": tax.id,
+            }
+        )
+        note = wizard._missing_xml_id_note(tax, "sale_tax_template")
+        self.assertIn(f"account.{self.company.id}_sale_tax_template", note)
+        self.assertIn("base.wizard_test_probe_xmlid", note)
+
+    def test_13_diff_note_renders_boolean_and_m2o(self):
+        """The per-field detail rendered by diff_notes should use the
+        actual → expected form for booleans and m2o display names."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        fp = self._get_record_for_xml_id("template_generic_domestic_fiscal_position")
+        fp.vat_required = True
+        note = wizard.diff_notes(
+            self.chart_template_data["account.fiscal.position"][
+                "template_generic_domestic_fiscal_position"
+            ],
+            fp,
+        )
+        self.assertIn("VAT required", note)
+        self.assertIn("True → False", note)
+
+    def test_14_diff_note_label_for_fp_account_mapping(self):
+        """Fiscal position mappings must render as `src → dest`, not the
+        parent fiscal position's name (whose rec_name is `position_id`)."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        fp = self._get_record_for_xml_id("template_generic_domestic_fiscal_position")
+        account_data = self.chart_template_data["account.account"]
+        src = self._get_record_for_xml_id(list(account_data)[0])
+        dest = self._get_record_for_xml_id(list(account_data)[1])
+        fp.account_ids = [
+            Command.create({"account_src_id": src.id, "account_dest_id": dest.id})
+        ]
+        # Template for this fp has no account_ids → the post-loop flags drift.
+        note = wizard.diff_notes(
+            self.chart_template_data["account.fiscal.position"][
+                "template_generic_domestic_fiscal_position"
+            ],
+            fp,
+        )
+        self.assertIn(f"{src.display_name} → {dest.display_name}", note)
+        self.assertIn("∅", note)  # expected side is empty
+
+    def test_15_diff_note_commands_count_mismatch(self):
+        """When template and DB disagree on the number of repartition lines,
+        the detail surfaces `N record(s) → M record(s)` rather than a
+        per-line breakdown."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        tax = self._get_record_for_xml_id("sale_tax_template")
+        # Construct a synthetic template value that has one fewer line than
+        # the DB. Modifying the real tax would trip Odoo's "exactly one
+        # base line per side" constraint, so we exercise the renderer
+        # directly via a crafted record_values dict.
+        full = self.chart_template_data["account.tax"]["sale_tax_template"]
+        trimmed = dict(full)
+        trimmed["repartition_line_ids"] = list(full["repartition_line_ids"])[:-1]
+        wizard.tax_field_ids += self.env["ir.model.fields"].search(
+            [("model", "=", "account.tax"), ("name", "=", "repartition_line_ids")]
+        )
+        note = wizard.diff_notes(trimmed, tax)
+        self.assertRegex(note, r"\d+ record\(s\) → \d+ record\(s\)")
+
+    def test_16_m2m_command_link_branch(self):
+        """Drift must be detected when the template value is expressed with
+        `Command.link(...)` — exercises the LINK branch in the m2m
+        command-list comparator."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        tag_a = self.env["account.account.tag"].create(
+            {"name": "Link A", "applicability": "taxes"}
+        )
+        tag_b = self.env["account.account.tag"].create(
+            {"name": "Link B", "applicability": "taxes"}
+        )
+        rep_line = self._get_record_for_xml_id(
+            "sale_tax_template"
+        ).repartition_line_ids.filtered(lambda r: r.repartition_type == "tax")[:1]
+        self.assertTrue(rep_line)
+        rep_line.tag_ids = [Command.set(tag_a.ids)]
+        # Template expects tag_b linked (not tag_a in DB).
+        result = wizard.diff_fields({"tag_ids": [Command.link(tag_b.id)]}, rep_line)
+        self.assertIn("tag_ids", result)
+        # And no drift when the LINK target matches the DB.
+        rep_line.tag_ids = [Command.set(tag_b.ids)]
+        result = wizard.diff_fields({"tag_ids": [Command.link(tag_b.id)]}, rep_line)
+        self.assertNotIn("tag_ids", result)
+
+    def test_17_diff_note_label_branches(self):
+        """`_diff_note_label` must render src→dest for fp mappings,
+        `document_type/repartition_type factor%` for repartition lines,
+        and fall back to `display_name` for anything else."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        # fp.account branch
+        fp = self._get_record_for_xml_id("template_generic_domestic_fiscal_position")
+        account_data = self.chart_template_data["account.account"]
+        src = self._get_record_for_xml_id(list(account_data)[0])
+        dest = self._get_record_for_xml_id(list(account_data)[1])
+        fp.account_ids = [
+            Command.create({"account_src_id": src.id, "account_dest_id": dest.id})
+        ]
+        mapping = fp.account_ids[:1]
+        self.assertTrue(mapping)
+        self.assertEqual(
+            wizard._diff_note_label(mapping),
+            f"{src.display_name} → {dest.display_name}",
+        )
+        # tax.repartition.line branch
+        rep = self._get_record_for_xml_id(
+            "sale_tax_template"
+        ).repartition_line_ids.filtered(lambda r: r.repartition_type == "tax")[:1]
+        self.assertTrue(rep)
+        self.assertEqual(
+            wizard._diff_note_label(rep),
+            f"{rep.document_type}/{rep.repartition_type} {rep.factor_percent:g}%",
+        )
+        # default branch — any other model falls through to display_name.
+        tag = self.env["account.account.tag"].create(
+            {"name": "LabelDefault", "applicability": "accounts"}
+        )
+        self.assertEqual(wizard._diff_note_label(tag), tag.display_name)
+
+    def test_18_diff_note_expected_m2x_names_branches(self):
+        """`_diff_note_expected_m2x_names` handles xmlid strings, SET and
+        LINK command lists, and returns [] for unknown shapes."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        # SET command
+        tag_a = self.env["account.account.tag"].create(
+            {"name": "Set-A", "applicability": "taxes"}
+        )
+        tag_b = self.env["account.account.tag"].create(
+            {"name": "Set-B", "applicability": "taxes"}
+        )
+        names = wizard._diff_note_expected_m2x_names(
+            [Command.set([tag_b.id, tag_a.id])], "account.account.tag"
+        )
+        self.assertEqual(names, sorted([tag_a.display_name, tag_b.display_name]))
+        # LINK command (appended one by one)
+        names = wizard._diff_note_expected_m2x_names(
+            [Command.link(tag_a.id), Command.link(tag_b.id)],
+            "account.account.tag",
+        )
+        self.assertEqual(names, sorted([tag_a.display_name, tag_b.display_name]))
+        # xmlid string — short form gets the company prefix applied
+        fp_xmlids = ",".join(
+            [
+                "template_generic_domestic_fiscal_position",
+                "template_generic_export_fiscal_position",
+            ]
+        )
+        names = wizard._diff_note_expected_m2x_names(
+            fp_xmlids, "account.fiscal.position"
+        )
+        self.assertEqual(len(names), 2)
+        # Unknown value / missing comodel → empty
+        self.assertEqual(wizard._diff_note_expected_m2x_names(42, None), [])
+        self.assertEqual(wizard._diff_note_expected_m2x_names(None, None), [])
+
+    def test_19_diff_note_sub_detail_branches(self):
+        """`_diff_note_sub_detail` renders sub-field diffs for m2o, m2m
+        and scalar sub-fields."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        rep = self._get_record_for_xml_id(
+            "sale_tax_template"
+        ).repartition_line_ids.filtered(lambda r: r.repartition_type == "tax")[:1]
+        tag = self.env["account.account.tag"].create(
+            {"name": "Sub-Tag", "applicability": "taxes"}
+        )
+        # m2o path: expected_v is an xmlid string
+        new_account = self._get_record_for_xml_id(
+            list(self.chart_template_data["account.account"])[0]
+        )
+        model_data = self.env["ir.model.data"].search(
+            [("model", "=", "account.account"), ("res_id", "=", new_account.id)]
+        )
+        short_xmlid = model_data.name.split("_", maxsplit=1)[1]
+        detail = wizard._diff_note_sub_detail(
+            {"account_id": short_xmlid, "factor_percent": 50.0},
+            rep,
+            ["account_id", "factor_percent"],
+        )
+        self.assertIn(f"account_id '{rep.account_id.display_name}'", detail)
+        self.assertIn(f"'{new_account.display_name}'", detail)
+        self.assertIn("factor_percent", detail)
+        self.assertIn(f"'{rep.factor_percent}'", detail)
+        self.assertIn("'50.0'", detail)
+        # m2m path: expected_v is a command list
+        rep.tag_ids = [Command.set([])]
+        detail = wizard._diff_note_sub_detail(
+            {"tag_ids": [Command.set([tag.id])]}, rep, ["tag_ids"]
+        )
+        self.assertIn(f"tag_ids [∅] → [{tag.display_name}]", detail)
+
+    def test_20_diff_note_commands_branches(self):
+        """`_diff_note_commands` counts SET/LINK/CREATE correctly and picks
+        the right branch: count mismatch, per-line detail, or generic
+        fallback."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        tax = self._get_record_for_xml_id("sale_tax_template")
+        field = tax._fields["repartition_line_ids"]
+        actual = tax.repartition_line_ids
+        # SET branch — expected_count = len(cmd[2]); DB has 4 lines, template says 8.
+        synthetic = [
+            999_001,
+            999_002,
+            999_003,
+            999_004,
+            999_005,
+            999_006,
+            999_007,
+            999_008,
+        ]
+        result = wizard._diff_note_commands(field, actual, [Command.set(synthetic)])
+        self.assertEqual(
+            result,
+            f"{len(actual)} record(s) → {len(synthetic)} record(s)",
+        )
+        # LINK branch — two LINK commands count as 2 (so count mismatch again).
+        result = wizard._diff_note_commands(
+            field, actual, [Command.link(999_001), Command.link(999_002)]
+        )
+        self.assertIn(f"{len(actual)} record(s) → 2 record(s)", result)
+        # CREATE branch with same count and a real sub-diff → per-line format.
+        # Build a template with the same count as actual but with a drifted
+        # factor_percent on the first line.
+        template_lines = [
+            Command.create(
+                {
+                    "repartition_type": r.repartition_type,
+                    "document_type": r.document_type,
+                    "factor_percent": r.factor_percent,
+                }
+            )
+            for r in actual
+        ]
+        # Flip factor_percent on the first line from 100 → 42 to force drift.
+        template_lines[0][2]["factor_percent"] = 42.0
+        result = wizard._diff_note_commands(field, actual, template_lines)
+        self.assertIn("#1:", result)
+        self.assertIn("factor_percent", result)
+        # Same count, no drift at all → generic fallback message.
+        template_lines_nodiff = [
+            Command.create(
+                {
+                    "repartition_type": r.repartition_type,
+                    "document_type": r.document_type,
+                    "factor_percent": r.factor_percent,
+                }
+            )
+            for r in actual
+        ]
+        result = wizard._diff_note_commands(field, actual, template_lines_nodiff)
+        self.assertEqual(
+            result,
+            f"{len(actual)} record(s) → differs from template",
+        )
+
+    def test_21_diff_note_m2o_branches(self):
+        """`_diff_note_m2o` renders actual/expected display names whether
+        the template value is an xmlid string, an int database id, or
+        points to something that can't be resolved."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        tax = self._get_record_for_xml_id("sale_tax_template")
+        field = tax._fields["tax_group_id"]
+        actual = tax.tax_group_id
+        # Resolvable xmlid → expected side uses the record's display_name.
+        model_data = self.env["ir.model.data"].search(
+            [("model", "=", "account.tax.group"), ("res_id", "=", actual.id)]
+        )[:1]
+        self.assertTrue(model_data)
+        short_xmlid = model_data.name.split("_", maxsplit=1)[1]
+        result = wizard._diff_note_m2o(field, actual, short_xmlid)
+        self.assertEqual(result, f"'{actual.display_name}' → '{actual.display_name}'")
+        # Unresolvable xmlid → echo the raw string on the expected side.
+        result = wizard._diff_note_m2o(field, actual, "does_not_exist_xmlid")
+        self.assertEqual(result, f"'{actual.display_name}' → 'does_not_exist_xmlid'")
+        # Int expected pointing to an existing record → display_name.
+        other_group = self.env["account.tax.group"].create({"name": "M2O-Int-Probe"})
+        result = wizard._diff_note_m2o(field, actual, other_group.id)
+        self.assertEqual(
+            result, f"'{actual.display_name}' → '{other_group.display_name}'"
+        )
+        # Int expected pointing to a non-existent id → stringified id.
+        missing_id = 2_000_000_000
+        result = wizard._diff_note_m2o(field, actual, missing_id)
+        self.assertEqual(result, f"'{actual.display_name}' → '{missing_id}'")
+        # None/empty expected → empty expected side.
+        result = wizard._diff_note_m2o(field, actual, None)
+        self.assertEqual(result, f"'{actual.display_name}' → ''")
+        # Empty actual + xmlid expected → empty actual side.
+        empty = self.env["account.tax.group"]
+        result = wizard._diff_note_m2o(field, empty, short_xmlid)
+        self.assertEqual(result, f"'' → '{actual.display_name}'")
+
+    def test_22_diff_note_commands_caps_at_three_sub_diffs(self):
+        """The per-line sub-diff enumeration must stop after 3 entries to
+        keep the note readable even when more lines drifted."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        tax = self._get_record_for_xml_id("sale_tax_template")
+        field = tax._fields["repartition_line_ids"]
+        actual = tax.repartition_line_ids
+        self.assertGreaterEqual(len(actual), 4)
+        # Build a template that flips factor_percent on every line → 4+
+        # differing sub-records, but the renderer should only list 3.
+        template_lines = [
+            Command.create(
+                {
+                    "repartition_type": r.repartition_type,
+                    "document_type": r.document_type,
+                    "factor_percent": (r.factor_percent or 0) + 1,
+                }
+            )
+            for r in actual
+        ]
+        result = wizard._diff_note_commands(field, actual, template_lines)
+        self.assertEqual(result.count("#"), 3)
+
+    def test_23_account_group_code_prefix_end_drift_note(self):
+        """When the template's code_prefix_end differs from the DB, the
+        wizard must append a per-field bullet with the actual/expected
+        values under the "Differences in these fields:" header."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        t_data = {
+            "test_group_end_drift": {
+                "name": "End Drift Group",
+                "code_prefix_start": "643",
+                "code_prefix_end": "648",
+            },
+        }
+        group = self.env["account.group"].create(
+            {
+                "name": "End Drift Group",
+                "code_prefix_start": "643",
+                # Same as start — template expects "648".
+                "code_prefix_end": "643",
+                "company_id": self.company.id,
+            }
+        )
+        self.env["ir.model.data"].create(
+            {
+                "name": f"{self.company.id}_test_group_end_drift",
+                "module": "account",
+                "model": "account.group",
+                "res_id": group.id,
+            }
+        )
+        wizard._find_account_groups(t_data)
+        updated = wizard.account_group_ids.filtered(lambda r: r.type == "updated")
+        self.assertEqual(len(updated), 1)
+        label = group._fields["code_prefix_end"].get_description(self.env)["string"]
+        self.assertIn("Differences in these fields:", updated.notes)
+        self.assertIn(f"- {label}: '643' → '648'", updated.notes)
+
+    def test_24_account_group_code_prefix_end_drift_without_header(self):
+        """When `diff_notes` returns no drift (template omits
+        `code_prefix_end`, so the main loop skips it) but the local
+        `code_prefix_end` normalization still disagrees with the DB, the
+        renderer must prepend the "Differences in these fields:" header
+        itself."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        # Template omits code_prefix_end entirely → normalizes to
+        # code_prefix_start ("700"); DB has "750".
+        t_data = {
+            "test_group_end_only": {
+                "name": "End Only Group",
+                "code_prefix_start": "700",
+            },
+        }
+        group = self.env["account.group"].create(
+            {
+                "name": "End Only Group",
+                "code_prefix_start": "700",
+                "code_prefix_end": "750",
+                "company_id": self.company.id,
+            }
+        )
+        self.env["ir.model.data"].create(
+            {
+                "name": f"{self.company.id}_test_group_end_only",
+                "module": "account",
+                "model": "account.group",
+                "res_id": group.id,
+            }
+        )
+        wizard._find_account_groups(t_data)
+        updated = wizard.account_group_ids.filtered(lambda r: r.type == "updated")
+        self.assertEqual(len(updated), 1)
+        # The header must be emitted locally (diff_notes returned empty).
+        self.assertTrue(updated.notes.startswith("Differences in these fields:"))
+        self.assertIn("'750' → '700'", updated.notes)
+
+    def test_25_account_group_missing_xml_id(self):
+        """A matched-but-xmlid-less account group must be flagged as
+        "updated" with the `Missing XML-ID` note, and the note must be
+        appended (not overwriting) when another drift already produced
+        a header."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        # Template says the group should be xmlid `test_group_missing`, and
+        # the DB has a matching record but with no xml_id at all.
+        t_data = {
+            "test_group_missing": {
+                "name": "Missing XmlId Group",
+                "code_prefix_start": "810",
+                "code_prefix_end": "819",
+            },
+        }
+        self.env["account.group"].create(
+            {
+                "name": "Missing XmlId Group",
+                # code_prefix_end drifted so diff_notes also produces a header.
+                "code_prefix_start": "810",
+                "code_prefix_end": "810",
+                "company_id": self.company.id,
+            }
+        )
+        wizard._find_account_groups(t_data)
+        updated = wizard.account_group_ids.filtered(lambda r: r.type == "updated")
+        self.assertEqual(len(updated), 1)
+        self.assertIn("Missing XML-ID", updated.notes)
+        self.assertIn(f"account.{self.company.id}_test_group_missing", updated.notes)
+
+    def test_26_tax_group_missing_xml_id(self):
+        """A tax group matched by a non-xmlid field must be flagged as
+        "updated" with the `Missing XML-ID` note from
+        `_find_tax_groups`."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        tax_group = self._get_record_for_xml_id("tax_group_15")
+        # Drop the xmlid so matching must fall back to the `name` field.
+        self._get_model_data(tax_group).unlink()
+        wizard._find_tax_groups(
+            {
+                "tax_group_15": self.chart_template_data["account.tax.group"][
+                    "tax_group_15"
+                ],
+            }
+        )
+        updated = wizard.tax_group_ids.filtered(
+            lambda r: r.update_tax_group_id == tax_group
+        )
+        self.assertEqual(len(updated), 1)
+        self.assertIn("Missing XML-ID", updated.notes)
+        self.assertIn(f"account.{self.company.id}_tax_group_15", updated.notes)
+
+    def test_27_fiscal_position_missing_xml_id(self):
+        """A fiscal position matched by a non-xmlid field must be flagged
+        as "updated" with the `Missing XML-ID` note from
+        `_find_fiscal_positions`."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        fp = self._get_record_for_xml_id("template_generic_domestic_fiscal_position")
+        # Drop the xmlid so matching must fall back to the `name` field.
+        self._get_model_data(fp).unlink()
+        wizard._find_fiscal_positions(
+            {
+                "template_generic_domestic_fiscal_position": self.chart_template_data[
+                    "account.fiscal.position"
+                ]["template_generic_domestic_fiscal_position"],
+            }
+        )
+        updated = wizard.fiscal_position_ids.filtered(
+            lambda r: r.update_fiscal_position_id == fp
+        )
+        self.assertEqual(len(updated), 1)
+        self.assertIn("Missing XML-ID", updated.notes)
+        self.assertIn(
+            f"account.{self.company.id}_template_generic_domestic_fiscal_position",
+            updated.notes,
+        )
+
+    def test_28_diff_note_translation_shows_correct_language(self):
+        """When a translatable field drifts only in a non-English variant,
+        the diff note must show the per-language values rather than the
+        identical English ones."""
+        self.env["res.lang"]._activate_lang("fr_FR")
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        account_data = self.chart_template_data["account.account"]
+        account_xml_id = list(account_data)[0]
+        account = self._get_record_for_xml_id(account_xml_id)
+        # English value stays in sync; only French diverges.
+        english_name = account.with_context(lang="en_US").name
+        account.with_context(lang="fr_FR").name = "Compte dérivé"
+        record_values = {
+            "name": english_name,
+            "name@fr": "Compte attendu",
+        }
+        note = wizard.diff_notes(record_values, account)
+        self.assertIn("[fr]", note)
+        self.assertIn("Compte dérivé", note)
+        self.assertIn("Compte attendu", note)
+        # Sanity: don't render the misleading English-only comparison.
+        self.assertNotIn(f"'{english_name}' → '{english_name}'", note)
+
+    def test_27b_get_chart_template_data_drops_missing_translations(self):
+        """When the template has no translation for a language, the
+        per-language key must not fall back to the English source — that
+        falsely flags user-provided translations as drift."""
+        self.env["res.lang"]._activate_lang("nl_NL")
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        # generic_coa template carries no nl translations, so the per-
+        # language keys for nl must not appear at all.
+        data = wizard._get_chart_template_data()
+        for record_values in data["account.fiscal.position"].values():
+            self.assertNotIn(
+                "name@nl",
+                record_values,
+                "Missing template translations must not be backfilled with"
+                " the English value",
+            )
+
+    def test_27c_user_translation_without_template_translation_is_not_drift(self):
+        """A DB-side translation must not be reported as drifted when the
+        template has no translation for that language."""
+        self.env["res.lang"]._activate_lang("nl_NL")
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        fp = self._get_record_for_xml_id("template_generic_domestic_fiscal_position")
+        # User-set translation that has no counterpart in the template.
+        fp.with_context(lang="nl_NL").name = "Binnenlands - test"
+        record_values = wizard._get_chart_template_data()["account.fiscal.position"][
+            "template_generic_domestic_fiscal_position"
+        ]
+        note = wizard.diff_notes(record_values, fp)
+        self.assertNotIn(
+            "[nl]",
+            note,
+            "Dutch translation should not be flagged when the template has"
+            " no Dutch translation",
+        )
+        self.assertNotIn("Binnenlands - test", note)
+
+    def test_27d_diff_note_renders_synthesized_boolean_expected(self):
+        """When the post-loop synthesizes drift for a boolean missing from
+        the template, the note must show the field's actual default as the
+        expected value — not `False` from `bool(None)`."""
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        account_data = self.chart_template_data["account.account"]
+        account = self._get_record_for_xml_id(list(account_data)[0])
+        account.active = False
+        record_values = dict(account_data[list(account_data)[0]])
+        record_values.pop("active", None)
+        note = wizard.diff_notes(record_values, account)
+        self.assertIn("Active", note)
+        self.assertIn("False → True", note)
+        self.assertNotIn("False → False", note)
+
+    def test_28a_no_drift_when_only_missing_translation_would_differ(self):
+        """A template translation for a language the DB never had stored
+        must not be flagged as drift — it's a translation the user never
+        created, not drift in a translation they did."""
+        self.env["res.lang"]._activate_lang("fr_FR")
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        account_data = self.chart_template_data["account.account"]
+        account = self._get_record_for_xml_id(list(account_data)[0])
+        english_name = account.with_context(lang="en_US").name
+        # No French translation set on the DB record.
+        record_values = {
+            "name": english_name,
+            "name@fr": "Compte attendu",
+        }
+        diff = wizard.diff_fields(record_values, account)
+        self.assertNotIn(
+            "name@fr",
+            diff,
+            "Missing-translation case must not produce a drift entry",
+        )
+        note = wizard.diff_notes(record_values, account)
+        self.assertNotIn("[fr]", note)
+        self.assertNotIn("Compte attendu", note)
+
+    def test_28c_english_drift_does_not_drag_in_missing_translation(self):
+        """When English drifts and a non-English template translation
+        exists but the DB never stored that language, the missing-language
+        line must not appear in the rendered note."""
+        self.env["res.lang"]._activate_lang("nl_NL")
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        account_data = self.chart_template_data["account.account"]
+        account = self._get_record_for_xml_id(list(account_data)[0])
+        # English drifts; no Dutch translation has ever been stored.
+        account.with_context(lang="en_US").name = "Undistributed Profits/Losses"
+        record_values = {
+            "name": "Profit or Loss Appropriation",
+            "name@nl": "Resultaatverwerking",
+        }
+        diff = wizard.diff_fields(record_values, account)
+        self.assertIn("name", diff)
+        self.assertNotIn("name@nl", diff)
+        note = wizard.diff_notes(record_values, account)
+        self.assertIn("Undistributed Profits/Losses", note)
+        self.assertIn("Profit or Loss Appropriation", note)
+        self.assertNotIn("[nl]", note)
+        self.assertNotIn("Resultaatverwerking", note)
+
+    def test_28b_diff_note_translation_html_field_strips_tags(self):
+        """`_diff_note_translation_detail` must strip HTML tags from both
+        actual and expected values on an HTML translatable field so the
+        bullet stays readable.
+        """
+        self.env["res.lang"]._activate_lang("fr_FR")
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        fp = self._get_record_for_xml_id("template_generic_domestic_fiscal_position")
+        # Use the actual stored value as the "actual" side: the per-lang
+        # write path on Html(translate=True) makes it unreliable to assume
+        # the en/fr slots stay independent, so we work directly with what
+        # ends up in the record.
+        fp.with_context(lang="fr_FR").note = "<p>Note <b>actuelle</b></p>"
+        field = fp._fields["note"]
+        detail = wizard._diff_note_translation_detail(
+            field,
+            fp,
+            {"note@fr": "<p>Note <i>attendue</i></p>"},
+            ["note@fr"],
+        )
+        self.assertIn("[fr]", detail)
+        # Inner content only — tags must be stripped on both sides.
+        self.assertIn("Note actuelle", detail)
+        self.assertIn("Note attendue", detail)
+        self.assertNotIn("<p>", detail)
+        self.assertNotIn("<b>", detail)
+        self.assertNotIn("<i>", detail)
+
+    def test_29_diff_note_translation_shows_both_languages(self):
+        """When both English and a translation differ, both per-language
+        lines must appear."""
+        self.env["res.lang"]._activate_lang("fr_FR")
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        account_data = self.chart_template_data["account.account"]
+        account_xml_id = list(account_data)[0]
+        account = self._get_record_for_xml_id(account_xml_id)
+        account.with_context(lang="en_US").name = "Drift EN"
+        account.with_context(lang="fr_FR").name = "Drift FR"
+        record_values = {
+            "name": "Expected EN",
+            "name@fr": "Expected FR",
+        }
+        note = wizard.diff_notes(record_values, account)
+        self.assertIn("[en]", note)
+        self.assertIn("[fr]", note)
+        self.assertIn("Drift EN", note)
+        self.assertIn("Expected EN", note)
+        self.assertIn("Drift FR", note)
+        self.assertIn("Expected FR", note)

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -249,7 +249,9 @@ class WizardUpdateChartsAccounts(models.TransientModel):
 
     def _domain_fp_field_ids(self):
         return self._domain_per_name("account.fiscal.position") + [
-            ("ttype", "!=", "one2many")
+            "|",
+            ("ttype", "!=", "one2many"),
+            ("name", "in", ["account_ids"]),
         ]
 
     def _default_tax_group_field_ids(self):
@@ -460,12 +462,17 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                                     r_data, f_name, lang.code
                                 )
                             )
+                            # Only populate the per-language key when the
+                            # template actually carries a translation for
+                            # this language. Falling back to the English
+                            # value here would cause diff_fields to compare
+                            # the DB's real translation against the English
+                            # source and incorrectly flag user-provided
+                            # translations as drift.
+                            if not field_translation:
+                                continue
                             short_lang = lang.code.split("_")[0]
-                            key_lang = f"{f_name}@{short_lang}"
-                            if field_translation:
-                                r_data[key_lang] = field_translation
-                            else:
-                                r_data[key_lang] = r_data[f_name]
+                            r_data[f"{f_name}@{short_lang}"] = field_translation
         return t_data
 
     def action_find_records(self):
@@ -533,7 +540,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         """
         mail_thread_fields = set(self.env["mail.thread"]._fields)
         specials_mapping = {
-            "account.tax.group": mail_thread_fields | {"sequence"},
+            "account.tax.group": mail_thread_fields | {"sequence", "tax_ids"},
             "account.tax": mail_thread_fields
             | {
                 "children_tax_ids",
@@ -542,8 +549,10 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             "account.account": mail_thread_fields
             | {
                 "root_id",
+                "company_ids",
             },
             "account.group": {"parent_id"},
+            "account.fiscal.position": {"tax_ids"},
         }
         specials = {
             "display_name",
@@ -598,11 +607,16 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         fields_by_key = {x.name: x for x in field_mapping[real._name]}
         to_include = field_mapping[real._name].mapped("name")
         for key in record_values.keys():
+            if key in ignore or key not in to_include:
+                continue
+            field_info = fields_by_key.get(key)
+            # Skip empty scalar templates so unset fields aren't flagged,
+            # but let empty m2m/o2m/boolean values through so that an
+            # explicit "clear links" in the template is detected when the
+            # real record has values.
             if (
-                key in ignore
-                or key not in to_include
-                or key in fields_by_key
-                and fields_by_key.get(key).ttype != "boolean"
+                field_info
+                and field_info.ttype not in ("boolean", "many2many", "one2many")
                 and not record_values.get(key)
             ):
                 continue
@@ -613,6 +627,9 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 real_value = self.padded_code(real_value)
             # Field ttype conditions
             if field.ttype == "many2many":
+                # Normalize falsy template values (None/False/"") so an
+                # explicit "no links" is compared like an empty string.
+                record_value = record_value or ""
                 if isinstance(record_value, str):
                     # If any template xmlid can't be resolved we skip the
                     # check — we can't reliably tell whether the link is
@@ -620,9 +637,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                     # unlinked (tracked separately by `missing_xml_id`).
                     expected_ids = set()
                     unresolved = False
-                    for v in record_value.split(","):
-                        if not v:
-                            continue
+                    for v in filter(None, record_value.split(",")):
                         xml_id = (
                             f"account.{self.company_id.id}_{v}" if "." not in v else v
                         )
@@ -634,10 +649,18 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                     if not unresolved and set(real_value.ids) != expected_ids:
                         result[key] = record_value
                 else:
-                    record_value_compare = []
-                    for record_value_item in record_value:
-                        record_value_compare += record_value_item[2]
-                    if record_value_compare.sort() != real_value.ids.sort():
+                    # record_value is an ORM command list. Collect the
+                    # expected record ids from SET (6) and LINK (4)
+                    # commands and compare as an unordered set.
+                    expected_cmd_ids = set()
+                    for cmd in (
+                        c for c in record_value if isinstance(c, list | tuple) and c
+                    ):
+                        if cmd[0] == 6 and len(cmd) >= 3 and isinstance(cmd[2], list):
+                            expected_cmd_ids = set(cmd[2])
+                        elif cmd[0] == 4:
+                            expected_cmd_ids.add(cmd[1])
+                    if expected_cmd_ids != set(real_value.ids):
                         result[key] = record_value
                 continue
             elif field.ttype == "many2one":
@@ -673,25 +696,35 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 continue
             # Define correct value if field is translatable
             if field.translate:
+                en_value = (real.with_context(lang="en_US")[key] or "").strip()
+                if field.ttype == "html":
+                    en_value = tools.mail.html_to_inner_content(en_value)
                 for lang in langs:
                     if lang.code == "en_US":
                         key_lang = key
                     else:
                         short_lang = lang.code.split("_")[0]
                         key_lang = f"{key}@{short_lang}"
-                    if key_lang in record_values:
-                        real_value_lang = (
-                            real.with_context(lang=lang.code)[key] or ""
-                        ).strip()
-                        record_value_lang = record_values[key_lang].strip()
-                        if field.ttype == "html":
-                            # Convert HTML to inner content for comparison
-                            # especially to prevent comparing str with Markup
-                            real_value_lang = tools.mail.html_to_inner_content(
-                                real_value_lang
-                            )
-                        if record_value_lang != real_value_lang:
-                            result[key_lang] = record_value_lang
+                    if key_lang not in record_values:
+                        continue
+                    real_value_lang = (
+                        real.with_context(lang=lang.code)[key] or ""
+                    ).strip()
+                    record_value_lang = record_values[key_lang].strip()
+                    if field.ttype == "html":
+                        # Convert HTML to inner content for comparison
+                        # especially to prevent comparing str with Markup
+                        real_value_lang = tools.mail.html_to_inner_content(
+                            real_value_lang
+                        )
+                    # Skip non-English variants whose actual value is just
+                    # the English fallback: there's no stored translation
+                    # for that language, so the diff would only reflect
+                    # Odoo's read-time fallback, not real drift.
+                    if lang.code != "en_US" and real_value_lang == en_value:
+                        continue
+                    if record_value_lang != real_value_lang:
+                        result[key_lang] = record_value_lang
             elif field.ttype == "html":
                 # Convert HTML to inner content for comparison
                 # especially to prevent comparing str with Markup
@@ -700,6 +733,40 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                     result[key] = record_value
             elif record_value != real_value:
                 result[key] = record_value
+        # The template CSV loader drops empty cells from record_values (see
+        # account.chart.template._parse_csv), so an explicit "no tags"
+        # column never reaches us. For tracked m2m/o2m fields that are
+        # absent from the template data, flag drift if the real record
+        # still has links — that's the only way the wizard can report
+        # e.g. an account whose template has tag_ids="" but whose DB
+        # record carries tags.
+        for key, field in fields_by_key.items():
+            if (
+                key in ignore
+                or key in result
+                or key in record_values
+                or field.ttype not in ("many2many", "one2many", "boolean")
+            ):
+                continue
+            # Skip readonly/inverse fields — they're populated automatically
+            # (e.g. `replacing_tax_ids`) and can't be overwritten anyway.
+            orm_field = real._fields.get(key)
+            if not orm_field or orm_field.readonly:
+                continue
+            if field.ttype == "boolean":
+                # Computed booleans (e.g. repartition lines'
+                # `use_in_tax_closing`, derived from account_id/
+                # repartition_type) would otherwise false-positive against
+                # the static default — trust the compute instead.
+                if getattr(orm_field, "compute", None):
+                    continue
+                # When the template is silent on a boolean, the expected
+                # value is the field's default — not a blanket False.
+                expected = real.default_get([key]).get(key, False)
+                if bool(real[key]) != bool(expected):
+                    result[key] = expected
+            elif real[key]:
+                result[key] = ""
         # __translation_module__
         if len(result.keys()) > 0 and not self.env.context.get("skip_translation_keys"):
             if "__translation_module__" in record_values:
@@ -710,36 +777,246 @@ class WizardUpdateChartsAccounts(models.TransientModel):
 
     @api.model
     def diff_notes(self, record_values, real):
-        """Get notes for humans on why is this record going to be updated.
+        """Get notes for humans on why this record is going to be updated.
 
-        :param openerp.models.Model record_values:
-            Record values values.
-
-        :param openerp.models.Model real:
-            Real record.
-
-        :return str:
-            Notes result.
+        Shows each differing field with a concise "actual → expected" detail
+        so the user can audit the proposed change before accepting it.
         """
-        result = list()
-        different_fields_set = set()
-        for f in (
-            self.with_context(skip_translation_keys=True)
-            .diff_fields(record_values, real)
-            .keys()
+        diff = self.with_context(skip_translation_keys=True).diff_fields(
+            record_values, real
+        )
+        # Collapse translation variants (e.g. name@fr) onto their base field.
+        by_field = {}
+        for key in diff:
+            base = key.split("@", 1)[0] if "@" in key else key
+            by_field.setdefault(base, []).append(key)
+        if not by_field:
+            return ""
+        # Merge the diff result on top of record_values so synthesized
+        # drift (e.g. booleans absent from the template but expected to
+        # match the field's default) renders its real expected value
+        # instead of `bool(None) = False`.
+        effective_values = {**record_values, **diff}
+        lines = [self.env._("Differences in these fields:")]
+        for base in sorted(
+            by_field, key=lambda n: real._fields[n].get_description(self.env)["string"]
         ):
-            field_name = f.split("@")[0] if "@" in f else f
-            different_fields_set.add(
-                real._fields[field_name].get_description(self.env)["string"]
+            field = real._fields[base]
+            label = field.get_description(self.env)["string"]
+            detail = self._diff_note_detail(
+                field, real, effective_values, by_field[base]
             )
-        different_fields = sorted(list(different_fields_set))
-        if different_fields:
-            result.append(
-                self.env._(
-                    "Differences in these fields: %s.", ", ".join(different_fields)
+            lines.append(f"- {label}: {detail}" if detail else f"- {label}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _diff_note_truncate(value):
+        text = "" if value is None or value is False else str(value)
+        return text if len(text) <= 80 else text[:77] + "…"
+
+    def _diff_note_resolve_xmlid(self, short_or_full):
+        xml_id = (
+            f"account.{self.company_id.id}_{short_or_full}"
+            if "." not in short_or_full
+            else short_or_full
+        )
+        return self.env.ref(xml_id, raise_if_not_found=False)
+
+    @staticmethod
+    def _diff_note_label(rec):
+        """Fallback label for sub-records whose `display_name` is the parent."""
+        if rec._name == "account.fiscal.position.account":
+            return (
+                f"{rec.account_src_id.display_name} "
+                f"→ {rec.account_dest_id.display_name}"
+            )
+        if rec._name == "account.tax.repartition.line":
+            return f"{rec.document_type}/{rec.repartition_type} {rec.factor_percent:g}%"
+        return rec.display_name
+
+    def _diff_note_expected_m2x_names(self, expected_v, comodel_name):
+        """Resolve an m2m/o2m template value (xmlid string or command list)
+        to a sorted list of display names."""
+        names = []
+        if isinstance(expected_v, str):
+            for v in filter(None, expected_v.split(",")):
+                rec = self._diff_note_resolve_xmlid(v)
+                names.append(rec.display_name if rec else v)
+        elif isinstance(expected_v, list | tuple) and comodel_name:
+            Comodel = self.env[comodel_name]
+            for cmd in (
+                c for c in expected_v if isinstance(c, list | tuple) and len(c) >= 3
+            ):
+                if cmd[0] == 6 and isinstance(cmd[2], list):
+                    names = Comodel.browse(cmd[2]).mapped("display_name")
+                    break
+                if cmd[0] == 4:
+                    names.append(Comodel.browse(cmd[1]).display_name)
+        return sorted(names)
+
+    def _diff_note_sub_detail(self, sub_vals, rec, diff_keys):
+        """Render "field actual → expected" parts for a single sub-record."""
+        parts = []
+        for k in diff_keys:
+            sub_field = rec._fields.get(k)
+            actual_v = rec[k] if sub_field else None
+            expected_v = sub_vals.get(k)
+            ttype = sub_field.type if sub_field else None
+            if ttype == "many2one":
+                a_name = actual_v.display_name if actual_v else ""
+                e_rec = (
+                    self._diff_note_resolve_xmlid(expected_v)
+                    if isinstance(expected_v, str)
+                    else None
                 )
+                e_name = e_rec.display_name if e_rec else (expected_v or "")
+                parts.append(f"{k} '{a_name}' → '{e_name}'")
+            elif ttype in ("many2many", "one2many"):
+                a_names = sorted(actual_v.mapped("display_name")) if actual_v else []
+                e_names = self._diff_note_expected_m2x_names(
+                    expected_v, sub_field.comodel_name
+                )
+                a_str = ", ".join(a_names) or "∅"
+                e_str = ", ".join(e_names) or "∅"
+                parts.append(
+                    f"{k} [{self._diff_note_truncate(a_str)}]"
+                    f" → [{self._diff_note_truncate(e_str)}]"
+                )
+            else:
+                parts.append(
+                    f"{k} '{self._diff_note_truncate(actual_v)}'"
+                    f" → '{self._diff_note_truncate(expected_v)}'"
+                )
+        return "; ".join(parts)
+
+    def _diff_note_commands(self, field, actual, expected_raw):
+        """Detail string for an m2m/o2m whose template value is a command list."""
+        actual_count = len(actual)
+        expected_count = 0
+        for cmd in (c for c in expected_raw if isinstance(c, list | tuple) and c):
+            if cmd[0] in (0, 4):  # CREATE / LINK
+                expected_count += 1
+            elif cmd[0] == 6 and len(cmd) >= 3:  # SET
+                expected_count += len(cmd[2])
+        if actual_count != expected_count:
+            return self.env._(
+                "%(actual)s record(s) → %(expected)s record(s)",
+                actual=actual_count,
+                expected=expected_count,
             )
-        return "\n".join(result)
+        sub_diffs = []
+        for idx, cmd in (
+            (i, c)
+            for i, c in enumerate(expected_raw[:actual_count])
+            if isinstance(c, list | tuple) and len(c) >= 3 and isinstance(c[2], dict)
+        ):
+            sub_diff = self.with_context(skip_translation_keys=True).diff_fields(
+                cmd[2], actual[idx]
+            )
+            diff_keys = sorted(k for k in sub_diff if k != "__translation_module__")
+            if diff_keys:
+                detail = self._diff_note_sub_detail(cmd[2], actual[idx], diff_keys)
+                sub_diffs.append(f"#{idx + 1}: {detail}")
+            if len(sub_diffs) >= 3:
+                break
+        if sub_diffs:
+            return "\n    " + "\n    ".join(sub_diffs)
+        return self.env._(
+            "%(n)s record(s) → differs from template",
+            n=actual_count,
+        )
+
+    def _diff_note_m2x(self, field, actual, expected_raw):
+        """Detail string for an m2m/o2m field."""
+        actual_names = (
+            sorted(self._diff_note_label(rec) for rec in actual) if actual else []
+        )
+        if isinstance(expected_raw, str) or not expected_raw:
+            expected_names = self._diff_note_expected_m2x_names(
+                expected_raw, field.comodel_name
+            )
+            actual_str = ", ".join(actual_names) or "∅"
+            expected_str = ", ".join(expected_names) or "∅"
+            return (
+                f"[{self._diff_note_truncate(actual_str)}]"
+                f" → [{self._diff_note_truncate(expected_str)}]"
+            )
+        return self._diff_note_commands(field, actual, expected_raw)
+
+    def _diff_note_m2o(self, field, actual, expected_raw):
+        """Detail string for a many2one field."""
+        actual_name = actual.display_name if actual else ""
+        expected_name = ""
+        if isinstance(expected_raw, str):
+            rec = self._diff_note_resolve_xmlid(expected_raw)
+            expected_name = rec.display_name if rec else expected_raw
+        elif isinstance(expected_raw, int):
+            rec = self.env[field.comodel_name].browse(expected_raw)
+            expected_name = rec.display_name if rec.exists() else str(expected_raw)
+        return (
+            f"'{self._diff_note_truncate(actual_name)}'"
+            f" → '{self._diff_note_truncate(expected_name)}'"
+        )
+
+    def _diff_note_detail(self, field, real, record_values, diff_keys=None):
+        """Return a "actual → expected" string for a differing field.
+
+        `diff_keys` lists the actual keys from the diff for this field (e.g.
+        ["name", "name@fr"]); for translatable fields we use it to render
+        per-language details so the bullet always reads the same-language
+        actual value rather than whatever `env.lang` happened to be.
+        """
+        if field.translate and diff_keys:
+            return self._diff_note_translation_detail(
+                field, real, record_values, diff_keys
+            )
+        actual = real[field.name]
+        expected_raw = record_values.get(field.name)
+        if field.type in ("many2many", "one2many"):
+            return self._diff_note_m2x(field, actual, expected_raw)
+        if field.type == "many2one":
+            return self._diff_note_m2o(field, actual, expected_raw)
+        if field.type == "boolean":
+            return f"{bool(actual)} → {bool(expected_raw)}"
+        return (
+            f"'{self._diff_note_truncate(actual)}'"
+            f" → '{self._diff_note_truncate(expected_raw)}'"
+        )
+
+    def _diff_note_translation_detail(self, field, real, record_values, diff_keys):
+        """Render per-language details for a translatable field whose diff
+        includes translation variants (e.g. `name@fr`).
+
+        Variants are only present in ``diff_keys`` when ``diff_fields``
+        decided the per-language value really drifted, so we can render
+        them directly without re-checking against the English fallback.
+        """
+        active_langs = self.env["res.lang"].search([("active", "=", True)])
+        by_short = {}
+        for lang in active_langs:
+            by_short.setdefault(lang.code.split("_")[0], lang)
+        parts = []
+        for key in sorted(diff_keys):
+            if "@" in key:
+                short = key.split("@", 1)[1]
+                lang = by_short.get(short)
+                lang_code = lang.code if lang else "en_US"
+                lang_label = short
+            else:
+                lang_code = "en_US"
+                lang_label = "en"
+            actual = real.with_context(lang=lang_code)[field.name] or ""
+            expected = record_values.get(key) or ""
+            if field.type == "html":
+                actual = tools.mail.html_to_inner_content(actual) if actual else ""
+                expected = (
+                    tools.mail.html_to_inner_content(expected) if expected else ""
+                )
+            parts.append(
+                f"[{lang_label}] '{self._diff_note_truncate(actual)}'"
+                f" → '{self._diff_note_truncate(expected)}'"
+            )
+        return "; ".join(parts)
 
     def _domain_taxes_to_deactivate(self, found_taxes_ids):
         return [
@@ -802,6 +1079,18 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         )
         return full_xml_id not in record_xml_ids
 
+    def _missing_xml_id_note(self, record, xml_id):
+        """Human-readable note for a missing xml_id, showing expected vs
+        the ones currently attached to the record."""
+        full = f"account.{self.company_id.id}_{xml_id}" if "." not in xml_id else xml_id
+        current = record._get_external_ids().get(record.id, [])
+        current_str = ", ".join(current) or self.env._("none")
+        return self.env._(
+            "Missing XML-ID (expected %(expected)s; currently: %(current)s).",
+            expected=full,
+            current=current_str,
+        )
+
     def recreate_xml_id(self, record, xml_id):
         """Recreate the xml_id if it is different than expected, otherwise
         chart.template won't do it correctly.
@@ -845,7 +1134,9 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 # Check the tax group for changes
                 notes = self.diff_notes(r_data, tax_group)
                 if self.missing_xml_id(tax_group, xmlid):
-                    notes += (notes and "\n" or "") + self.env._("Missing XML-ID.")
+                    notes += (notes and "\n" or "") + self._missing_xml_id_note(
+                        tax_group, xmlid
+                    )
                 if notes:
                     # Tax group to be updated
                     tax_group_vals.append(
@@ -884,7 +1175,9 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 # Check the tax for changes
                 notes = self.diff_notes(r_data, tax)
                 if self.missing_xml_id(tax, xmlid):
-                    notes += (notes and "\n" or "") + self.env._("Missing XML-ID.")
+                    notes += (notes and "\n" or "") + self._missing_xml_id_note(
+                        tax, xmlid
+                    )
                 if notes:
                     # Tax to be updated
                     tax_vals.append(
@@ -935,7 +1228,9 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 # Check the account for changes
                 notes = self.diff_notes(r_data, account)
                 if self.missing_xml_id(account, xmlid):
-                    notes += (notes and "\n" or "") + self.env._("Missing XML-ID.")
+                    notes += (notes and "\n" or "") + self._missing_xml_id_note(
+                        account, xmlid
+                    )
                 if notes:
                     # Account to be updated
                     account_vals.append(
@@ -976,11 +1271,25 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                     else r_data["code_prefix_start"]
                 )
                 if code_prefix_end != account_group.code_prefix_end:
-                    notes += (notes and "\n" or "") + self.env._(
-                        "Differences in these fields: %s.", code_prefix_end
+                    label = account_group._fields["code_prefix_end"].get_description(
+                        self.env
+                    )["string"]
+                    line = self.env._(
+                        "- %(label)s: '%(actual)s' → '%(expected)s'",
+                        label=label,
+                        actual=account_group.code_prefix_end or "",
+                        expected=code_prefix_end or "",
                     )
+                    if notes:
+                        # Append under the existing "Differences in these fields:"
+                        # header produced by diff_notes.
+                        notes += f"\n{line}"
+                    else:
+                        notes = self.env._("Differences in these fields:") + f"\n{line}"
                 if self.missing_xml_id(account_group, xmlid):
-                    notes += (notes and "\n" or "") + self.env._("Missing XML-ID.")
+                    notes += (notes and "\n" or "") + self._missing_xml_id_note(
+                        account_group, xmlid
+                    )
                 if notes:
                     # Account to be updated
                     ag_vals.append(
@@ -1015,7 +1324,9 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 # Check the fiscal position for changes
                 notes = self.diff_notes(r_data, fp)
                 if self.missing_xml_id(fp, xmlid):
-                    notes += (notes and "\n" or "") + self.env._("Missing XML-ID.")
+                    notes += (notes and "\n" or "") + self._missing_xml_id_note(
+                        fp, xmlid
+                    )
                 if notes:
                     # Fiscal position template to be updated
                     fp_vals.append(


### PR DESCRIPTION
Overhauls the chart-update wizard so the "Records to create/update" step
surfaces what actually differs, and so it detects drift on fields that
were previously silently ignored.

Detection
- `account.tax.fiscal_position_ids` / `original_tax_ids` (the Odoo 19
  replacement for the removed `account.fiscal.position.tax`) now
  participate in the diff; m2m comparison resolves template xmlids to
  record ids and compares as sets, with a guard that skips the check
  when a template xmlid can't be resolved (avoids false positives when
  an xmlid was unlinked from a record that's still correctly linked).
- Fixed the m2m command-list comparator that used `.sort() != .sort()`
  — `.sort()` returns `None` so no drift was ever flagged there. Now
  collects ids from SET/LINK commands and compares as an unordered set.
  Restores drift detection for e.g. `repartition_line_ids/tag_ids`.
- Post-loop synthesizes drift for tracked m2m/o2m/boolean fields that
  the CSV loader dropped (empty cells never reach `record_values`).
  Booleans fall back to the field's declared default via `default_get`.
  Skips readonly/computed fields so inverse relations (e.g.
  `replacing_tax_ids`) and compute-derived fields (e.g. repartition
  lines' `use_in_tax_closing`) don't produce false positives.
- `account.fiscal.position.account_ids` is now a tracked field
  (whitelist added to `_domain_fp_field_ids`, same pattern the tax
  side uses for `repartition_line_ids`).

Ignored fields
- `company_ids` on `account.account`, `tax_ids` on `account.tax.group`
  and on `account.fiscal.position` — these are inverse/secondary
  relations that the template never sets directly.

Notes (the wizard's per-record message)
- Rewrote `diff_notes` to produce a bullet list per differing field
  with a concise "actual → expected" detail.
- m2m/o2m show resolved display names; `account.fiscal.position.account`
  and `account.tax.repartition.line` use a meaningful label (src→dest,
  document_type/repartition_type factor%) instead of the parent-based
  `display_name`.
- o2m with an ORM command list (e.g. `repartition_line_ids`):
  * count mismatch → "N record(s) → M record(s)"
  * same count → per-line details on separate indented lines showing
    which sub-field drifted and its resolved value.
- `Missing XML-ID` note now shows both the expected xmlid and the ones
  currently attached to the record.
- `code_prefix_end` drift on account groups is emitted as a normal
  bullet (`End Code Prefix: '…' → '…'`) under the same header.
