### PR TITLE
[IMP] account_lock_to_date: fix outdated group name in README

### DIFF
--- a/account_lock_to_date/README.rst
+++ b/account_lock_to_date/README.rst
@@ -47,12 +47,13 @@ Usage
 To set a new lock to dates, go to *Invoicing / Accounting / Actions /
 Update accounting lock to dates*.
 
-A user without an Adviser group will not be able to post or update
-posted journal entries on the date "Lock To Date for Non-Advisers" or
+A user without the **Accounting/Invoicing Administrator** role
+(``account.group_account_manager``) will not be able to post or update
+posted journal entries on the date "Lock To Date for Non-Accounting Administrators" or
 after.
 
-A user that has an Adviser group will not be able to post or update
-posted journal entries on the date "Lock To Date" or after.
+A user that has the Accounting/Invoicing Administrator role will not be able to post or
+update posted journal entries on the date "Lock To Date" or after.
 
 Bug Tracker
 ===========

--- a/account_lock_to_date/readme/USAGE.md
+++ b/account_lock_to_date/readme/USAGE.md
@@ -1,9 +1,10 @@
 To set a new lock to dates, go to *Invoicing / Accounting / Actions /
 Update accounting lock to dates*.
 
-A user without an Adviser group will not be able to post or update
-posted journal entries on the date "Lock To Date for Non-Advisers" or
+A user without the **Accounting/Invoicing Administrator** role
+(`account.group_account_manager`) will not be able to post or update
+posted journal entries on the date "Lock To Date for Non-Accounting Administrators" or
 after.
 
-A user that has an Adviser group will not be able to post or update
-posted journal entries on the date "Lock To Date" or after.
+A user that has the Accounting/Invoicing Administrator role will not be able to post or
+update posted journal entries on the date "Lock To Date" or after.


### PR DESCRIPTION
## Summary

The USAGE README referenced the obsolete 'Adviser group' terminology.

In Odoo 17+/18, the group \account.group_account_manager\ is labelled **Administrator** under the *Invoicing* (Community) or *Accounting* (Enterprise) category.

### Changes
- **USAGE.md / README.rst**: Replace 'Adviser group'/'Non-Advisers' with 'Accounting/Invoicing Administrator (\account.group_account_manager\)' and 'Non-Accounting Administrators'.

> Note: \README.rst\ was updated manually to match the fragments. CI pre-commit will re-verify the generated output.