### PR TITLE
[17.0] [IMP] account_asset_management: support branch companies with parent masters

### DIFF
--- a/account_asset_management/__manifest__.py
+++ b/account_asset_management/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Assets Management",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.2.2",
     "license": "AGPL-3",
     "depends": ["account", "report_xlsx_helper"],
     "excludes": ["account_asset"],

--- a/account_asset_management/migrations/17.0.1.2.2/noupdate_changes.xml
+++ b/account_asset_management/migrations/17.0.1.2.2/noupdate_changes.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="account_asset_profile_multi_company_rule" model="ir.rule">
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'parent_of', company_ids)]</field>
+    </record>
+    <record id="account_asset_group_multi_company_rule" model="ir.rule">
+        <field
+            name="domain_force"
+        >['|', ('company_id', '=', False), ('company_id', 'parent_of', company_ids)]</field>
+    </record>
+</odoo>

--- a/account_asset_management/migrations/17.0.1.2.2/post-migration.py
+++ b/account_asset_management/migrations/17.0.1.2.2/post-migration.py
@@ -1,0 +1,12 @@
+# Copyright 2026 Imaro Tech
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env,
+        "account_asset_management",
+        "migrations/17.0.1.2.2/noupdate_changes.xml",
+    )

--- a/account_asset_management/models/account_asset_group.py
+++ b/account_asset_management/models/account_asset_group.py
@@ -1,6 +1,7 @@
 # Copyright 2009-2020 Noviat
 # Copyright 2019 Tecnativa - Pedro M. Baeza
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2026 Imaro Tech - Ignacio R. Díaz
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -12,6 +13,7 @@ class AccountAssetGroup(models.Model):
     _order = "code, name"
     _parent_store = True
     _check_company_auto = True
+    _check_company_domain = models.check_company_domain_parent_of
     _rec_names_search = ["code", "name"]
 
     name = fields.Char(size=64, required=True, index=True)

--- a/account_asset_management/models/account_asset_line.py
+++ b/account_asset_management/models/account_asset_line.py
@@ -1,5 +1,6 @@
 # Copyright 2009-2018 Noviat
 # Copyright 2021 Tecnativa - João Marques
+# Copyright 2026 Imaro Tech - Ignacio R. Díaz
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -223,6 +224,7 @@ class AccountAssetLine(models.Model):
             "date": depreciation_date,
             "ref": f"{asset.name} - {self.name}",
             "journal_id": asset.profile_id.journal_id.id,
+            "company_id": asset.company_id.id,
         }
         return move_data
 
@@ -263,17 +265,32 @@ class AccountAssetLine(models.Model):
             asset = line.asset_id
             depreciation_date = line.line_date
             am_vals = line._setup_move_data(depreciation_date)
-            move = self.env["account.move"].with_context(**ctx).create(am_vals)
+            move = (
+                self.env["account.move"]
+                .with_company(asset.company_id)
+                .with_context(**ctx)
+                .create(am_vals)
+            )
             depr_acc = asset.profile_id.account_depreciation_id
             exp_acc = asset.profile_id.account_expense_depreciation_id
             aml_d_vals = line._setup_move_line_data(
                 depreciation_date, depr_acc, "depreciation", move
             )
-            self.env["account.move.line"].with_context(**ctx).create(aml_d_vals)
+            (
+                self.env["account.move.line"]
+                .with_company(asset.company_id)
+                .with_context(**ctx)
+                .create(aml_d_vals)
+            )
             aml_e_vals = line._setup_move_line_data(
                 depreciation_date, exp_acc, "expense", move
             )
-            self.env["account.move.line"].with_context(**ctx).create(aml_e_vals)
+            (
+                self.env["account.move.line"]
+                .with_company(asset.company_id)
+                .with_context(**ctx)
+                .create(aml_e_vals)
+            )
             move.action_post()
             line.with_context(allow_asset_line_update=True).write({"move_id": move.id})
             created_move_ids.append(move.id)

--- a/account_asset_management/models/account_asset_profile.py
+++ b/account_asset_management/models/account_asset_profile.py
@@ -1,4 +1,5 @@
 # Copyright 2009-2018 Noviat
+# Copyright 2026 Imaro Tech - Ignacio R. Díaz
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -9,6 +10,7 @@ class AccountAssetProfile(models.Model):
     _name = "account.asset.profile"
     _inherit = "analytic.mixin"
     _check_company_auto = True
+    _check_company_domain = models.check_company_domain_parent_of
     _description = "Asset profile"
     _order = "name"
 

