### PR TITLE
[19.0][FIX] account_asset_management: Generate journal items when the residual value is zero and the asset is sold

### DIFF
--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -8,6 +8,7 @@ import time
 from datetime import date, datetime
 
 from odoo import Command, fields
+from odoo.exceptions import UserError
 from odoo.tests import Form, tagged
 from odoo.tools import mute_logger
 
@@ -954,6 +955,84 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         last_line.create_move()
         self.assertEqual(asset.value_residual, 0)
         self.assertEqual(asset.state, "close")
+
+    def test_20_asset_removal_without_value_residual(self):
+        """Asset removal without residual value,
+        the gain must be equal to the sale value because the asset is fully depreciated.
+        """
+        self.car5y.account_plus_value_id = self.company_data["default_account_revenue"]
+        self.car5y.account_min_value_id = self.company_data["default_account_expense"]
+        asset = self.asset_model.create(
+            {
+                "name": "test asset removal",
+                "profile_id": self.car5y.id,
+                "purchase_value": 1000,
+                "salvage_value": 0,
+                "date_start": "2019-01-01",
+                "method_time": "number",
+                "method_number": 10,
+                "method_period": "month",
+                "prorata": False,
+            }
+        )
+        asset.compute_depreciation_board()
+        asset.validate()
+        lines = asset.depreciation_line_ids.filtered(lambda x: not x.init_entry)
+        self.assertEqual(len(lines), 10)
+        for asset_line in lines:
+            asset_line.create_move()
+        self.assertEqual(asset.value_residual, 0)
+        self.assertEqual(asset.state, "close")
+        sale_invoice = self.init_invoice("out_invoice", amounts=[500], post=False)
+        sale_invoice_form = Form(sale_invoice)
+        with sale_invoice_form.invoice_line_ids.edit(0) as line_form:
+            line_form.asset_id = asset
+        sale_invoice_form.save()
+        self.assertEqual(
+            sale_invoice.invoice_line_ids[0].account_id, self.car5y.account_asset_id
+        )
+        action = asset.remove()
+        self.assertNotIn("early_removal", action["context"])
+        wizard_form = Form(
+            self.remove_model.with_context(
+                **action["context"],
+            )
+        )
+        wizard_form.posting_regime = "gain_loss_on_sale"
+        remove_wizard = wizard_form.save()
+        # check the values from the invoice
+        self.assertEqual(remove_wizard.sale_value, 500)
+        self.assertEqual(remove_wizard.account_sale_id, self.car5y.account_asset_id)
+        remove_wizard.date_remove = "2019-01-31"
+        with self.assertRaisesRegex(
+            UserError, "The removal date must be after the last depreciation date"
+        ):
+            remove_wizard.remove()
+        remove_wizard.date_remove = "2020-01-31"
+        remove_wizard.remove()
+        line_remove = asset.depreciation_line_ids.filtered(lambda x: x.type == "remove")
+        self.assertEqual(len(line_remove), 1)
+        self.assertEqual(line_remove.amount, 0)
+        account_move_remove = line_remove.move_id
+        self.assertEqual(len(account_move_remove.line_ids), 4)
+        aml_sale = account_move_remove.line_ids.filtered(
+            lambda x: x.account_id == remove_wizard.account_sale_id and x.debit == 500
+        )
+        self.assertEqual(len(aml_sale), 1)
+        aml_depre = account_move_remove.line_ids.filtered(
+            lambda x: x.account_id == self.car5y.account_depreciation_id
+            and x.debit == 1000
+        )
+        self.assertEqual(len(aml_depre), 1)
+        aml_asset = account_move_remove.line_ids.filtered(
+            lambda x: x.account_id == self.car5y.account_asset_id and x.credit == 1000
+        )
+        self.assertEqual(len(aml_asset), 1)
+        aml_gain = account_move_remove.line_ids.filtered(
+            lambda x: x.account_id == remove_wizard.account_plus_value_id
+        )
+        self.assertEqual(len(aml_gain), 1)
+        self.assertEqual(aml_gain.credit, 500)
 
     def test_21_asset_profile_salvage_value(self):
         """Compute salvage value from asset profile."""

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -330,46 +330,45 @@ class AccountAssetRemove(models.TransientModel):
         }
         move_lines.append((0, 0, move_line_vals))
 
-        if residual_value:
-            if self.posting_regime == "residual_value":
+        if self.posting_regime == "residual_value" and residual_value:
+            move_line_vals = {
+                "name": asset.name,
+                "account_id": self.account_residual_value_id.id,
+                "analytic_distribution": asset.analytic_distribution,
+                "debit": residual_value,
+                "credit": 0.0,
+                "partner_id": partner_id,
+                "asset_id": asset.id,
+            }
+            move_lines.append((0, 0, move_line_vals))
+        elif self.posting_regime == "gain_loss_on_sale":
+            if self.sale_value:
+                sale_value = self.sale_value
                 move_line_vals = {
                     "name": asset.name,
-                    "account_id": self.account_residual_value_id.id,
+                    "account_id": self.account_sale_id.id,
                     "analytic_distribution": asset.analytic_distribution,
-                    "debit": residual_value,
+                    "debit": sale_value,
                     "credit": 0.0,
                     "partner_id": partner_id,
                     "asset_id": asset.id,
                 }
                 move_lines.append((0, 0, move_line_vals))
