### PR TITLE
[IMP] account_lock_date_update: fix outdated group name in README

### DIFF
--- a/account_lock_date_update/README.rst
+++ b/account_lock_date_update/README.rst
@@ -28,7 +28,8 @@ Account Lock Date Update
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-Allow an Account adviser to update accounting lock dates.
+Allow an Accounting/Invoicing Administrator to update the accounting lock dates
+via a wizard dialog, without requiring System Administrator access.
 
 **Table of contents**
 
@@ -38,10 +39,11 @@ Allow an Account adviser to update accounting lock dates.
 Usage
 =====
 
-To use this module, you need to be a Billing Administrator and go to:
+To use this module, you need the **Accounting/Invoicing Administrator** role
+(``account.group_account_manager``) and go to:
 
 - Invoicing -> Accounting -> Lock Dates
-- Change values and click on **Update** button
+- Change values and click on the **Update** button
 
 Bug Tracker
 ===========

--- a/account_lock_date_update/readme/DESCRIPTION.md
+++ b/account_lock_date_update/readme/DESCRIPTION.md
@@ -1,1 +1,2 @@
-Allow an Account adviser to update accounting lock dates.
+Allow an Accounting/Invoicing Administrator to update the accounting lock dates
+via a wizard dialog, without requiring System Administrator access.

--- a/account_lock_date_update/readme/USAGE.md
+++ b/account_lock_date_update/readme/USAGE.md
@@ -1,4 +1,5 @@
-To use this module, you need to be a Billing Administrator and go to:
+To use this module, you need the **Accounting/Invoicing Administrator** role
+(`account.group_account_manager`) and go to:
 
-- Invoicing -\> Accounting -\> Lock Dates
-- Change values and click on **Update** button
+- Invoicing \-> Accounting \-> Lock Dates
+- Change values and click on the **Update** button


### PR DESCRIPTION
## Summary

The README (DESCRIPTION and USAGE) referenced the obsolete group labels:
- \Account adviser\ (pre-v13 name)
- \Billing Administrator\ (v13–v16 name)

In Odoo 17+/18, the group \account.group_account_manager\ is labelled **Administrator** under the *Invoicing* (Community) or *Accounting* (Enterprise) category.

### Changes
- **DESCRIPTION.md / README.rst**: Replace 'Account adviser' with 'Accounting/Invoicing Administrator'; add clarification that the module provides a wizard dialog without requiring System Administrator access.
- **USAGE.md / README.rst**: Replace 'Billing Administrator' with 'Accounting/Invoicing Administrator (\account.group_account_manager\)';
> Note: \README.rst\ was updated manually to match the fragments (no \oca-gen-addon-readme\ installed locally). CI pre-commit will re-verify the generated output.