### PR TITLE
[19.0][FIX] account_journal_general_sequence,account_move_name_sequence: Dropped Date support in method _next (ir.sequence).

### DIFF
--- a/account_journal_general_sequence/models/account_move.py
+++ b/account_journal_general_sequence/models/account_move.py
@@ -64,7 +64,7 @@ class AccountMove(models.Model):
             lambda one: (one.date or "", one.name or "", one.id or 0)
         ):
             chosen_map[move.id] = move.journal_id.entry_number_sequence_id._next(
-                move.date
+                fields.Datetime.to_datetime(move.date)
             )
         # Write all the new numbers in the chosen moves
         for move_id, new_number in chosen_map.items():

--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -86,9 +86,11 @@ class AccountMove(models.Model):
                 else:
                     seq = move.journal_id.sequence_id
                 # next_by_id(date) only applies on ir.sequence.date_range selection
-                # => we use with_context(ir_sequence_date=date).next_by_id()
+                # => we use with_context(ir_sequence_date=datetime).next_by_id()
                 # which applies on ir.sequence.date_range selection AND prefix
-                name = seq.with_context(ir_sequence_date=move.date).next_by_id()
+                name = seq.with_context(
+                    ir_sequence_date=fields.Datetime.to_datetime(move.date)
+                ).next_by_id()
             move.name = name
         # Force compute of sequence_prefix and sequence_number
         self._compute_split_sequence()


### PR DESCRIPTION
Since [odoo/odoo commit 4b9dd78](https://github.com/odoo/odoo/commit/4b9dd7893f968ead2e54169833993e2813d56736), argument `sequence_date` of method `_next` (model `ir.sequence`) is assumed to be a `Datetime` object, effectively dropping the support of it being a `Date` object.

These OCA modules still calls said method with a `Date` object as argument.