### PR TITLE
[19.0][FIX+IMP+REF] account_chart_update: Several refinements and fixes

### DIFF
--- a/account_chart_update/tests/test_account_chart_update.py
+++ b/account_chart_update/tests/test_account_chart_update.py
@@ -3,6 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
+from copy import deepcopy
+from unittest.mock import patch
 
 from odoo import Command
 from odoo.tests import tagged
@@ -1081,3 +1083,54 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
         note = wizard.diff_notes(record_values, fp)
         self.assertIn("[fr]", note)
         self.assertIn("Note légale attendue", note)
+
+    def test_31_update_inactive_tax(self):
+        """Deactive a tax that is part of a m2m in other tax to check that is not
+        detected as a change, and to check that the inactive tax is updated.
+        """
+        tax = self._get_record_for_xml_id("sale_tax_template")
+        official_name = tax.name
+        tax.name = "Test 1 tax name changed"
+        tax.active = False
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        wizard.action_find_records()
+        # 0% export shouldn't count as updated due to the field `original_tax_ids` not
+        # finding the inactive m2m element
+        self.assertEqual(len(wizard.tax_ids), 1)
+        self.assertEqual(wizard.tax_ids.update_tax_id, tax)
+        self.assertEqual(wizard.tax_ids.type, "updated")
+        wizard.action_update_records()
+        self.assertEqual(wizard.updated_taxes, 1)
+        # The update is done even if the record is inactive
+        self.assertEqual(tax.name, official_name)
+
+    def test_32_update_m2m_with_inactive_tax(self):
+        """Patch the CoA to have a tax deactived, and removed from the m2m of other tax:
+        it should be detected and removed on update even if inactive.
+        """
+        # Patch the CoA to return the sales tax as inactive
+        patcher = patch(
+            "odoo.addons.account.models.chart_template.AccountChartTemplate."
+            "_get_chart_template_data",
+        )
+        mock = patcher.start()
+        patched_coa = deepcopy(self.chart_template_data)
+        patched_coa["account.tax"]["sale_tax_template"]["active"] = False
+        del patched_coa["account.tax"]["sale_export_tax_template"]["original_tax_ids"]
+        mock.return_value = patched_coa
+        # Honor the deactivation of the sales tax and remove it from export tax m2m
+        tax = self._get_record_for_xml_id("sale_tax_template")
+        tax.active = False
+        export_tax = self._get_record_for_xml_id(
+            "sale_export_tax_template"
+        ).with_context(active_test=False)
+        # Do the update and check
+        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
+        wizard.action_find_records()
+        self.assertEqual(len(wizard.tax_ids), 1)
+        self.assertEqual(wizard.tax_ids.update_tax_id, export_tax)
+        self.assertEqual(wizard.tax_ids.type, "updated")
+        wizard.action_update_records()
+        self.assertEqual(wizard.updated_taxes, 1)
+        self.assertFalse(export_tax.original_tax_ids)
+        patcher.stop()

--- a/account_chart_update/tests/test_account_chart_update.py
+++ b/account_chart_update/tests/test_account_chart_update.py
@@ -507,7 +507,7 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
 
     def test_15_diff_note_commands_count_mismatch(self):
         """When template and DB disagree on the number of repartition lines,
-        the detail surfaces `N record(s) → M record(s)` rather than a
+        the detail surfaces `N record(s) to be created` rather than a
         per-line breakdown."""
         wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
         tax = self._get_record_for_xml_id("sale_tax_template")
@@ -522,7 +522,7 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
             [("model", "=", "account.tax"), ("name", "=", "repartition_line_ids")]
         )
         note = wizard.diff_notes(trimmed, tax)