-            elif self.posting_regime == "gain_loss_on_sale":
-                if self.sale_value:
-                    sale_value = self.sale_value
-                    move_line_vals = {
-                        "name": asset.name,
-                        "account_id": self.account_sale_id.id,
-                        "analytic_distribution": asset.analytic_distribution,
-                        "debit": sale_value,
-                        "credit": 0.0,
-                        "partner_id": partner_id,
-                        "asset_id": asset.id,
-                    }
-                    move_lines.append((0, 0, move_line_vals))
-                balance = self.sale_value - residual_value
-                balance_comp = currency.compare_amounts(balance, 0)
-                account_id = (
-                    self.account_plus_value_id.id
-                    if balance_comp > 0
-                    else self.account_min_value_id.id
-                )
-                move_line_vals = {
-                    "name": asset.name,
-                    "account_id": account_id,
-                    "debit": balance_comp < 0 and -balance or 0.0,
-                    "credit": balance_comp > 0 and balance or 0.0,
-                    "analytic_distribution": asset.analytic_distribution,
-                    "partner_id": partner_id,
-                    "asset_id": asset.id,
-                }
-                move_lines.append((0, 0, move_line_vals))
+            balance = self.sale_value - residual_value
+            balance_comp = currency.compare_amounts(balance, 0)
+            account_id = (
+                self.account_plus_value_id.id
+                if balance_comp > 0
+                else self.account_min_value_id.id
+            )
+            move_line_vals = {
+                "name": asset.name,
+                "account_id": account_id,
+                "debit": balance_comp < 0 and -balance or 0.0,
+                "credit": balance_comp > 0 and balance or 0.0,
+                "analytic_distribution": asset.analytic_distribution,
+                "partner_id": partner_id,
+                "asset_id": asset.id,
+            }
+            move_lines.append((0, 0, move_line_vals))
         return move_lines

--- a/account_asset_management/wizard/account_asset_remove.py
+++ b/account_asset_management/wizard/account_asset_remove.py
@@ -5,7 +5,7 @@
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, fields, models
+from odoo import Command, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
 
@@ -317,7 +317,7 @@ class AccountAssetRemove(models.TransientModel):
                 "partner_id": partner_id,
                 "asset_id": asset.id,
             }
-            move_lines.append((0, 0, move_line_vals))
+            move_lines.append(Command.create(move_line_vals))
 
         depreciation_base_comp = currency.compare_amounts(asset.depreciation_base, 0)
         move_line_vals = {
@@ -328,7 +328,7 @@ class AccountAssetRemove(models.TransientModel):
             "partner_id": partner_id,
             "asset_id": asset.id,
         }
-        move_lines.append((0, 0, move_line_vals))
+        move_lines.append(Command.create(move_line_vals))
 
         if self.posting_regime == "residual_value" and residual_value:
             move_line_vals = {
@@ -340,7 +340,7 @@ class AccountAssetRemove(models.TransientModel):
                 "partner_id": partner_id,
                 "asset_id": asset.id,
             }
-            move_lines.append((0, 0, move_line_vals))
+            move_lines.append(Command.create(move_line_vals))
         elif self.posting_regime == "gain_loss_on_sale":
             if self.sale_value:
                 sale_value = self.sale_value
@@ -353,7 +353,7 @@ class AccountAssetRemove(models.TransientModel):
                     "partner_id": partner_id,
                     "asset_id": asset.id,
                 }
-                move_lines.append((0, 0, move_line_vals))
+                move_lines.append(Command.create(move_line_vals))
             balance = self.sale_value - residual_value
             balance_comp = currency.compare_amounts(balance, 0)
             account_id = (
@@ -370,5 +370,5 @@ class AccountAssetRemove(models.TransientModel):
                 "partner_id": partner_id,
                 "asset_id": asset.id,
             }
-            move_lines.append((0, 0, move_line_vals))
+            move_lines.append(Command.create(move_line_vals))
         return move_lines


### PR DESCRIPTION
If depreciation is finished (the residual value is zero) and the asset is sold, the entire amount is a gain for the company. However, in this case, the journal items are not created. After this commit, the journal items are created using `account_sale_id` vs `account_plus_value_id`

TT62013
@Tecnativa @pedrobaeza @carlosdauden @sergio-teruel @florian-dacosta could you please review this?

FWP of https://github.com/OCA/account-financial-tools/pull/2289