### PR TITLE
[17.0][FIX] account_asset_management: Display the appropriate error message if an error occurs

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -1200,7 +1200,7 @@ class AccountAsset(models.Model):
                 with self.env.cr.savepoint():
                     result += depreciation.create_move()
             except Exception:
-                e = exc_info()[0]
+                e = exc_info()[1]
                 tb = "".join(format_exception(*exc_info()))
                 asset_ref = depreciation.asset_id.name
                 if depreciation.asset_id.code:


### PR DESCRIPTION
Backport from 18.0: https://github.com/OCA/account-financial-tools/pull/2330

Display the appropriate error message if an error occurs

**Before**
<img width="1004" height="147" alt="antes" src="https://github.com/user-attachments/assets/8db91580-c9c5-48e3-8b30-6d4546738d7e" />

**After**
<img width="866" height="206" alt="despues" src="https://github.com/user-attachments/assets/2dd6df8c-176c-4c89-ab2d-0c56f43d23b5" />


@Tecnativa TT63129