-        self.assertRegex(note, r"\d+ record\(s\) → \d+ record\(s\)")
+        self.assertRegex(note, r"\d+ record\(s\) to be created")
 
     def test_16_m2m_command_link_branch(self):
         """Drift must be detected when the template value is expressed with
@@ -653,70 +653,6 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
         )
         self.assertIn(f"tag_ids [∅] → [{tag.display_name}]", detail)
 
-    def test_20_diff_note_commands_branches(self):
-        """`_diff_note_commands` counts SET/LINK/CREATE correctly and picks
-        the right branch: count mismatch, per-line detail, or generic
-        fallback."""
-        wizard = self.wizard_obj.with_company(self.company).create(self.wizard_vals)
-        tax = self._get_record_for_xml_id("sale_tax_template")
-        field = tax._fields["repartition_line_ids"]
-        actual = tax.repartition_line_ids
-        # SET branch — expected_count = len(cmd[2]); DB has 4 lines, template says 8.
-        synthetic = [
-            999_001,
-            999_002,
-            999_003,
-            999_004,
-            999_005,
-            999_006,
-            999_007,
-            999_008,
-        ]
-        result = wizard._diff_note_commands(field, actual, [Command.set(synthetic)])
-        self.assertEqual(
-            result,
-            f"{len(actual)} record(s) → {len(synthetic)} record(s)",
-        )
-        # LINK branch — two LINK commands count as 2 (so count mismatch again).
-        result = wizard._diff_note_commands(
-            field, actual, [Command.link(999_001), Command.link(999_002)]
-        )
-        self.assertIn(f"{len(actual)} record(s) → 2 record(s)", result)
-        # CREATE branch with same count and a real sub-diff → per-line format.
-        # Build a template with the same count as actual but with a drifted
-        # factor_percent on the first line.
-        template_lines = [
-            Command.create(
-                {
-                    "repartition_type": r.repartition_type,
-                    "document_type": r.document_type,
-                    "factor_percent": r.factor_percent,
-                }
-            )
-            for r in actual
-        ]
-        # Flip factor_percent on the first line from 100 → 42 to force drift.
-        template_lines[0][2]["factor_percent"] = 42.0
-        result = wizard._diff_note_commands(field, actual, template_lines)
-        self.assertIn("#1:", result)
-        self.assertIn("factor_percent", result)
-        # Same count, no drift at all → generic fallback message.
-        template_lines_nodiff = [
-            Command.create(
-                {
-                    "repartition_type": r.repartition_type,
-                    "document_type": r.document_type,
-                    "factor_percent": r.factor_percent,
-                }
-            )
-            for r in actual
-        ]
-        result = wizard._diff_note_commands(field, actual, template_lines_nodiff)
-        self.assertEqual(
-            result,
-            f"{len(actual)} record(s) → differs from template",
-        )
-
     def test_21_diff_note_m2o_branches(self):
         """`_diff_note_m2o` renders actual/expected display names whether
         the template value is an xmlid string, an int database id, or
@@ -763,19 +699,20 @@ class TestAccountChartUpdate(TestAccountChartUpdateCommon):
         actual = tax.repartition_line_ids
         self.assertGreaterEqual(len(actual), 4)
         # Build a template that flips factor_percent on every line → 4+
-        # differing sub-records, but the renderer should only list 3.
+        # differing sub-records, and the renderer list all of them.
         template_lines = [
-            Command.create(
+            Command.update(
+                r.id,
                 {
                     "repartition_type": r.repartition_type,
                     "document_type": r.document_type,
                     "factor_percent": (r.factor_percent or 0) + 1,
-                }
+                },
             )
             for r in actual
         ]
         result = wizard._diff_note_commands(field, actual, template_lines)
