### PR TITLE
[18.0][FIX] account_usability: Ensure translations getting used

### DIFF
--- a/account_usability/__init__.py
+++ b/account_usability/__init__.py
@@ -1,1 +1,3 @@
+from .hooks import pre_init_hook, post_init_hook
 from . import models
+from . import wizards

--- a/account_usability/__manifest__.py
+++ b/account_usability/__manifest__.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2019 - Today: GRAP (http://www.grap.coop)
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Account - Missing Menus & Saxon Accounting",
-    "version": "18.0.1.1.1",
+    "version": "18.0.1.1.2",
     "category": "Accounting",
     "license": "AGPL-3",
     "summary": "Adds missing menu entries for Account module and"
@@ -13,6 +14,7 @@
     "maintainers": ["legalsylvain"],
     "website": "https://github.com/OCA/account-financial-tools",
     "depends": ["account"],
+    "external_dependencies": {"python": ["openupgradelib"]},
     "data": [
         "data/ir_module_category.xml",
         "security/res_groups.xml",
@@ -25,4 +27,6 @@
     ],
     "demo": ["demo/res_groups.xml"],
     "installable": True,
+    "pre_init_hook": "pre_init_hook",
+    "post_init_hook": "post_init_hook",
 }

--- a/account_usability/hooks.py
+++ b/account_usability/hooks.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html
+from openupgradelib import openupgrade
+
+
+def pre_init_hook(env):
+    """Add menu_finance also as xmlid for account_usability
+    so that it get listed in i18n/account_usability.pot
+    automatically and can be translated with the default workflow
+    """
+    menu_finance = env.ref("account.menu_finance")
+    openupgrade.add_xmlid(
+        env.cr, "account_usability", "menu_finance", "ir.ui.menu", menu_finance.id
+    )
+
+
+def post_init_hook(env):
+    """Ensure translation is getting overwritten on install
+    by default this isn't the case, because on a normal install
+    no i18n-overwrite is passed"""
+    module = env.ref("base.module_account_usability")
+    module._update_translations(overwrite=True)

--- a/account_usability/i18n/de.po
+++ b/account_usability/i18n/de.po
@@ -126,7 +126,7 @@ msgstr "Vorlagen"
 msgid "Use anglo-saxon accounting"
 msgstr "Anglo-amerikanische Buchführung verwenden"
 
-#. module: account
-#: model:ir.ui.menu,name:account.menu_finance
+#. module: account_usability
+#: model:ir.ui.menu,name:account_usability.menu_finance
 msgid "Accounting"
 msgstr "Buchhaltung"

--- a/account_usability/migrations/18.0.1.1.2/post-migration.py
+++ b/account_usability/migrations/18.0.1.1.2/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+from odoo.addons.account_usability.hooks import post_init_hook
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    post_init_hook(env)

--- a/account_usability/migrations/18.0.1.1.2/pre-migration.py
+++ b/account_usability/migrations/18.0.1.1.2/pre-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+from odoo.addons.account_usability.hooks import pre_init_hook
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    pre_init_hook(env)

--- a/account_usability/readme/CONTRIBUTORS.md
+++ b/account_usability/readme/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
 - Álvaro Trius \<<alvaro.trius@forgeflow.com>\>
 - \[APSL-Nagarro\](<https://apsl.tech>):
   - Antoni Marroig \<<amarroig@apsl.net>\>
+- Michael Tietz (MT Software) \<<mtietz@mt-software.de>\>

--- a/account_usability/views/menu.xml
+++ b/account_usability/views/menu.xml
@@ -6,9 +6,10 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 <odoo>
     <!-- Rename groups to fit with EE naming 'Billing' -> 'Accounting' -->
-    <record id="account.menu_finance" model="ir.ui.menu">
+    <record id="menu_finance" model="ir.ui.menu">
         <field name="name">Accounting</field>
     </record>
+
 
     <menuitem
         id="menu_accounting_bank_and_cash"

--- a/account_usability/wizards/__init__.py
+++ b/account_usability/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import base_language_install

--- a/account_usability/wizards/base_language_install.py
+++ b/account_usability/wizards/base_language_install.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class BaseLanguageInstall(models.TransientModel):
+    _inherit = "base.language.install"
+
+    def lang_install(self):
+        """Reload this addon's translations after a language install.
+
+        account_usability shares translation terms (e.g. ``menu_finance``)
+        with core addons like ``account``. The standard install may pick
+        another addon's translation for such a term, so we re-run
+        ``_update_translations`` scoped to this module to make sure its own
+        ``.po`` wins for the newly installed languages.
+        """
+        res = super().lang_install()
+        self.ensure_one()
+        module = self.env.ref("base.module_account_usability")
+        module._update_translations(self.lang_ids.mapped("code"), self.overwrite)
+        return res

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@
 freezegun
 numpy-financial<=1.0.0
 numpy>=1.15
+openupgradelib
 python-dateutil


### PR DESCRIPTION
Within the oca it is not possible to extend the *.pot file for an addon,
since it is getting changed by the ocabot automatically. 

Since menu_finance is renamed it is not possible to translate it within the default behavior.

To make it work in the default behavior we not to teach account_usability
that it actually created the records to translate. For menu_finance just add the xmlid in pre_init_hook.

The second thing, which needs to be done, is to load the translation of account_usability separately,
otherwise when loading all the terms from the different addons the translation term of account will win.
 
By this changes we can stick to the default translation process with weblate. 
And we don't need to create separate addons in the different l10n-* addons like it is already done
https://github.com/OCA/l10n-italy/pull/4298
and
https://github.com/OCA/l10n-germany/pull/233

cc @primes2h @yweng8111 @smaddlsoft @Sylvain @legalsylvain