### PR TITLE
[16.0][FIX] account_move_template: keep analytic account selected in wizard

### DIFF
--- a/account_move_template/wizard/account_move_template_run.py
+++ b/account_move_template/wizard/account_move_template_run.py
@@ -168,8 +168,10 @@ Valid dictionary to overwrite template lines:
     def generate_move(self):
         self.ensure_one()
         sequence2amount = {}
+        sequence2analytic = {}
         for wizard_line in self.line_ids:
             sequence2amount[wizard_line.sequence] = wizard_line.amount
+            sequence2analytic[wizard_line.sequence] = wizard_line.analytic_distribution
         company_cur = self.company_id.currency_id
         self.template_id.compute_lines(sequence2amount)
         if all([company_cur.is_zero(x) for x in sequence2amount.values()]):
@@ -179,7 +181,11 @@ Valid dictionary to overwrite template lines:
             amount = sequence2amount[line.sequence]
             if not company_cur.is_zero(amount):
                 move_vals["line_ids"].append(
-                    Command.create(self._prepare_move_line(line, amount))
+                    Command.create(
+                        self._prepare_move_line(
+                            line, amount, sequence2analytic.get(line.sequence)
+                        )
+                    )
                 )
         move = self.env["account.move"].create(move_vals)
         result = self.env["ir.actions.actions"]._for_xml_id(
@@ -207,7 +213,7 @@ Valid dictionary to overwrite template lines:
         }
         return move_vals
 
-    def _prepare_move_line(self, line, amount):
+    def _prepare_move_line(self, line, amount, analytic_distribution=None):
         date_maturity = False
         if line.payment_term_id:
             date_maturity = max(
@@ -225,7 +231,8 @@ Valid dictionary to overwrite template lines:
             "partner_id": self.partner_id.id or line.partner_id.id,
             "date_maturity": date_maturity or self.date,
             "tax_repartition_line_id": line.tax_repartition_line_id.id or False,
-            "analytic_distribution": line.analytic_distribution,
+            "analytic_distribution": analytic_distribution
+            or line.analytic_distribution,
         }
         if line.tax_ids:
             values["tax_ids"] = [Command.set(line.tax_ids.ids)]


### PR DESCRIPTION
@Escodoo HT02119

## Description:
When generating a journal entry from a move template `("Create Entry from Model")`, any analytic account selected on a wizard line was discarded — the created journal entry always used the analytic distribution from the original template line instead, which is usually empty. This happened because generate_move() built the move lines from template_id.line_ids (the static template) without ever reading back the `analytic_distribution` the user had just set on `self.line_ids` (the wizard lines). This fix maps each wizard line's `analytic_distribution` by sequence and passes it into `_prepare_move_line()`, using it in place of the template's own value.

cc @marcelsavegnago @WesleyOliveira98 @rvalyi @kaynnan @pedrobaeza 