-        self.assertEqual(result.count("#"), 3)
+        self.assertEqual(result.count("#"), 4)
 
     def test_23_account_group_code_prefix_end_drift_note(self):
         """When the template's code_prefix_end differs from the DB, the

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -5,9 +5,9 @@
 # Copyright 2015 Tecnativa - Antonio Espinosa
 # Copyright 2016 Tecnativa - Jairo Llopis
 # Copyright 2016 Jacques-Etienne Baudoux <je@bcim.be>
-# Copyright 2018 Tecnativa - Pedro M. Baeza
 # Copyright 2020 Noviat - Luc De Meyer
 # Copyright 2024-2025 Tecnativa - Víctor Martínez
+# Copyright 2018,2026 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
@@ -17,6 +17,17 @@ from odoo import Command, api, fields, models, tools
 from odoo.tools.translate import TranslationImporter
 
 _logger = logging.getLogger(__name__)
+
+
+# One2many fields that should be checked in the update
+O2M_FIELDS_EXCEPTION = {
+    "account.tax": ["repartition_line_ids"],
+    "account.fiscal.position": ["account_ids"],
+}
+# Fields that can be checked, but are not marked by default
+UNCHECKED_FIELDS = {
+    "account.fiscal.position": ["sequence"],
+}
 
 
 # HACK https://github.com/odoo/odoo/pull/234333
@@ -153,35 +164,45 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         comodel_name="ir.model.fields",
         relation="wizard_update_charts_tax_group_fields_rel",
         string="Tax group fields",
-        domain=lambda self: self._domain_tax_group_field_ids(),
+        domain=lambda self: [
+            ("id", "in", self._get_fields_per_model("account.tax.group").ids)
+        ],
         default=lambda self: self._default_tax_group_field_ids(),
     )
     tax_field_ids = fields.Many2many(
         comodel_name="ir.model.fields",
         relation="wizard_update_charts_tax_fields_rel",
         string="Tax fields",
-        domain=lambda self: self._domain_tax_field_ids(),
+        domain=lambda self: [
+            ("id", "in", self._get_fields_per_model("account.tax").ids)
+        ],
         default=lambda self: self._default_tax_field_ids(),
     )
     account_field_ids = fields.Many2many(
         comodel_name="ir.model.fields",
         relation="wizard_update_charts_account_fields_rel",
         string="Account fields",
-        domain=lambda self: self._domain_account_field_ids(),
+        domain=lambda self: [
+            ("id", "in", self._get_fields_per_model("account.account").ids)
+        ],
         default=lambda self: self._default_account_field_ids(),
     )
     account_group_field_ids = fields.Many2many(
         comodel_name="ir.model.fields",
         relation="wizard_update_charts_account_group_fields_rel",
         string="Account groups fields",
-        domain=lambda self: self._domain_account_group_field_ids(),
+        domain=lambda self: [
+            ("id", "in", self._get_fields_per_model("account.group").ids)
+        ],
         default=lambda self: self._default_account_group_field_ids(),
     )
     fp_field_ids = fields.Many2many(
         comodel_name="ir.model.fields",
         relation="wizard_update_charts_fp_fields_rel",
         string="Fiscal position fields",
-        domain=lambda self: self._domain_fp_field_ids(),
+        domain=lambda self: [
+            ("id", "in", self._get_fields_per_model("account.fiscal.position").ids)
+        ],
         default=lambda self: self._default_fp_field_ids(),
     )
     tax_group_matching_ids = fields.One2many(
@@ -215,89 +236,55 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         default=lambda self: self._default_fp_matching_ids(),
     )
 
-    def _domain_per_name(self, name):
+    @api.model
+    def _get_fields_per_model(self, model):
+        """Unified method that retrieves the elegible fields per each model. Used for
+        filling the per field selection in the wizard.
+        """
+        domain = [
+            ("model", "=", model),
+            ("name", "not in", tuple(self.fields_to_ignore(model))),
+            ("related", "=", False),
+        ]
+        o2m_exceptions = O2M_FIELDS_EXCEPTION.get(model, [])
+        extra_domain = [("ttype", "!=", "one2many")]
+        if o2m_exceptions:
+            extra_domain = ["|"] + extra_domain + [("name", "in", o2m_exceptions)]
+        fields = self.env["ir.model.fields"].search(domain + extra_domain)
+        # Filter fields that are computed readonly
+        obj = self.env[model]
+        fields = fields.filtered(
+            lambda x, obj=obj: x.name not in obj._fields
+            or not obj._fields[x.name].compute
+            or not obj._fields[x.name].readonly
+        )
+        return fields
+
+    @api.model
+    def _get_default_per_model(self, model):
+        """Unified method called by each default method of the field selection
+        m2m that gets the fields by model and exclude the unchecked ones.
+        """
         return [
-            ("model", "=", name),
-            ("name", "not in", tuple(self.fields_to_ignore(name))),
-        ]
-
-    def _domain_tax_group_field_ids(self):
-        return self._domain_per_name("account.tax.group") + [
-            ("ttype", "!=", "one2many")
-        ]
-
-    def _domain_tax_field_ids(self):
-        # Allow specific o2m fields critical for comparison
-        # (repartition_line_ids) but exclude other o2m
-        return self._domain_per_name("account.tax") + [
-            "|",
-            ("ttype", "!=", "one2many"),
-            (
-                "name",
-                "in",
-                [
-                    "repartition_line_ids",
-                ],
-            ),
-        ]
-
-    def _domain_account_field_ids(self):
-        return self._domain_per_name("account.account") + [("ttype", "!=", "one2many")]
-
-    def _domain_account_group_field_ids(self):
-        return self._domain_per_name("account.group") + [("ttype", "!=", "one2many")]
-
-    def _domain_fp_field_ids(self):
-        return self._domain_per_name("account.fiscal.position") + [
-            "|",
-            ("ttype", "!=", "one2many"),
-            ("name", "in", ["account_ids"]),
+            Command.link(x.id)
+            for x in self._get_fields_per_model(model)
+            if x.name not in UNCHECKED_FIELDS.get(model, [])
         ]
 
     def _default_tax_group_field_ids(self):
-        return [
-            Command.link(x.id)
-            for x in self.env["ir.model.fields"].search(
-                self._domain_tax_group_field_ids()
-                + self.get_uncheck_fields_domain("account.tax.group"),
-            )
-        ]
+        return self._get_default_per_model("account.tax.group")
 
     def _default_tax_field_ids(self):
-        return [
-            Command.link(x.id)
-            for x in self.env["ir.model.fields"].search(
-                self._domain_tax_field_ids()
-                + self.get_uncheck_fields_domain("account.tax"),
-            )
-        ]
+        return self._get_default_per_model("account.tax")
 
     def _default_account_field_ids(self):
-        return [
-            Command.link(x.id)
-            for x in self.env["ir.model.fields"].search(
-                self._domain_account_field_ids()
-                + self.get_uncheck_fields_domain("account.account"),
-            )
-        ]
+        return self._get_default_per_model("account.account")
 
     def _default_account_group_field_ids(self):
-        return [
-            Command.link(x.id)
-            for x in self.env["ir.model.fields"].search(
-                self._domain_account_group_field_ids()
-                + self.get_uncheck_fields_domain("account.group")
-            )
-        ]
+        return self._get_default_per_model("account.group")
 
     def _default_fp_field_ids(self):
-        return [
-            Command.link(x.id)
-            for x in self.env["ir.model.fields"].search(
-                self._domain_fp_field_ids()
-                + self.get_uncheck_fields_domain("account.fiscal.position")
-            )
-        ]
+        return self._get_default_per_model("account.fiscal.position")
 
     def _get_matching_ids(self, model_name, ordered_opts):
         vals = []
@@ -562,22 +549,6 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         return set(models.MAGIC_COLUMNS) | specials
 
     @api.model
-    def get_default_unchecked_fields(self, name):
-        """Get fields that should be unchecked by default for a given model.
-
-        :param str name: The name of the template model.
-        :return set: Fields to uncheck by default.
-        """
-        unchecked_mapping = {
-            "account.fiscal.position": {"sequence"},
-        }
-        return unchecked_mapping.get(name, set())
-
-    def get_uncheck_fields_domain(self, name):
-        unchecked_fields = list(self.get_default_unchecked_fields(name))
-        return [("name", "not in", unchecked_fields)]
-
-    @api.model
     def diff_fields(self, record_values, real):  # noqa: C901
         """Get fields that are different in record values and real records.
 
