### PR TITLE
[FIX] account_lock_to_date: fix reversed comparison in fiscalyear lock to date check

### DIFF
--- a/account_lock_to_date/models/res_company.py
+++ b/account_lock_to_date/models/res_company.py
@@ -68,7 +68,7 @@ class ResCompany(models.Model):
             if (
                 old_fiscalyear_lock_to_date
                 and fiscalyear_lock_to_date
-                and fiscalyear_lock_to_date > old_fiscalyear_lock_to_date
+                and fiscalyear_lock_to_date < old_fiscalyear_lock_to_date
             ):
                 raise ValidationError(
                     _(

--- a/account_lock_to_date/tests/test_account_lock_to_date_update.py
+++ b/account_lock_to_date/tests/test_account_lock_to_date_update.py
@@ -111,6 +111,30 @@ class TestAccountLockToDateUpdate(TransactionCase):
             datetime.strptime("2900-02-01", DEFAULT_SERVER_DATE_FORMAT).date(),
         )
 
+    def test_02b_update_to_later_date_succeeds(self):
+        """We test that updating the fiscalyear_lock_to_date to a LATER
+        date than the current one succeeds (this was the bug: the old
+        code incorrectly rejected later dates instead of earlier ones)."""
+        self.company.fiscalyear_lock_to_date = "2900-01-01"
+        wizard = self.create_account_lock_date_update()
+        wizard.write({"fiscalyear_lock_to_date": "2900-02-01"})
+        self.demo_user.write({"groups_id": [(4, self.adviser_group.id)]})
+        wizard.with_user(self.demo_user.id).execute()
+        self.assertEqual(
+            self.company.fiscalyear_lock_to_date,
+            datetime.strptime("2900-02-01", DEFAULT_SERVER_DATE_FORMAT).date(),
+        )
+
+    def test_02c_update_to_earlier_date_fails(self):
+        """We test that updating the fiscalyear_lock_to_date to an
+        EARLIER date than the current one is rejected."""
+        self.company.fiscalyear_lock_to_date = "2900-02-01"
+        wizard = self.create_account_lock_date_update()
+        wizard.write({"fiscalyear_lock_to_date": "2900-01-01"})
+        self.demo_user.write({"groups_id": [(4, self.adviser_group.id)]})
+        with self.assertRaises(ValidationError):
+            wizard.with_user(self.demo_user.id).execute()
+
     def test_03_create_move_outside_period(self):
         """We test that we cannot create journal entries after the
         locked date"""


### PR DESCRIPTION
## Description

Fixes #2334

The `_check_lock_to_dates` method in `res_company.py` had a reversed
comparison when validating the new `fiscalyear_lock_to_date` against
the previous one.

The error message states that the new lock to date for advisors must
be set **after** the previous lock to date, but the code was actually
raising a `ValidationError` when the new date was **later** than the
old one, and silently allowing the new date to be **earlier** than
(or equal to) the old one — the exact opposite of the intended and
documented behavior.

### Before
```python
if (
    old_fiscalyear_lock_to_date
    and fiscalyear_lock_to_date
    and fiscalyear_lock_to_date > old_fiscalyear_lock_to_date
):
    raise ValidationError(...)
```

### After
```python
if (
    old_fiscalyear_lock_to_date
    and fiscalyear_lock_to_date
    and fiscalyear_lock_to_date < old_fiscalyear_lock_to_date
):
    raise ValidationError(...)
```

## Tests

Added two new test cases in `test_account_lock_to_date_update.py`:

- `test_02b_update_to_later_date_succeeds`: confirms that moving the
  fiscalyear lock to date forward is now allowed.
- `test_02c_update_to_earlier_date_fails`: confirms that moving the
  fiscalyear lock to date backward is correctly rejected.

All 7 existing tests plus the 2 new ones pass (0 failed, 0 errors).