### PR TITLE
[19.0][FIX] account_move_name_sequence: make incoming supplier invoice test robust

### DIFF
--- a/account_move_name_sequence/tests/test_account_incoming_supplier_invoice.py
+++ b/account_move_name_sequence/tests/test_account_incoming_supplier_invoice.py
@@ -1,7 +1,5 @@
 import json
 
-from markupsafe import Markup
-
 from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -86,9 +84,9 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
         self.assertEqual(
             len(message_ids), 1, "Only one message should be posted in the chatter"
         )
-        self.assertEqual(
+        self.assertIn(
+            "Vendor Bill Created",
             message_ids.body,
-            Markup("<p>Vendor Bill Created</p>"),
             "Only the invoice creation should be posted",
         )
 


### PR DESCRIPTION
### Description
This PR resolves a test case failure in the `account_move_name_sequence` module on the OCA CI server.

Reference:- https://github.com/OCA/account-financial-tools/pull/2286

**Issue:**
The test `test_supplier_invoice_mailed_from_supplier` asserted the exact HTML tag wrapping of the vendor bill creation message in the chatter:
```python
self.assertEqual(message_ids.body, Markup("<p>Vendor Bill Created</p>"))