### PR TITLE
[18.0][IMP] account_move_name_sequence: add sequence_id on payment.method.line

### DIFF
--- a/account_move_name_sequence/models/__init__.py
+++ b/account_move_name_sequence/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_journal
 from . import account_move
 from . import ir_sequence
+from . import account_payment_method_line

--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -24,6 +24,22 @@ class AccountMove(models.Model):
         ),
     ]
 
+    def _get_sequence_for_move(self):
+        self.ensure_one()
+        if (
+            self.move_type in ("out_refund", "in_refund")
+            and self.journal_id.type in ("sale", "purchase")
+            and self.journal_id.refund_sequence
+            and self.journal_id.refund_sequence_id
+        ):
+            return self.journal_id.refund_sequence_id
+        if (
+            self.origin_payment_id
+            and self.origin_payment_id.payment_method_line_id.sequence_id
+        ):
+            return self.origin_payment_id.payment_method_line_id.sequence_id
+        return self.journal_id.sequence_id
+
     @api.depends("name")
     def _compute_split_sequence(self):
         """
@@ -40,20 +56,12 @@ class AccountMove(models.Model):
             and move.move_type
             and move.restrict_mode_hash_table
         )
-        # Handle moves grouped by journal / move_type and year
-        for (journal, move_type, year), grouped_moves in moves.grouped(
-            lambda m: (m.journal_id, m.move_type, m.date.year)
+        # Handle moves grouped by sequence and year
+        for (sequence, year), grouped_moves in moves.grouped(
+            lambda m: (m._get_sequence_for_move(), m.date.year)
         ).items():
-            # Get the correct sequence in case there is a specific
-            # one for refund configured on journal
-            if (
-                move_type in ["in_refund", "out_refund"]
-                and journal.refund_sequence
-                and journal.refund_sequence_id
-            ):
-                sequence = journal.refund_sequence_id
-            else:
-                sequence = journal.sequence_id
+            if not sequence:
+                continue
             # Retrieve prefix and suffix to extract number
             prefix, suffix = sequence._get_prefix_suffix(
                 date=f"{year}-01-01", date_range=f"{year}-01-01"
@@ -66,7 +74,12 @@ class AccountMove(models.Model):
                     move.name[len(prefix) : len(move.name) - len(suffix)]
                 )
 
-    @api.depends("state", "journal_id", "date")
+    @api.depends(
+        "state",
+        "journal_id",
+        "date",
+        "origin_payment_id.payment_method_line_id.sequence_id",
+    )
     def _compute_name_by_sequence(self):
         for move in self:
             name = move.name or "/"
@@ -77,21 +90,13 @@ class AccountMove(models.Model):
                 move.state == "posted"
                 and (not move.name or move.name == "/")
                 and move.journal_id
-                and move.journal_id.sequence_id
             ):
-                if (
-                    move.move_type in ("out_refund", "in_refund")
-                    and move.journal_id.type in ("sale", "purchase")
-                    and move.journal_id.refund_sequence
-                    and move.journal_id.refund_sequence_id
-                ):
-                    seq = move.journal_id.refund_sequence_id
-                else:
-                    seq = move.journal_id.sequence_id
-                # next_by_id(date) only applies on ir.sequence.date_range selection
-                # => we use with_context(ir_sequence_date=date).next_by_id()
-                # which applies on ir.sequence.date_range selection AND prefix
-                name = seq.with_context(ir_sequence_date=move.date).next_by_id()
+                seq = move._get_sequence_for_move()
+                if seq:
+                    # next_by_id(date) only applies on ir.sequence.date_range selection
+                    # => we use with_context(ir_sequence_date=date).next_by_id()
+                    # which applies on ir.sequence.date_range selection AND prefix
+                    name = seq.with_context(ir_sequence_date=move.date).next_by_id()
             move.name = name
         # Force compute of sequence_prefix and sequence_number
         self._compute_split_sequence()
@@ -104,7 +109,8 @@ class AccountMove(models.Model):
 
     def _is_end_of_seq_chain(self):
         invoices_no_gap_sequences = self.filtered(
-            lambda inv: inv.journal_id.sequence_id.implementation == "no_gap"
+            lambda inv: inv._get_sequence_for_move()
+            and inv._get_sequence_for_move().implementation == "no_gap"
         )
         invoices_other_sequences = self - invoices_no_gap_sequences
         if not invoices_other_sequences and invoices_no_gap_sequences:

--- a/account_move_name_sequence/models/account_payment_method_line.py
+++ b/account_move_name_sequence/models/account_payment_method_line.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Ecosoft (http://ecosoft.co.th/)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountPaymentMethodLine(models.Model):
+    _inherit = "account.payment.method.line"
+
+    sequence_id = fields.Many2one(
+        comodel_name="ir.sequence",
+        string="Entry Sequence",
+        copy=False,
+        check_company=True,
+        help="This sequence will be used to generate the journal entry number.",
+    )

--- a/account_move_name_sequence/tests/test_account_move_name_seq.py
+++ b/account_move_name_sequence/tests/test_account_move_name_seq.py
@@ -94,6 +94,40 @@ class TestAccountMoveNameSequence(TransactionCase):
             )
         ]
 
+        # Setup PML sequences for inbound/outbound payment tests
+        # using the demo cash journal
+        cls.cash_journal = cls.env.ref(
+            "account_move_name_sequence.journal_cash_std_demo"
+        )
+        cls.inbound_pml = cls.env["account.payment.method.line"].search(
+            [
+                ("journal_id", "=", cls.cash_journal.id),
+                ("payment_type", "=", "inbound"),
+            ],
+            limit=1,
+        )
+        cls.outbound_pml = cls.env["account.payment.method.line"].search(
+            [
+                ("journal_id", "=", cls.cash_journal.id),
+                ("payment_type", "=", "outbound"),
+            ],
+            limit=1,
+        )
+        seq_vals = {
+            "implementation": "no_gap",
+            "use_date_range": True,
+            "padding": 4,
+            "company_id": cls.company.id,
+        }
+        cls.inbound_pml_seq = cls.env["ir.sequence"].create(
+            {"name": "Inbound PML Seq", "prefix": "IN/%(range_year)s/", **seq_vals}
+        )
+        cls.outbound_pml_seq = cls.env["ir.sequence"].create(
+            {"name": "Outbound PML Seq", "prefix": "OUT/%(range_year)s/", **seq_vals}
+        )
+        cls.inbound_pml.write({"sequence_id": cls.inbound_pml_seq.id})
+        cls.outbound_pml.write({"sequence_id": cls.outbound_pml_seq.id})
+
     def test_seq_creation(self):
         self.assertTrue(self.misc_journal.sequence_id)
         seq = self.misc_journal.sequence_id
@@ -386,3 +420,35 @@ class TestAccountMoveNameSequence(TransactionCase):
         )
         with self.assertRaisesRegex(UserError, error_msg):
             invoice._unlink_forbid_parts_of_chain()
+
+    def test_inbound_payment_method_line_sequence(self):
+        with Form(
+            self.env["account.payment"].with_context(
+                default_payment_type="inbound",
+                default_partner_type="customer",
+                default_move_journal_types=("bank", "cash"),
+            )
+        ) as pay_form:
+            pay_form.partner_id = self.partner
+            pay_form.amount = 100.0
+            pay_form.journal_id = self.cash_journal
+        payment = pay_form.save()
+        payment.action_post()
+        year = fields.Date.today().year
+        self.assertEqual(payment.move_id.name, f"IN/{year}/0001")
+
+    def test_outbound_payment_method_line_sequence(self):
+        with Form(
+            self.env["account.payment"].with_context(
+                default_payment_type="outbound",
+                default_partner_type="customer",
+                default_move_journal_types=("bank", "cash"),
+            )
+        ) as pay_form:
+            pay_form.partner_id = self.partner
+            pay_form.amount = 50.0
+            pay_form.journal_id = self.cash_journal
+        payment = pay_form.save()
+        payment.action_post()
+        year = fields.Date.today().year
+        self.assertEqual(payment.move_id.name, f"OUT/{year}/0001")

--- a/account_move_name_sequence/views/account_journal_views.xml
+++ b/account_move_name_sequence/views/account_journal_views.xml
@@ -41,6 +41,12 @@
                     }"
                 />
             </field>
+            <xpath expr="//field[@name='inbound_payment_method_line_ids']/list/field[@name='payment_account_id']" position="after">
+                <field name="sequence_id" />
+            </xpath>
+            <xpath expr="//field[@name='outbound_payment_method_line_ids']/list/field[@name='payment_account_id']" position="after">
+                <field name="sequence_id" />
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
This PR add `sequence_id` on `account.payment.method.line` so customer/vendor
payments can use a per-method sequence instead of the journal default.


<img width="1637" height="574" alt="selection_459" src="https://github.com/user-attachments/assets/78cad8ed-9395-4a19-9edc-87afb7f736a4" />

For use same journal but seperate sequence

customer payment
<img width="1621" height="460" alt="selection_460" src="https://github.com/user-attachments/assets/3507c115-c203-419f-bf36-7aea8f88dcbf" />

vendor payment
<img width="1628" height="451" alt="selection_461" src="https://github.com/user-attachments/assets/300a527f-5914-436a-8311-9cee3742ce82" />
