### PR TITLE
16.0 imp account_usability:  account tax template slg

### DIFF
--- a/account_usability/models/__init__.py
+++ b/account_usability/models/__init__.py
@@ -2,3 +2,4 @@ from . import account_group
 from . import account_tag
 from . import account_tax_group
 from . import res_config_settings
+from . import account_tax_template

--- a/account_usability/models/account_tax_template.py
+++ b/account_usability/models/account_tax_template.py
@@ -1,0 +1,23 @@
+# Copyright 2018 FOREST AND BIOMASS ROMANIA SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class AccountTaxTemplate(models.Model):
+    _inherit = "account.tax.template"
+
+    def name_get(self):
+        name_list = []
+        type_tax_use = dict(
+            self._fields["type_tax_use"]._description_selection(self.env)
+        )
+        tax_scope = dict(self._fields["tax_scope"]._description_selection(self.env))
+        for record in self:
+            name = record.name
+            if self._context.get("append_type_to_tax_name"):
+                name += " (%s)" % type_tax_use.get(record.type_tax_use)
+            if record.tax_scope:
+                name += " (%s)" % tax_scope.get(record.tax_scope)
+            name_list += [(record.id, name)]
+        return name_list

--- a/account_usability/views/view_account_tax_template.xml
+++ b/account_usability/views/view_account_tax_template.xml
@@ -11,4 +11,30 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         parent="menu_account_coa_settings"
         sequence="30"
     />
+
+    <record id="view_account_tax_template_form" model="ir.ui.view">
+        <field name="model">account.tax.template</field>
+        <field name="inherit_id" ref="account.view_account_tax_template_form" />
+        <field name="arch" type="xml">
+            <field name="type_tax_use" position="after">
+                <field name="tax_scope" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_account_tax_template_list" model="ir.ui.view">
+        <field name="model">account.tax.template</field>
+        <field name="inherit_id" ref="account.view_account_tax_template_tree" />
+        <field name="arch" type="xml">
+            <field name="description" position="before">
+                <field name="type_tax_use" />
+                <field name="tax_scope" />
+            </field>
+            <field name="description" position="after">
+                <field name="price_include" optional="hide" />
+                <field name="amount" optional="hide" />
+            </field>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
* [IMP] account_usability : improve account_tax_template view, adding missing tax_scope and amount fields (https://github.com/OCA/account-financial-tools/commit/9df2a5085408792c6faf77bdfd6c2b76e61027c3)
* [IMP] account_usability: improve display of account_tax_template. Rational: by default in Odoo  name_get display tax_scope, type_tax_use. but  only display description if available. As a result, it is not possible to identify account.tax.template. This PR implement the same name_get for account tax and account tax template. (https://github.com/OCA/account-financial-tools/commit/24baa3496ab4ccb143618d6aa60b400feca9aa03)
* 