@@ -592,6 +563,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         result = dict()
         ignore = self.fields_to_ignore(real._name)
         field_mapping = {
+            "account.tax.group": self.tax_group_field_ids,
             "account.tax": self.tax_field_ids,
             "account.account": self.account_field_ids,
             "account.group": self.account_group_field_ids,
@@ -601,9 +573,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         # If the fields to be queried are not mapped, use all of them
         # (example: account.tax.repartition.line).
         if real._name not in field_mapping:
-            field_mapping[real._name] = self.env["ir.model.fields"].search(
-                self._domain_per_name(real._name)
-            )
+            field_mapping[real._name] = self._get_fields_per_model(real._name)
         fields_by_key = {x.name: x for x in field_mapping[real._name]}
         to_include = field_mapping[real._name].mapped("name")
         for key in record_values.keys():

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -28,6 +28,17 @@ O2M_FIELDS_EXCEPTION = {
 UNCHECKED_FIELDS = {
     "account.fiscal.position": ["sequence"],
 }
+# For one2many records that require matching by keys, specify them here
+O2M_MATCH_KEYS = {
+    "account.tax": {
+        "repartition_line_ids": [
+            "document_type",
+            "factor_percent",
+            "repartition_type",
+            "account_id",
+        ],
+    }
+}
 
 
 # HACK https://github.com/odoo/odoo/pull/234333
@@ -648,21 +659,38 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                     result[key] = record_value
                 continue
             elif field.ttype == "one2many":
+                match_keys = O2M_MATCH_KEYS.get(field.model, {}).get(field.name, [])
+                if match_keys:
+                    real_value = real_value.sorted(",".join(match_keys))
+
+                    def match_cmp(n, match_keys, field):
+                        vals = []
+                        for key in match_keys:
+                            val = n[2].get(key, False)
+                            subfield = self.env[field.relation]._fields[key]
+                            if val and subfield.type == "many2one":
+                                val = self.env.ref(
+                                    f"account.{self.company_id.id}_{val}", False
+                                )
+                            vals.append(val)
+                        return vals
+
+                    # We assume we will find only 0 commands (CREATE)
+                    record_value = sorted(
+                        record_value,
+                        key=lambda n, match_keys=match_keys, field=field: match_cmp(
+                            n, match_keys, field
+                        ),
+                    )
                 if len(record_value) != len(real_value):
+                    # TODO: Try to add only missing ones
                     result[key] = [(5, 0, 0)] + record_value
                 else:
-                    for key2, record_value_item in enumerate(record_value):
-                        res_item = self.diff_fields(
-                            record_value_item[2], real_value[key2]
-                        )
-                        if len(res_item) > 0:
-                            # Something has changed in an element, we change everything
-                            # just in case (we do not know for sure that the record we
-                            # are consulting by key is the correct one, for example,
-                            # if it has been deleted by mistake and created again in
-                            # the same way).
-                            result[key] = [(5, 0, 0)] + record_value
-                            break
+                    for i, record_value_item in enumerate(record_value):
+                        res_item = self.diff_fields(record_value_item[2], real_value[i])
+                        if res_item:
+                            result.setdefault(key, [])
+                            result[key].append((1, real_value[i].id, res_item))
                 continue
             # Define correct value if field is translatable
             if field.translate:
@@ -854,40 +882,24 @@ class WizardUpdateChartsAccounts(models.TransientModel):
 
     def _diff_note_commands(self, field, actual, expected_raw):
         """Detail string for an m2m/o2m whose template value is a command list."""
-        actual_count = len(actual)
-        expected_count = 0
-        for cmd in (c for c in expected_raw if isinstance(c, list | tuple) and c):
-            if cmd[0] in (0, 4):  # CREATE / LINK
-                expected_count += 1
-            elif cmd[0] == 6 and len(cmd) >= 3:  # SET
-                expected_count += len(cmd[2])
-        if actual_count != expected_count:
-            return self.env._(
-                "%(actual)s record(s) → %(expected)s record(s)",
-                actual=actual_count,
-                expected=expected_count,
-            )
         sub_diffs = []
-        for idx, cmd in (
-            (i, c)
-            for i, c in enumerate(expected_raw[:actual_count])
-            if isinstance(c, list | tuple) and len(c) >= 3 and isinstance(c[2], dict)
-        ):
+        to_create = len([x for x in expected_raw if x[0] == 0])
+        if to_create:
+            sub_diffs += [self.env._("%s record(s) to be created.", to_create)]
+        for cmd in expected_raw:
+            if cmd[0] != 1:
+                continue
+            record = actual.filtered(lambda x, rec_id=cmd[1]: x.id == rec_id)
             sub_diff = self.with_context(skip_translation_keys=True).diff_fields(
-                cmd[2], actual[idx]
+                cmd[2], record
             )
             diff_keys = sorted(k for k in sub_diff if k != "__translation_module__")
             if diff_keys:
-                detail = self._diff_note_sub_detail(cmd[2], actual[idx], diff_keys)
-                sub_diffs.append(f"#{idx + 1}: {detail}")
-            if len(sub_diffs) >= 3:
-                break
+                detail = self._diff_note_sub_detail(cmd[2], record, diff_keys)
+                sub_diffs.append(f"#{cmd[1]}: {detail}")
         if sub_diffs:
             return "\n    " + "\n    ".join(sub_diffs)
-        return self.env._(
-            "%(n)s record(s) → differs from template",
-            n=actual_count,
-        )
+        return ""
 
     def _diff_note_m2x(self, field, actual, expected_raw):
         """Detail string for an m2m/o2m field."""

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -1022,8 +1022,8 @@ class WizardUpdateChartsAccounts(models.TransientModel):
                 )
                 record = self.env.ref(full_xmlid, raise_if_not_found=False)
                 if record:
-                    # To read company-dependent fields correctly
-                    return record.with_company(company)
+                    # To read company-dependent fields correctly & m2m inactive records
+                    return record.with_company(company).with_context(active_test=False)
             else:
                 f_name = matching.matching_value
                 if not data.get(f_name):
@@ -1327,6 +1327,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             tracking_disable=True,
             delay_account_group_sync=True,
             lang="en_US",
+            active_test=False,
         )
         model_fields = set(self.env[model]._fields)
         filtered_data = {
@@ -1389,7 +1390,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         # First create taxes in batch
         data = {}
         for wiz_tax in self.tax_ids:
-            tax = wiz_tax.update_tax_id
+            tax = wiz_tax.update_tax_id.with_context(active_test=False)
             if wiz_tax.type == "deleted":
                 tax.active = False
                 _logger.info(self.env._("Deactivated tax %s."), tax.name)

--- a/account_chart_update/wizard/wizard_chart_update.py
+++ b/account_chart_update/wizard/wizard_chart_update.py
@@ -1307,6 +1307,8 @@ class WizardUpdateChartsAccounts(models.TransientModel):
 
     def _load_data(self, model, data):
         """Process similar to the one in chart template _load() method."""
+        if not data:
+            return
         template = self.env["account.chart.template"].with_context(
             default_company_id=self.company_id.id,
             allowed_company_ids=[self.company_id.id],
@@ -1323,6 +1325,8 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             }
             for xml_id, vals in data.items()
         }