--- a/account_asset_management/security/account_asset_security.xml
+++ b/account_asset_management/security/account_asset_security.xml
@@ -6,7 +6,7 @@
         <field eval="True" name="global" />
         <field
             name="domain_force"
-        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        >['|', ('company_id', '=', False), ('company_id', 'parent_of', company_ids)]</field>
     </record>
     <record id="account_asset_multi_company_rule" model="ir.rule">
         <field name="name">Account Asset multi-company</field>
@@ -22,6 +22,6 @@
         <field eval="True" name="global" />
         <field
             name="domain_force"
-        >['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        >['|', ('company_id', '=', False), ('company_id', 'parent_of', company_ids)]</field>
     </record>
 </odoo>

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2014 ACSONE SA/NV (acsone.eu).
 # Copyright 2009-2018 Noviat
 # Copyright 2021 Tecnativa - João Marques
+# Copyright 2026 Imaro Tech - Ignacio R. Díaz
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import calendar
@@ -1058,3 +1059,240 @@ class TestAssetManagement(AccountTestInvoicingCommon):
             }
         )
         self.assertEqual(asset.salvage_value, 5)
+
+    def test_22_branch_asset_from_invoice_and_depreciation(self):
+        """Branch assets can use parent-company profiles and post in branch."""
+        branch = self.env["res.company"].create(
+            {
+                "name": "Branch Company",
+                "parent_id": self.company_data["company"].id,
+            }
+        )
+        branch_purchase_journal = self.company_data["default_journal_purchase"].copy(
+            {
+                "name": "Branch Purchases",
+                "code": "BRP22",
+                "company_id": branch.id,
+            }
+        )
+        self.partner.with_company(branch).write(
+            {
+                "property_account_payable_id": self.company_data[
+                    "default_account_payable"
+                ].id,
+                "property_account_receivable_id": self.company_data[
+                    "default_account_receivable"
+                ].id,
+            }
+        )
+        asset_profile = self.asset_profile_model.create(
+            {
+                "name": "Branch profile",
+                "company_id": self.company_data["company"].id,
+                "account_asset_id": self.company_data["default_account_assets"].id,
+                "account_depreciation_id": self.company_data[
+                    "default_account_assets"
+                ].id,
+                "account_expense_depreciation_id": self.company_data[
+                    "default_account_expense"
+                ].id,
+                "journal_id": self.company_data["default_journal_purchase"].id,
+            }
+        )
+        all_assets = self.asset_model.search([])
+        invoice = (
+            self.env["account.move"]
+            .with_company(branch)
+            .with_context(check_move_validity=False)
+            .create(
+                {
+                    "move_type": "in_invoice",
+                    "company_id": branch.id,
+                    "journal_id": branch_purchase_journal.id,
+                    "partner_id": self.partner.id,
+                    "invoice_date": fields.Date.context_today(self.env.user),
+                    "invoice_payment_term_id": self.env.ref(
+                        "account.account_payment_term_immediate"
+                    ).id,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "name": "Branch asset line",
+                                "product_id": self.product.id,
+                                "account_id": self.company_data[
+                                    "default_account_expense"
+                                ].id,
+                                "quantity": 1,
+                                "price_unit": 500.0,
+                                "tax_ids": [Command.clear()],
+                                "asset_profile_id": asset_profile.id,
+                            }
+                        )
+                    ],
+                }
+            )
+        )
+        invoice.action_post()
+        new_assets = self.asset_model.search([]) - all_assets
+        self.assertEqual(len(new_assets), 1)
+        asset = new_assets[0]
+        self.assertEqual(asset.company_id, branch)
+        self.assertEqual(asset.profile_id, asset_profile)
+        asset.compute_depreciation_board()
+        asset.validate()
+        asset.depreciation_line_ids[1].create_move()
+        move = asset.depreciation_line_ids[1].move_id
+        self.assertEqual(move.company_id, branch)
+        self.assertTrue(all(line.company_id == branch for line in move.line_ids))
+
+    def test_23_branch_asset_removal_with_parent_accounts(self):
+        """Branch removals can use parent-company accounts and post in branch."""
+        branch = self.env["res.company"].create(
+            {
+                "name": "Branch Company Removal",
+                "parent_id": self.company_data["company"].id,
+            }
+        )
+        branch_purchase_journal = self.company_data["default_journal_purchase"].copy(
+            {
+                "name": "Branch Purchases Removal",
+                "code": "BRP23",
+                "company_id": branch.id,
+            }
+        )
+        self.partner.with_company(branch).write(
+            {
+                "property_account_payable_id": self.company_data[
+                    "default_account_payable"
+                ].id,
+                "property_account_receivable_id": self.company_data[
+                    "default_account_receivable"
+                ].id,
+            }
+        )
+        asset_profile = self.asset_profile_model.create(
+            {
+                "name": "Branch profile removal",
+                "company_id": self.company_data["company"].id,
+                "account_asset_id": self.company_data["default_account_assets"].id,
+                "account_depreciation_id": self.company_data[
+                    "default_account_assets"
+                ].id,
+                "account_expense_depreciation_id": self.company_data[
+                    "default_account_expense"
+                ].id,
+                "journal_id": self.company_data["default_journal_purchase"].id,
+            }
+        )
+        all_assets = self.asset_model.search([])
+        invoice = (
+            self.env["account.move"]
+            .with_company(branch)
+            .with_context(check_move_validity=False)
+            .create(
+                {
+                    "move_type": "in_invoice",
+                    "company_id": branch.id,
+                    "journal_id": branch_purchase_journal.id,
+                    "partner_id": self.partner.id,
+                    "invoice_date": fields.Date.context_today(self.env.user),
+                    "invoice_payment_term_id": self.env.ref(
+                        "account.account_payment_term_immediate"
+                    ).id,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "name": "Branch removal asset line",
+                                "product_id": self.product.id,
+                                "account_id": self.company_data[
+                                    "default_account_expense"
+                                ].id,
+                                "quantity": 1,
+                                "price_unit": 500.0,
+                                "tax_ids": [Command.clear()],
+                                "asset_profile_id": asset_profile.id,
+                            }
+                        )
+                    ],
+                }
+            )
+        )
+        invoice.action_post()
+        asset = (self.asset_model.search([]) - all_assets)[0]
+        asset.validate()
+        wiz = self.remove_model.with_context(active_id=asset.id).create(
+            {
+                "date_remove": time.strftime("%Y-%m-%d"),
+                "sale_value": 0.0,
+                "posting_regime": "gain_loss_on_sale",
+                "company_id": branch.id,
+                "account_plus_value_id": self.company_data[
+                    "default_account_revenue"
+                ].id,
+                "account_min_value_id": self.company_data["default_account_expense"].id,
+            }
+        )
+        wiz.remove()
+        move = asset.depreciation_line_ids.filtered(
+            lambda line: line.type == "remove"
+        ).move_id
+        self.assertTrue(move)
+        self.assertEqual(move.company_id, branch)
+        self.assertTrue(all(line.company_id == branch for line in move.line_ids))
+
+    def test_24_branch_can_use_parent_groups_without_parent_selected(self):
+        """Branch contexts can see parent groups and profiles without selecting parent."""
+        branch = self.env["res.company"].create(
+            {
+                "name": "Branch Company Groups",
+                "parent_id": self.company_data["company"].id,
+            }
+        )
+        parent_group = self.env["account.asset.group"].create(
+            {
+                "name": "Parent Asset Group",
+                "company_id": self.company_data["company"].id,
+            }
+        )
+        parent_profile = self.asset_profile_model.create(
+            {
+                "name": "Parent Branch-Aware Profile",
+                "company_id": self.company_data["company"].id,
+                "account_asset_id": self.company_data["default_account_assets"].id,
+                "account_depreciation_id": self.company_data[
+                    "default_account_assets"
+                ].id,
+                "account_expense_depreciation_id": self.company_data[
+                    "default_account_expense"
+                ].id,
+                "journal_id": self.company_data["default_journal_purchase"].id,
+                "group_ids": [Command.link(parent_group.id)],
+            }
+        )
+        branch_env = self.env(
+            context={**self.env.context, "allowed_company_ids": [branch.id]}
+        )
+        visible_groups = branch_env["account.asset.group"].search(
+            [("id", "=", parent_group.id)]
+        )
+        visible_profiles = branch_env["account.asset.profile"].search(
+            [("id", "=", parent_profile.id)]
+        )
+        self.assertEqual(visible_groups, parent_group)
+        self.assertEqual(visible_profiles, parent_profile)
+        branch_profile = self.asset_profile_model.with_company(branch).create(
+            {
+                "name": "Branch profile with parent group",
+                "company_id": branch.id,
+                "account_asset_id": self.company_data["default_account_assets"].id,
+                "account_depreciation_id": self.company_data[
+                    "default_account_assets"
+                ].id,
+                "account_expense_depreciation_id": self.company_data[
+                    "default_account_expense"
+                ].id,
+                "journal_id": self.company_data["default_journal_purchase"].id,
+                "group_ids": [Command.link(parent_group.id)],
+            }
+        )
+        self.assertEqual(branch_profile.group_ids, parent_group)

