### PR TITLE
[18.0][IMP] account_asset_management: Improve visibility of the compute_depreciation_board button by displaying it only in draft state

### DIFF
--- a/account_asset_management/views/account_asset.xml
+++ b/account_asset_management/views/account_asset.xml
@@ -183,7 +183,7 @@
                                     name="compute_depreciation_board"
                                     string="Compute"
                                     icon="fa-gears"
-                                    invisible="state in ['close', 'removed']"
+                                    invisible="state != 'draft'"
                                 />
                             </div>
                             <field


### PR DESCRIPTION
Currently, this button is also displayed when the asset is in the open state, but all related fields are read-only. This can be confusing for users because the button appears to allow changes, while no modifications can actually be made.

If users need to modify the asset, they can set it back to draft, make the required changes, and then confirm it again.

TT59878
@Tecnativa @pedrobaeza could you please review this?