### PR TITLE
[18.0][FIX] account_usability: restrict journal items partner binding to accounting users

### DIFF
--- a/account_usability/views/view_account_move_line.xml
+++ b/account_usability/views/view_account_move_line.xml
@@ -7,5 +7,9 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 <odoo>
     <record id="account.action_account_moves_all_tree" model="ir.actions.act_window">
         <field name="binding_model_id" ref="base.model_res_partner" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('account.group_account_readonly'))]"
+        />
     </record>
 </odoo>


### PR DESCRIPTION
A user without accounting permissions but with a Sales role (sales_team.group_sale_salesman, while sale is installed) can open a contact's Journal Items from the res.partner form, when this should only be possible with accounting access (account.group_account_readonly).
<img width="1655" height="830" alt="image" src="https://github.com/user-attachments/assets/db74c90b-9dc6-48c1-8f68-79c7ab4331aa" />

<img width="1511" height="973" alt="image" src="https://github.com/user-attachments/assets/0b4e5dd2-e358-4663-aac6-987a7fdef067" />
