### PR TITLE
[17.0][FIX] account_loan: take care of residual_amount while checking consistency

### DIFF
--- a/account_loan/tests/test_loan.py
+++ b/account_loan/tests/test_loan.py
@@ -706,6 +706,14 @@ class TestLoan(BaseCommon):
         loan.button_draft()
         self.assertEqual(loan.state, "draft")
 
+    @mute_logger("odoo.models.unlink")
+    def test_post_with_residual_amount(self):
+        loan = self.create_loan("fixed-annuity", 30000, 1, 36)
+        loan.residual_amount = 600
+        loan.compute_lines()
+        self.post(loan)
+        self.assertEqual(loan.state, "posted")
+
     def post(self, loan):
         self.assertFalse(loan.move_ids)
         post = (

--- a/account_loan/wizards/account_loan_post.py
+++ b/account_loan/wizards/account_loan_post.py
@@ -89,7 +89,10 @@ class AccountLoanPost(models.TransientModel):
     def run(self):
         self.ensure_one()
         if self.loan_id.line_ids:
-            total_principal = sum(self.loan_id.line_ids.mapped("principal_amount"))
+            total_principal = (
+                sum(self.loan_id.line_ids.mapped("principal_amount"))
+                + self.loan_id.residual_amount
+            )
             if (
                 float_compare(
                     self.loan_id.loan_amount, total_principal, precision_digits=2


### PR DESCRIPTION
## Description

Fixes #2234

Backport of upstream 19.0 fix (commit 6bab7dd) to the 17.0 branch.

The `account.loan.post` wizard's consistency check compared the loan's
`loan_amount` against the sum of `principal_amount` across all lines,
but didn't account for `residual_amount` (used for leasing loans).
This caused a false "total principal amount does not match" error
whenever a leasing loan had a non-zero residual amount, making it
impossible to post such loans.

### Fix
```python
total_principal = (
    sum(self.loan_id.line_ids.mapped("principal_amount"))
    + self.loan_id.residual_amount
)
```

## Tests

Added `test_post_with_residual_amount` to `test_loan.py`, confirming
a leasing-style loan with a residual amount can be posted successfully.

All 18 existing tests plus the new one pass (0 failed, 0 errors).