--- a/account_asset_management/views/account_move.xml
+++ b/account_asset_management/views/account_move.xml
@@ -28,6 +28,7 @@
             >
                 <field
                     name="asset_profile_id"
+                    domain="[('company_id', 'parent_of', parent.company_id)]"
                     column_invisible="parent.move_type not in ('in_invoice', 'in_refund')"
                     optional="show"
                     groups="account.group_account_invoice"
@@ -45,6 +46,7 @@
             >
                 <field
                     name="asset_profile_id"
+                    domain="[('company_id', 'parent_of', parent.company_id)]"
                     invisible="parent.move_type not in ('in_invoice', 'in_refund')"
                 />
                 <field
@@ -59,7 +61,7 @@
             >
                 <field
                     name="asset_profile_id"
-                    domain="[('company_id','=', parent.company_id)]"
+                    domain="[('company_id', 'parent_of', parent.company_id)]"
                     optional="hide"
                     groups="account.group_account_invoice"
                 />

--- a/account_asset_management/views/account_move_line.xml
+++ b/account_asset_management/views/account_move_line.xml
@@ -8,7 +8,7 @@
             <field name="statement_line_id" position="after">
                 <field
                     name="asset_profile_id"
-                    domain="[('company_id','=', parent.company_id)]"
+                    domain="[('company_id', 'parent_of', parent.company_id)]"
                 />
                 <field name="asset_id" />
             </field>

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -1,5 +1,6 @@
 # Copyright 2009-2018 Noviat
 # Copyright 2021 Tecnativa - João Marques
