### PR TITLE
Revert "[18][account_asset_management] FIX first depreciation line amount with prorata temporis and month"

### DIFF
--- a/account_asset_management/models/account_asset.py
+++ b/account_asset_management/models/account_asset.py
@@ -788,43 +788,15 @@ class AccountAsset(models.Model):
         if self.prorata:
             if firstyear:
                 depreciation_date_start = self.date_start
-                if self.method_period == "month":
-                    # TODO manage quarter
-                    first_day_period = depreciation_date_start.replace(day=1)
-                    first_day_next_period = first_day_period + relativedelta(months=1)
-                    current_full_period_days = first_day_next_period - first_day_period
-                    current_partial_period_days = (
-                        first_day_next_period - depreciation_date_start
-                    )
-                    # compute a ratio of the first period of the asset
-                    # (example 14/07 would be 17/31=0.548)
-                    current_period_ratio = (
-                        current_partial_period_days / current_full_period_days
-                    )
-                    # get the number of period (month) until end of first fy
-                    # (not counting the first partial month)
-                    remaining_fy_duration = (
-                        (fy.date_to.year - first_day_next_period.year) * 12
-                        + (fy.date_to.month - first_day_next_period.month)
-                        + 1
-                    )
-                    first_fy_duration = self._get_fy_duration(fy, option="months")
-                    # ratio of first fiscal year using month
-                    duration_first_fy_ratio = (
-                        float(current_period_ratio + remaining_fy_duration)
-                        / first_fy_duration
-                    )
-                else:
-                    fy_date_stop = entry["date_stop"]
-                    first_fy_asset_days = (
-                        fy_date_stop - depreciation_date_start
-                    ).days + 1
-                    first_fy_duration = self._get_fy_duration(fy, option="days")
-                    duration_first_fy_ratio = (
-                        float(first_fy_asset_days) / first_fy_duration
-                    )
+                fy_date_stop = entry["date_stop"]
+                first_fy_asset_days = (fy_date_stop - depreciation_date_start).days + 1
+                first_fy_duration = self._get_fy_duration(fy, option="days")
                 first_fy_year_factor = self._get_fy_duration(fy, option="years")
-                duration_factor = duration_first_fy_ratio * first_fy_year_factor
+                duration_factor = (
+                    float(first_fy_asset_days)
+                    / first_fy_duration
+                    * first_fy_year_factor
+                )
             else:
                 duration_factor = self._get_fy_duration(fy, option="years")
         else:

--- a/account_asset_management/tests/test_account_asset_management.py
+++ b/account_asset_management/tests/test_account_asset_management.py
@@ -3,8 +3,9 @@
 # Copyright 2021 Tecnativa - João Marques
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import calendar
 import time
-from datetime import datetime
+from datetime import date, datetime
 
 from odoo import Command, fields
 from odoo.exceptions import UserError
@@ -304,13 +305,27 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         )
         asset.compute_depreciation_board()
         asset.invalidate_recordset()
-        self.assertAlmostEqual(asset.depreciation_line_ids[1].amount, 44.8, places=2)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[1].amount, 46.44, places=2
+            )
+        else:
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[1].amount, 47.33, places=2
+            )
         self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[4].amount, 55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[5].amount, 55.55, places=2)
         self.assertAlmostEqual(asset.depreciation_line_ids[6].amount, 55.55, places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 10.75, places=2)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[-1].amount, 9.11, places=2
+            )
+        else:
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[-1].amount, 8.22, places=2
+            )
 
     def test_03_proprata_init_prev_year(self):
         """Prorata temporis depreciation with init value in prev year."""
@@ -345,12 +360,26 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         self.assertAlmostEqual(asset.value_depreciated, 325.08, places=2)
         # check computed values in the depreciation board
         self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55, places=2)
-        # depreciation amount of 325.08
-        # is too high and hence a correction is applied to the next
-        # entry of the table
-        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 53.02, places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55, places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 10.75, places=2)
+        if calendar.isleap(date.today().year - 1):
+            # for leap years the first year depreciation amount of 325.08
+            # is too high and hence a correction is applied to the next
+            # entry of the table
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[2].amount, 54.66, places=2
+            )
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[3].amount, 55.55, places=2
+            )
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[-1].amount, 9.11, places=2
+            )
+        else:
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[2].amount, 55.55, places=2
+            )
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[-1].amount, 8.22, places=2
+            )
 
     def test_04_prorata_init_cur_year(self):
         """Prorata temporis depreciation with init value in curent year."""
@@ -382,10 +411,23 @@ class TestAssetManagement(AccountTestInvoicingCommon):
         # check the depreciated value is the initial value
         self.assertAlmostEqual(asset.value_depreciated, 279.44, places=2)
         # check computed values in the depreciation board
-        # compensate first period with the delta due to init_entry
-        self.assertAlmostEqual(asset.depreciation_line_ids[2].amount, 43.11, places=2)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[2].amount, 44.75, places=2
+            )
+        else:
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[2].amount, 45.64, places=2
+            )
         self.assertAlmostEqual(asset.depreciation_line_ids[3].amount, 55.55, places=2)
-        self.assertAlmostEqual(asset.depreciation_line_ids[-1].amount, 10.75, places=2)
+        if calendar.isleap(date.today().year):
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[-1].amount, 9.11, places=2
+            )
+        else:
+            self.assertAlmostEqual(
+                asset.depreciation_line_ids[-1].amount, 8.22, places=2
+            )
 
     def test_05_degressive_linear(self):
         """Degressive-Linear with annual and quarterly depreciation."""


### PR DESCRIPTION
Reverts OCA/account-financial-tools#2132

It's modifying the way the depreciation board is computed, provoking a serious problem on existing assets if you recompute the board with some depreciation lines already posted. The proof of this is the modification on the quantities of the test.

For this to land, it should adjust only the specific failing case, and not affect the tests, or to be a configurable option.

@Tecnativa 