### PR TITLE
[19.0][FIX] account_move_name_sequence: pay ref

### DIFF
--- a/account_move_name_sequence/models/account_move.py
+++ b/account_move_name_sequence/models/account_move.py
@@ -127,7 +127,9 @@ class AccountMove(models.Model):
 
     def _post(self, soft=True):
         self.flush_recordset()
-        return super()._post(soft=soft)
+        res = super()._post(soft=soft)
+        self._set_payment_reference_from_move_name_if_needed()
+        return res
 
     @api.depends()
     def _compute_name(self):
@@ -136,3 +138,14 @@ class AccountMove(models.Model):
         like when creating entry from email.
         """
         return self._compute_name_by_sequence()
+
+    def _set_payment_reference_from_move_name_if_needed(self):
+        for move in self:
+            if (
+                not move.payment_reference
+                and move.journal_id.sequence_id
+                and move.state == "posted"
+                and move.move_type == "out_invoice"
+                and move.name
+            ):
+                move.payment_reference = move.name

--- a/account_move_name_sequence/tests/test_account_move_name_seq.py
+++ b/account_move_name_sequence/tests/test_account_move_name_seq.py
@@ -368,6 +368,7 @@ class TestAccountMoveNameSequence(TransactionCase):
         self.assertEqual(invoice.name, "/", "name based on journal instead of sequence")
         invoice.action_post()
         self.assertIn("TB2CSEQ/", invoice.name, "name was not based on sequence")
+        self.assertEqual(invoice.payment_reference, invoice.name)
 
     def test_is_end_of_seq_chain(self):
         self.env.user.group_ids -= self.env.ref("account.group_account_manager")


### PR DESCRIPTION
When `account_move_name_sequence` is used, it stops generating payment_reference, which is important for invoices. Without it, odoo will not show bank account/payment info on invoice printout by default.

We force set it after move was posted as _compute_payment_reference can compute too early when move.name is still not set.