### PR TITLE
[15.0][FIX] account_move_line_repair_info: acess error when posting a customer invoice

### DIFF
--- a/account_move_line_repair_info/models/account_move.py
+++ b/account_move_line_repair_info/models/account_move.py
@@ -22,6 +22,8 @@ class AccountMove(models.Model):
                 lambda il: il.product_id.id == vals["product_id"]
                 and il.quantity == vals["quantity"]
             )
+            # sudo: billing users may not have access to repair fees
+            repair_line = repair_line.sudo()
             repair_order = repair_line.repair_fee_ids.mapped("repair_id")
             if len(repair_order) == 1:
                 res[i].update(
@@ -40,9 +42,10 @@ class AccountMove(models.Model):
 
     @api.model_create_multi
     def create(self, values):
-        rline_model = self.env["repair.line"]
-        fline_model = self.env["repair.fee"]
-        rorder_model = self.env["repair.order"]
+        # sudo: same reason as above
+        rline_model = self.env["repair.line"].sudo()
+        fline_model = self.env["repair.fee"].sudo()
+        rorder_model = self.env["repair.order"].sudo()
         for val in values:
             for invoice_line_ids in val.get("invoice_line_ids", []):
                 line_val = invoice_line_ids[2]

--- a/account_move_line_repair_info/models/stock_valuation_layer.py
+++ b/account_move_line_repair_info/models/stock_valuation_layer.py
@@ -10,7 +10,8 @@ class StockValuationLayer(models.Model):
 
     def _validate_accounting_entries(self):
         res = super()._validate_accounting_entries()
-        for svl in self:
+        # sudo: billing users may not have access to repairs
+        for svl in self.sudo():
             if svl.stock_move_id.repair_id:
                 current_move = svl.account_move_id
                 if current_move:


### PR DESCRIPTION
Posting a customer invoice that contains a storable product requires read on repair.fee

Steps to reproduce:

- Product with real time inventory valuation 
- Post an invoice related to a SO for that product with a user that is just Billing user or sales Manager

This needs FW port to v16 only