### PR TITLE
[19.0][FIX] account_chart_update: Fix error with computed Boolean fields

### DIFF
--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -754,15 +754,14 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             if not orm_field or orm_field.readonly:
                 continue
             if field.ttype == "boolean":
-                # Computed booleans (e.g. repartition lines'
-                # `use_in_tax_closing`, derived from account_id/
-                # repartition_type) would otherwise false-positive against
-                # the static default — trust the compute instead.
+                # If the Boolean field is computed, create a new pseudo-record
+                # and compute its value
                 if getattr(orm_field, "compute", None):
-                    continue
-                # When the template is silent on a boolean, the expected
-                # value is the field's default — not a blanket False.
-                expected = real.default_get([key]).get(key, False)
+                    expected_record = real.new(real.read()[0])
+                    getattr(expected_record, orm_field.compute)()
+                    expected = expected_record[key]
+                else:
+                    expected = real.default_get([key]).get(key, False)
                 if bool(real[key]) != bool(expected):
                     result[key] = expected
             elif real[key]:


### PR DESCRIPTION
The new logic does not ignore computed booleans.
When a missing boolean is computed, the wizard derives the expected value from the field compute logic instead of using `default_get`. For regular booleans, it keeps the existing behavior and compares against the field default.

Previously, the wizard skipped all computed booleans in the synthetic diff pass. That avoided false positives for fields such as `account.tax.repartition.line.use_in_tax_closing`, but it also hid valid differences for editable computed booleans, for example `account.fiscal.position.vat_required` when extended by `intrastat_base`.

@pedrobaeza @victoralmau ping
@Tecnativa 