+# Copyright 2026 Imaro Tech - Ignacio R. Díaz
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
@@ -41,25 +42,25 @@ class AccountAssetRemove(models.TransientModel):
     account_sale_id = fields.Many2one(
         comodel_name="account.account",
         string="Asset Sale Account",
-        domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",
+        domain="[('deprecated', '=', False), ('company_id', 'parent_of', company_id)]",
         default=lambda self: self._default_account_sale_id(),
     )
     account_plus_value_id = fields.Many2one(
         comodel_name="account.account",
         string="Plus-Value Account",
-        domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",
+        domain="[('deprecated', '=', False), ('company_id', 'parent_of', company_id)]",
         default=lambda self: self._default_account_plus_value_id(),
     )
     account_min_value_id = fields.Many2one(
         comodel_name="account.account",
         string="Min-Value Account",
-        domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",
+        domain="[('deprecated', '=', False), ('company_id', 'parent_of', company_id)]",
         default=lambda self: self._default_account_min_value_id(),
     )
     account_residual_value_id = fields.Many2one(
         comodel_name="account.account",
         string="Residual Value Account",
-        domain="[('deprecated', '=', False), ('company_id', '=', company_id)]",
+        domain="[('deprecated', '=', False), ('company_id', 'parent_of', company_id)]",
         default=lambda self: self._default_account_residual_value_id(),
     )
     posting_regime = fields.Selection(
@@ -202,8 +203,9 @@ class AccountAssetRemove(models.TransientModel):
             "ref": line_name,
             "journal_id": journal_id,
             "narration": self.note,
+            "company_id": asset.company_id.id,
         }
-        move = self.env["account.move"].create(move_vals)
+        move = self.env["account.move"].with_company(asset.company_id).create(move_vals)
 
         # create asset line
         asset_line_vals = {
@@ -219,7 +221,9 @@ class AccountAssetRemove(models.TransientModel):
 
         # create move lines
         move_lines = self._get_removal_data(asset, residual_value)
-        move.with_context(allow_asset=True).write({"line_ids": move_lines})
+        move.with_company(asset.company_id).with_context(allow_asset=True).write(
+            {"line_ids": move_lines}
+        )
 
         return {
             "name": _("Asset '%s' Removal Journal Entry") % asset_ref,


### PR DESCRIPTION
Since Odoo 17, branch companies can share accounting master data defined on their parent company.

This PR aligns `account_asset_management` with that behavior by allowing branch companies to use parent-company asset profiles and asset groups.

As a result, multi-branch environments can centralize asset configuration without duplicating masters across companies.

At the same time, generated journal entries remain company-consistent: `account.move` and `account.move.line` records are created in the operating branch company, including depreciation posting and asset disposal flows.

The related multi-company security rules are updated accordingly, and a migration step reloads affected `noupdate` rules on already installed databases.

Tests have been added for the following cases:

* asset creation from vendor bill
* depreciation posting
* remove asset using parent-company masters.