+        if not filtered_data:
+            return
         created_records = template._load_data({model: filtered_data})[model]
         # Make sure all translation data is indexed by XML ID
         translation_data = {}


### PR DESCRIPTION
These are up to four refinements that come together as they were done for getting a complete functional update of the Spanish CoA in a 19.0 migrated database. Check each commit individually for the corresponding diff, but here is the summary for each of them:

* **[IMP+REF] Field selection**:

  The field selection m2m defaults and domains were not correct at all, as they were including computed non writable or related fields.

  While working on this, a refactoring reducing code and unifiying coincident logic has been done.

* **[IMP] No _load_data if no data**:

  For avoiding a bit of processing and return early when no further steps needed.

* **[FIX] Update repartition_line_ids instead overwriting them**:

  Previous code was iterating through the repartition lines by the insertion order, but this may not match, although the lines are the same, but in different order.

  <img width="1205" height="529" alt="image" src="https://github.com/user-attachments/assets/86dee78a-b963-4b9a-a933-b26adbe91f22" />

  As removing repartition lines (for re-adding them later in other order) is forbidden when such lines have been used in invoices:

  ```
  update or delete on table "account_tax_repartition_line" violates RESTRICT setting of foreign key constraint "account_move_line_tax_repartition_line_id_fkey" on table "account_move_line"
  DETAIL:  Key (id)=(NNN) is referenced from table "account_move_line".
  ```

  we should make an effort to match the expected with the real one.

  This has been done sorting both the expected and the real ones through the values of certain fields that have been manually preset in the constant O2M_MATCH_KEYS.

  The diff notes method has also been reworked to adapt to the new situation, and remove the limit of maximum 3 subfields. You want to see all the differences, even if they are a lot. If not, you may think that there are no more changes, and when updated, be surprised having them.

  Some tests have been adapted, and one of them has been totally removed. Anyway, note that those tests checking directly the methods `_diff_notes...` are synthetic and don't test real results, so their usefulness is limited.

* **[FIX] Handle inactive records in m2m fields**:

  If for example a tax is inactive, it doesn't appear in regular m2m fields unless the context active_test=False is passed, so we introduce it in the needed places for having the proper comparisons.

  It includes regression tests that check these specific cases.

@Tecnativa TT58562